### PR TITLE
feat(models): repack per-expert HF MoE keys into packed host banks (#53)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -161,6 +161,12 @@ def _place_expert_weights(model, gate_up_banks, down_banks) -> None:
     """
     import torch
 
+    # The gate_up bank is [num_experts, 2*intermediate, hidden]: for each expert
+    # row the *first* ``intermediate_size`` rows are the gate projection and the
+    # next ``intermediate_size`` are the up projection (gate then up, concatenated
+    # on dim 1 -- the layout the repacker / dummy fabricator both produce). The
+    # down bank is [num_experts, hidden, intermediate].
+    intermediate = int(getattr(model.config, "moe_intermediate_size", 0))
     for layer_id in _moe_layers(model.config):
         moe = getattr(getattr(model, "layers", [None] * (layer_id + 1))[layer_id], "mlp", None)
         experts = getattr(moe, "experts", None)
@@ -171,10 +177,9 @@ def _place_expert_weights(model, gate_up_banks, down_banks) -> None:
         gu = gate_up_banks[layer_id].tensor if hasattr(gate_up_banks[layer_id], "tensor") else gate_up_banks[layer_id]
         dn = down_banks[layer_id].tensor if hasattr(down_banks[layer_id], "tensor") else down_banks[layer_id]
         for e in range(len(experts)):
-            gate, up = gu[e, 0].clone(), gu[e, 1].clone()
             with torch.no_grad():
-                experts[e].gate_proj.weight.copy_(gate)
-                experts[e].up_proj.weight.copy_(up)
+                experts[e].gate_proj.weight.copy_(gu[e, 0:intermediate])
+                experts[e].up_proj.weight.copy_(gu[e, intermediate : 2 * intermediate])
                 experts[e].down_proj.weight.copy_(dn[e])
 
 

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import glob
 import json
 import os
-from typing import Iterator, Tuple
+from typing import Iterator, Optional, Tuple
 
 import torch
 from safetensors import safe_open
@@ -190,13 +190,23 @@ def stream_moe_expert_sources(
     dtype: torch.dtype,
     layer_sink=None,
 ) -> Tuple[list, list]:
-    """Stream packed per-layer MoE expert tensors into final offload banks.
+    """Stream per-layer MoE expert tensors into final offload banks.
 
-    The model's ``iter_weights`` normalizes expert weights to
-    ``...experts.gate_up_proj`` / ``...experts.down_proj`` with shape
-    ``[num_experts, ...]``. Each arrives whole-layer, so it is written straight
-    into its own ``[num_experts, ...]`` per-layer bank. Returns
-    ``(gate_up_banks, down_banks)`` (per-layer bank objects).
+    Two checkpoint layouts are accepted (ADR 0002):
+
+    * **packed** -- ``...experts.{gate_up_proj|down_proj}`` already stacked to
+      ``[num_experts, ...]`` (what the model adapter / FTW normalizes to). Each
+      arrives whole-layer and is written straight into its per-layer bank.
+    * **per-expert** -- the raw HF layout
+      ``...experts.{e}.{gate|up|down}_proj`` (one ``[I, H]`` / ``[H, I]`` tensor
+      per expert). A real HF checkpoint (e.g. Qwen3-30B-A3B) ships this form, so
+      the streamer stacks the per-expert rows into the packed
+      ``gate_up [E, 2I, H]`` (gate then up, concatenated on dim 1) and
+      ``down [E, H, I]`` banks -- the exact layout the ``dummy=True`` fabricator
+      and the offload slot cache expect.
+
+    Either form (or a mix) is fine per layer. Returns ``(gate_up_banks,
+    down_banks)`` (per-layer bank objects), each ``[num_experts, ...]``.
     """
     del layer_sink  # converter-facing sink not used on the B70 port
     banks: dict[str, list] = {
@@ -205,23 +215,38 @@ def stream_moe_expert_sources(
     }
     row_shape: dict[str, tuple[int, ...]] = {}
     seen: dict[str, set[int]] = {"gate_up": set(), "down": set()}
+    # Per-expert rows are buffered as {layer: {expert_id: row}} and fused into the
+    # packed bank at the end (see _finalize_per_expert_banks) rather than written
+    # in-place row-by-row: the in-place int+slice / narrow / scatter write paths of
+    # the torch XPU build are unreliable, whereas torch.cat is not.
+    per_expert: dict[str, list[dict[int, torch.Tensor]]] = {
+        "gate": [{} for _ in range(config.num_layers)],
+        "up": [{} for _ in range(config.num_layers)],
+        "down": [{} for _ in range(config.num_layers)],
+    }
 
     for name, tensor in tensors:
-        info = _packed_expert_source_info(name)
+        info = _expert_source_info(name)
         if info is None:
             raise ValueError(f"Unexpected expert weight key: {name}")
-        layer, packed_name = info
-        bank_name = "gate_up" if packed_name == "gate_up_proj" else "down"
-        _copy_expert_layer_into_bank(
-            banks,
-            row_shape,
-            seen,
-            bank_name=bank_name,
-            tensor=tensor.to(dtype=dtype),
-            layer=layer,
-            config=config,
-            dtype=dtype,
-        )
+        layer, packed_name, expert_id = info
+        bank_name = "gate_up" if packed_name in {"gate_up_proj", "gate_proj", "up_proj"} else "down"
+        if expert_id is None:
+            # Packed: the tensor is the whole [num_experts, ...] layer -> copy as-is.
+            _copy_expert_layer_into_bank(
+                banks,
+                row_shape,
+                seen,
+                bank_name=bank_name,
+                tensor=tensor.to(dtype=dtype),
+                layer=layer,
+                config=config,
+                dtype=dtype,
+            )
+        else:
+            # Per-expert: buffer this one row; the bank is fused at the end.
+            _buffer_expert_row(per_expert, row_shape, bank_name, packed_name, tensor.to(dtype=dtype), layer, expert_id, config)
+            seen[bank_name].add(layer)
 
     missing = {
         name: sorted(set(range(config.num_layers)) - seen)
@@ -230,28 +255,58 @@ def stream_moe_expert_sources(
     }
     if missing:
         raise ValueError(f"Missing MoE expert source layers: {missing}")
+    _finalize_per_expert_banks(banks, per_expert, config)
     return (
         [bank.tensor for bank in banks["gate_up"]],
         [bank.tensor for bank in banks["down"]],
     )
 
 
-def _packed_expert_source_info(key: str) -> Tuple[int, str] | None:
-    """Map a HF MoE expert key to ``(layer, packed_name)`` or None.
+def _expert_source_info(key: str) -> Tuple[int, str, Optional[int]] | None:
+    """Map a HF MoE expert key to ``(layer, name, expert_id)`` or None.
 
-    Accepts the Qwen-style ``model.layers.{L}.mlp.experts.{e}.{proj}`` (per-expert,
-    projected) keys and the packed ``...experts.{gate_up_proj|down_proj}`` (already
-    stacked to ``[num_experts, ...]``) keys the model adapter normalizes to.
+    ``name`` is the trailing projection token and ``expert_id`` is the row index for
+    per-expert keys (``None`` when the key is already the packed,
+    ``[num_experts, ...]`` tensor). Recognized forms (anchored on ``mlp`` -> ``experts``):
+
+    * packed -- ``model.layers.{L}.mlp.experts.{gate_up_proj|down_proj}`` (the
+      experts key is terminal, nothing follows it) -> ``(L, name, None)``
+    * per-expert -- ``model.layers.{L}.mlp.experts.{e}.{gate|up|down}_proj`` ->
+      ``(L, name, e)`` (``gate_proj``/``up_proj`` both feed the ``gate_up`` bank,
+      ``down_proj`` feeds ``down``). A non-projection trailing token (e.g. an
+      unknown ``...experts.{e}.{other}``) is not an expert source and yields ``None``.
     """
     parts = key.split(".")
-    if len(parts) < 5 or parts[0] != "model" or parts[1] != "layers":
-        return None
-    if parts[-2] != "experts" or parts[-1] not in {"gate_up_proj", "down_proj"}:
+    # A MoE expert key is anchored on the trailing ``.experts.`` group. The layer
+    # id is the integer token immediately before the ``mlp`` token that precedes
+    # ``experts`` (``...layers.{L}.mlp.experts...``), which is not a fixed offset
+    # from the end (the per-expert form appends ``.{e}.{proj}``), so locate ``mlp``
+    # first and take the integer that directly precedes it.
+    if "mlp" not in parts or "experts" not in parts:
         return None
     try:
-        return int(parts[2]), parts[-1]
-    except ValueError:
+        mlp_pos = parts.index("mlp")
+        layer = int(parts[mlp_pos - 1])
+    except (ValueError, IndexError):
         return None
+    if parts[mlp_pos + 1] != "experts":
+        return None
+    last = parts[-1]
+    # Packed form: the experts key is TERMINAL -- ``...experts.{gate_up_proj|
+    # down_proj}`` (the tensor is already stacked to [num_experts, ...]). A
+    # trailing ``.{e}.{proj}`` group would mean the per-expert form, so those
+    # tokens are only accepted when nothing follows ``experts``.
+    e_pos = parts.index("experts")
+    if last in {"gate_up_proj", "down_proj"} and len(parts) == e_pos + 2:
+        return layer, last, None
+    # Per-expert form: ``...experts.{e}.{proj}`` -- parts[-2] is the expert index.
+    if last in {"gate_proj", "up_proj", "down_proj"}:
+        try:
+            expert_id = int(parts[-2])
+        except ValueError:
+            return None
+        return layer, last, expert_id
+    return None
 
 
 def _copy_expert_layer_into_bank(
@@ -281,6 +336,95 @@ def _copy_expert_layer_into_bank(
         banks[bank_name][layer] = bank = _PlainBank(torch.empty((config.num_experts, *tensor.shape[1:]), dtype=dtype))
     bank.tensor.copy_(tensor)
     seen[bank_name].add(layer)
+
+
+def _buffer_expert_row(
+    per_expert: dict[str, list[dict[int, torch.Tensor]]],
+    row_shape: dict[str, tuple[int, ...]],
+    bank_name: str,
+    packed_name: str,
+    tensor: torch.Tensor,
+    layer: int,
+    expert_id: int,
+    config,
+) -> None:
+    """Buffer one per-expert row; the packed bank is fused at the end of the stream.
+
+    ``gate_proj`` / ``up_proj`` are keyed under the ``gate_up`` bank (as the ``gate``
+    and ``up`` halves respectively); ``down_proj`` under ``down``. Rows are not
+    written in-place -- see :func:`_finalize_per_expert_banks`.
+    """
+    bucket = "gate" if packed_name == "gate_proj" else ("up" if packed_name == "up_proj" else "down")
+    bucket_by_layer = per_expert[bucket]
+    if not (0 <= layer < config.num_layers):
+        raise ValueError(f"Unexpected MoE expert layer {layer}")
+    if not (0 <= expert_id < config.num_experts):
+        raise ValueError(f"Unexpected MoE expert id {expert_id} in layer {layer}")
+    expected_shape = row_shape.setdefault(bank_name, tuple(tensor.shape))
+    if tuple(tensor.shape) != expected_shape:
+        raise ValueError(
+            f"Inconsistent {bank_name} per-expert shape {tuple(tensor.shape)}; expected {expected_shape}"
+        )
+    if expert_id in bucket_by_layer[layer]:
+        raise ValueError(f"Duplicate per-expert source for layer {layer} expert {expert_id} ({packed_name})")
+    bucket_by_layer[layer][expert_id] = tensor
+
+
+def _finalize_per_expert_banks(banks: dict[str, list], per_expert, config) -> None:
+    """Fuse the buffered per-expert rows into the packed per-layer banks.
+
+    ``gate_up`` is ``[E, 2I, H]`` (gate then up, matching the ``dummy=True``
+    fabricator and the upstream ``_BANK_SCHEMAS``); ``down`` is ``[E, H, I]``.
+    A layer is only finalized once *all* of its experts are present (gate + up +
+    down), so a checkpoint that ships a bank packed and the rest per-expert (or
+    vice versa) still completes.
+
+    The per-expert rows (``[I, H]`` / ``[H, I]``) are stacked into the ``[E, ...]``
+    bank with ``cat`` on the *middle* dim + a ``permute`` (``_stack_expert_rows``),
+    and the gate/up fusion is a ``cat`` on dim 1. These 3-D ops are the only
+    reliable path in the torch XPU build: in-place row writes (``__setitem__`` with
+    an int + slice, ``narrow`` + ``copy_``, ``scatter``) and ``cat``/``reshape`` on
+    the 2-D per-expert rows are all mishandled by that build (they drop or
+    misplace the expert dimension), whereas ``cat(dim=1)`` + ``permute`` on 3-D
+    tensors are correct.
+    """
+    num_layers = config.num_layers
+    num_experts = config.num_experts
+    for layer in range(num_layers):
+        if banks["gate_up"][layer] is not None and banks["down"][layer] is not None:
+            continue  # already produced by a packed source; per-expert rows (if any) unused
+        gate = per_expert["gate"][layer]
+        up = per_expert["up"][layer]
+        down = per_expert["down"][layer]
+        # Only finalize a layer whose expert coverage is complete.
+        if len(gate) < num_experts or len(up) < num_experts or len(down) < num_experts:
+            continue
+        gate_bank = _stack_expert_rows([gate[e] for e in range(num_experts)])  # [E, I, H]
+        up_bank = _stack_expert_rows([up[e] for e in range(num_experts)])  # [E, I, H]
+        down_bank = _stack_expert_rows([down[e] for e in range(num_experts)])  # [E, H, I]
+        # Fuse gate + up on the inner (dim 1) axis -> [E, 2I, H].
+        banks["gate_up"][layer] = _PlainBank(torch.cat([gate_bank, up_bank], dim=1))
+        banks["down"][layer] = _PlainBank(down_bank)
+
+
+def _stack_expert_rows(rows: list) -> torch.Tensor:
+    """Stack ``[E]`` per-expert rows of shape ``[D0, D1]`` into one ``[E, D0, D1]``
+    tensor, using only ops the torch XPU build handles correctly (see
+    :func:`_finalize_per_expert_banks`).
+
+    Each 2-D row is promoted to ``[1, D0, D1]`` (``unsqueeze(0)``) and the results
+    are ``cat``-ed on dim 0 -> ``[E, D0, D1]``. A direct ``cat`` on the 2-D rows
+    (dim 0 or 1) drops/misplaces the expert dimension in this build, so the rows
+    are first made 3-D: ``cat`` on a 3-D tensor along dim 0 is reliable.
+    """
+    if not rows:
+        raise ValueError("Cannot stack an empty list of expert rows")
+    first = rows[0]
+    if first.dim() != 2:
+        raise ValueError(f"Expected 2-D per-expert rows; got {first.dim()}-D")
+    if any(r.dim() != 2 or r.shape != first.shape for r in rows[1:]):
+        raise ValueError("Per-expert rows must share a single shape")
+    return torch.cat([row.unsqueeze(0) for row in rows], dim=0)
 
 
 __all__ = [

--- a/tests/test_models_loader.py
+++ b/tests/test_models_loader.py
@@ -21,6 +21,15 @@ torch = pytest.importorskip("torch")
 # Populated by the ``moe_ckpt`` fixture with the exact expert tensor written to
 # the checkpoint, so the "real banks" test can assert the loader round-trips it.
 _EXPECTED_L0_GATE_UP = None
+# Populated by the ``moe_ckpt_perexpert`` fixture with the per-expert source tensors
+# (gate / up / down for layer 0) so the repack test can assert the stacked bank
+# equals the concatenation of the exact bytes that were written.
+_EXPECTED_L0_PEREXPERT = None
+# Populated by the ``moe_ckpt_distinguishable`` fixture: the exact per-expert
+# gate/up/down bytes for layer 0, written with *distinguishable* values so a test
+# can tell whether the loader routed each byte to the right expert + projection
+# (a shape-only check would miss a gate<->up swap or an expert row shift).
+_EXPECTED_L0_DISTINGUISHABLE = None
 
 from freetoken.models.loader import load_model
 from freetoken.models.weight import _PlainBank, load_moe_expert_sources
@@ -76,6 +85,59 @@ def _qwen3_moe_weights() -> dict:
     return w
 
 
+def _qwen3_moe_weights_per_expert() -> dict:
+    """A tiny Qwen3-MoE checkpoint in the *raw HF* per-expert layout: one
+    ``...experts.{e}.{gate,up,down}_proj`` tensor per expert (NOT the packed
+    ``gate_up_proj``/``down_proj`` form). This is what a real HF checkpoint such
+    as Qwen3-30B-A3B ships, so the loader must repack it to the packed banks."""
+    hidden, inter, experts, vocab = 128, 32, 4, 64
+    layers = 2
+    w = {
+        "model.embed_tokens.weight": torch.randn(vocab, hidden),
+        "lm_head.weight": torch.randn(vocab, hidden),
+        "model.layers.0.self_attn.q_proj.weight": torch.randn(hidden, hidden),
+    }
+    for layer in range(layers):
+        for e in range(experts):
+            prefix = f"model.layers.{layer}.mlp.experts.{e}"
+            w[f"{prefix}.gate_proj"] = torch.randn(inter, hidden)
+            w[f"{prefix}.up_proj"] = torch.randn(inter, hidden)
+            w[f"{prefix}.down_proj"] = torch.randn(hidden, inter)
+    return w
+
+
+def _qwen3_moe_weights_distinguishable() -> dict:
+    """A per-expert checkpoint whose values *identify* both the expert and the
+    projection, so a placement test can prove each byte landed in exactly the
+    right place (catches a gate<->up swap or an off-by-one expert row that a
+    shape check would miss).
+
+    Values (exact integers, lossless in bf16, all distinct per (expert,
+    projection) and distinct across the two halves of a fused gate_up row):
+
+    * gate_proj (expert e, row r, col c): 100*(e+1) + r   -> in [100, 431]
+    * up_proj   (expert e, row r, col c): 100*(e+1) + r + 1  -> in [101, 432]
+    * down_proj (expert e, row r, col c): 100*(e+1) + r + 2  -> in [102, 433]
+
+    (Columns are constant within a row; the row index alone distinguishes the
+    two I=32-row halves of the fused ``[E, 2I, H]`` gate_up bank.)
+    """
+    hidden, inter, experts, vocab = 128, 32, 4, 64
+    layers = 2
+    w = {
+        "model.embed_tokens.weight": torch.randn(vocab, hidden),
+        "lm_head.weight": torch.randn(vocab, hidden),
+    }
+    for layer in range(layers):
+        for e in range(experts):
+            prefix = f"model.layers.{layer}.mlp.experts.{e}"
+            base = 100 * (e + 1)
+            w[f"{prefix}.gate_proj"] = torch.arange(inter, dtype=torch.float32)[:, None].repeat(1, hidden) + base
+            w[f"{prefix}.up_proj"] = torch.arange(inter, dtype=torch.float32)[:, None].repeat(1, hidden) + base + 1
+            w[f"{prefix}.down_proj"] = torch.arange(hidden, dtype=torch.float32)[:, None].repeat(1, inter) + base + 2
+    return w
+
+
 @pytest.fixture(scope="module")
 def moe_ckpt(tmp_path_factory):
     weights = _qwen3_moe_weights()
@@ -85,6 +147,42 @@ def moe_ckpt(tmp_path_factory):
     # reproducible across calls).
     global _EXPECTED_L0_GATE_UP
     _EXPECTED_L0_GATE_UP = weights["model.layers.0.mlp.experts.gate_up_proj"].to(torch.bfloat16)
+    return path
+
+
+@pytest.fixture(scope="module")
+def moe_ckpt_perexpert(tmp_path_factory):
+    weights = _qwen3_moe_weights_per_expert()
+    path = _write_checkpoint(
+        tmp_path_factory.mktemp("qwen3moe-pe"), config=QWEN3_MOE_CONFIG, weights=weights
+    )
+    global _EXPECTED_L0_PEREXPERT
+    _EXPECTED_L0_PEREXPERT = {
+        name: weights[name].to(torch.bfloat16)
+        for name in (
+            "model.layers.0.mlp.experts.0.gate_proj",
+            "model.layers.0.mlp.experts.0.up_proj",
+            "model.layers.0.mlp.experts.0.down_proj",
+        )
+    }
+    return path
+
+
+@pytest.fixture(scope="module")
+def moe_ckpt_distinguishable(tmp_path_factory):
+    weights = _qwen3_moe_weights_distinguishable()
+    path = _write_checkpoint(
+        tmp_path_factory.mktemp("qwen3moe-dist"), config=QWEN3_MOE_CONFIG, weights=weights
+    )
+    global _EXPECTED_L0_DISTINGUISHABLE
+    _EXPECTED_L0_DISTINGUISHABLE = {
+        name: weights[name].to(torch.bfloat16)
+        for name in (
+            "model.layers.0.mlp.experts.0.gate_proj",
+            "model.layers.0.mlp.experts.0.up_proj",
+            "model.layers.0.mlp.experts.0.down_proj",
+        )
+    }
     return path
 
 
@@ -173,3 +271,85 @@ def test_load_model_real_moe_routes_experts_to_host(moe_ckpt):
     assert model is not None
     assert len(expert_sources[0]) == 2
     assert expert_sources[0][0].device.type == "cpu"
+
+
+# --- per-expert (raw HF) checkpoint -> repacked packed banks (#53) -----------
+
+
+def test_load_moe_expert_sources_real_banks_per_expert_layout(moe_ckpt_perexpert):
+    """A raw HF per-expert checkpoint is repacked to the same packed banks the
+    ``dummy=True`` path fabricates: gate_up [E, 2I, H] (gate then up) + down
+    [E, H, I]."""
+    gate_up, down = load_moe_expert_sources(moe_ckpt_perexpert, dtype=torch.bfloat16)
+    assert len(gate_up) == 2 and len(down) == 2
+    for gu, dn in zip(gate_up, down):
+        assert gu.shape == (4, 2 * 32, 128)
+        assert dn.shape == (4, 128, 32)
+        assert gu.device.type == "cpu" and dn.device.type == "cpu"
+    # Round-trip: layer 0's bank row 0 must equal the exact gate/up bytes that
+    # were written, fused on the inner (dim 1) axis: the first [I, H] block is the
+    # gate row, the second the up row. The expected bank is built by the same
+    # reliable 3-D route the loader uses (promote the rows to 3-D, then cat) --
+    # a bare 2-D ``torch.cat(..., dim=1)`` is mishandled by the torch XPU build
+    # (it flattens), so it must not be used to construct the reference.
+    exp = _EXPECTED_L0_PEREXPERT
+    gate0 = exp["model.layers.0.mlp.experts.0.gate_proj"]
+    up0 = exp["model.layers.0.mlp.experts.0.up_proj"]
+    down0 = exp["model.layers.0.mlp.experts.0.down_proj"]
+    from freetoken.models.weight import _stack_expert_rows
+
+    expected_gate_up = torch.cat([_stack_expert_rows([gate0]), _stack_expert_rows([up0])], dim=1)[0]
+    assert torch.equal(gate_up[0][0], expected_gate_up)
+    assert torch.equal(down[0][0], down0)
+
+
+def test_load_model_real_moe_per_expert_routes_to_host(moe_ckpt_perexpert):
+    """The top-level loader path (load_model) handles the per-expert layout and
+    routes the repacked banks to host memory, exactly like the packed path."""
+    model, expert_sources = load_model(moe_ckpt_perexpert, torch.device("cpu"))
+    assert model is not None
+    assert len(expert_sources[0]) == 2
+    assert expert_sources[0][0].shape == (4, 2 * 32, 128)
+    assert expert_sources[0][0].device.type == "cpu"
+
+
+def test_load_moe_expert_sources_rejects_unknown_expert_key(tmp_path):
+    """An expert-looking key that is neither packed nor a known per-expert
+    projection still raises (the loader must not silently mis-route weights)."""
+    cfg = dict(QWEN3_MOE_CONFIG)
+    weights = {
+        "model.embed_tokens.weight": torch.randn(64, 128),
+        "model.layers.0.mlp.experts.0.bogus_proj": torch.randn(32, 128),
+    }
+    path = _write_checkpoint(tmp_path, config=cfg, weights=weights)
+    with pytest.raises(ValueError, match="Unexpected expert weight key"):
+        load_moe_expert_sources(path, dtype=torch.bfloat16)
+
+
+def test_place_expert_weights_routes_each_byte_correctly(moe_ckpt_distinguishable):
+    """``load_model`` must place the repacked packed banks into the model's
+    per-expert modules with the *exact* byte-to-place routing: gate row ->
+    ``gate_proj``, the following up row -> ``up_proj``, down -> ``down_proj``,
+    one row per expert.
+
+    The checkpoint's values distinguish (expert, projection), so a routing
+    mistake -- e.g. the old code splitting a fused ``[E, 2I, H]`` row as
+    ``gu[e,0]``/``gu[e,1]`` (a 4-D ``[E,2,I,H]`` layout), which would swap or
+    truncate the gate/up halves -- makes an assertion below fail, whereas the
+    shape-only tests pass regardless. This is the regression guard for the
+    packed-bank contract (#53 / ADR 0002).
+    """
+    hidden, inter, experts = 128, 32, 4
+    model, _ = load_model(moe_ckpt_distinguishable, torch.device("cpu"))
+    for layer in range(2):
+        exp = _EXPECTED_L0_DISTINGUISHABLE  # layer-0 reference (values are layer-independent here)
+        for e in range(experts):
+            m = model.layers[layer].mlp.experts[e]
+            base = 100 * (e + 1)
+            exp_gate = torch.arange(inter, dtype=torch.float32)[:, None].repeat(1, hidden) + base
+            exp_up = torch.arange(inter, dtype=torch.float32)[:, None].repeat(1, hidden) + base + 1
+            exp_down = torch.arange(hidden, dtype=torch.float32)[:, None].repeat(1, inter) + base + 2
+            # The model params are bf16; the expected ints are exactly representable.
+            assert torch.equal(m.gate_proj.weight, exp_gate.to(torch.bfloat16)), (layer, e, "gate")
+            assert torch.equal(m.up_proj.weight, exp_up.to(torch.bfloat16)), (layer, e, "up")
+            assert torch.equal(m.down_proj.weight, exp_down.to(torch.bfloat16)), (layer, e, "down")


### PR DESCRIPTION
## What

Closes **#53** (MoE host-offload, ADR 0002): make the loader accept the **raw HF per-expert** expert layout and repack it into the **packed host banks** the offload slot cache and the `dummy=True` fabricator already expect.

A real HF checkpoint (Qwen3-30B-A3B) ships per-expert keys —
`model.layers.{L}.mlp.experts.{e}.{gate_proj,up_proj,down_proj}` (one `[I,H]`/`[H,I]` tensor per expert) — but the loader only accepted the packed `...experts.{gate_up_proj,down_proj}` form and raised `Unexpected expert weight key` on a real checkpoint. This is the blocker for loading any real MoE model.

## Changes

### `python/freetoken/models/weight.py`
- `_expert_source_info` (was `_packed_expert_source_info`) now classifies **both** layouts, anchored on `mlp -> experts`:
  - packed (`...experts.{gate_up_proj|down_proj}`, terminal) → `(L, name, None)`
  - per-expert (`...experts.{e}.{gate|up|down}_proj`) → `(L, name, e)`
  - anything else → `None` (still rejected with `Unexpected expert weight key`)
- `stream_moe_expert_sources` keeps the packed path unchanged; per-expert rows are **buffered** per `(layer, expert)` and fused into the packed bank at the end.
- New `_buffer_expert_row` + `_finalize_per_expert_banks` + `_stack_expert_rows`: build `gate_up [E,2I,H]` (gate then up, concatenated on dim 1) and `down [E,H,I]` per layer.

### `python/freetoken/models/loader.py` (follow-on fix in this PR)
- `_place_expert_weights` now splits the `[E,2I,H]` gate_up bank correctly: `gate = gu[e, 0:I]`, `up = gu[e, I:2I]`, `down = dn[e]`. The previous code did `gate, up = gu[e,0], gu[e,1]` — a 4-D `[E,2,I,H]` split that (a) silently mis-weighted every dummy-loaded expert and (b) would crash on a real per-expert checkpoint (the `[2I]` row wouldn't unpack into two).

### Why the buffered/fused approach in `weight.py`
The torch XPU build (2.13.0+xpu) mishandles in-place row writes (`__setitem__` with an int+slice, `narrow`+`copy_`, `scatter`) and `cat`/`reshape` on the 2-D per-expert rows — they drop or misplace the expert dimension. Stacking the rows with `unsqueeze(0)` + `cat(dim=0)` on 3-D tensors and fusing gate/up with `cat(dim=1)` is the reliable path; the docstrings document this.

## Tests (`tests/test_models_loader.py`)

- `test_load_moe_expert_sources_real_banks_per_expert_layout` — new per-expert checkpoint fixture; asserts the repacked bank shape **and** that layer-0 row 0 equals the exact written gate/up bytes fused on dim 1 (built via the same reliable 3-D route, since a bare 2-D `cat` is broken in this build).
- `test_load_model_real_moe_per_expert_routes_to_host` — the top-level `load_model` path handles the per-expert layout and routes the repacked banks to host memory.
- `test_load_moe_expert_sources_rejects_unknown_expert_key` — an unknown `...experts.0.bogus_proj` still raises (no silent mis-routing).
- **`test_place_expert_weights_routes_each_byte_correctly`** — a distinguishable-value per-expert checkpoint (gate=`100*(e+1)+r`, up=`+1`, down=`+2`). Asserts every expert's `gate_proj`/`up_proj`/`down_proj` in the loaded model equals the exact bytes written. This is the regression guard for the `_place_expert_weights` fix: it **fails** against the old 4-D split (gate row becomes all-100 instead of 100..131) and passes with the correct `[E,2I,H]` split.

## Verification
- CPU/CI suite: `pytest -m "not xpu and not slow"` → **31 passed, 2 skipped**
- XPU loader suite: **12 passed** (was 11; +1 for the placement-correctness test)
- XPU full suite: **2 passed, 43 deselected** (no regressions)

## Note
Offline-verifiable (no 61 GB download). The `_place_expert_weights` fix is the critical enabler for a real per-expert checkpoint to load without crashing. Follow-ups **#54** (rewire the Qwen3-MoE forward to read these host banks) and **#7** (XPU LRU slot pool + copy engine) build directly on this bank contract.