### PR TITLE
feat(moe): rewire Qwen3-MoE forward through the LRU slot pool (#54)

### DIFF
--- a/docs/intel-b70.md
+++ b/docs/intel-b70.md
@@ -34,10 +34,38 @@ Python (ft)
   → host RAM expert banks + CPU AMX/AVX-512 overflow
 ```
 
-## Driver / runtime pitfalls
+## Running Qwen3-30B-A3B with host-offloaded experts (#54)
 
-* Prefer a **single** Level Zero ICD (Arc client driver). Nested
-  Data-Center ICDs inside containers can split-brain device discovery.
-* Pin `ZE_AFFINITY_MASK` / `ONEAPI_DEVICE_SELECTOR` in benchmarks.
-* PCIe 4.0 x8 (OCuLink) boxes have less host↔device bandwidth than x16;
-  `ft bench bw` must be run on the actual machine before trusting `hybrid`.
+ADR 0002 moves the MoE expert weights out of XPU VRAM into pinned host RAM
+plus a small LRU slot pool, so a 30B-A3B MoE runs on a B70 whose 32 GB cannot
+hold every expert. The dense weights (embeddings, attention, norms, router,
+`lm_head`) stay on the XPU; only the expert `gate`/`up`/`down` projections are
+offloaded.
+
+* **Checkpoint is ~61 GB.** Qwen3-30B-A3B ships as bf16 safetensors shards;
+  download the full set before the first run (the loader streams the shards,
+  but the offload banks are built from the expert shards on the first
+  `load_model`, so a partial download stalls there). `ft serve` should surface
+  the expected download / build time up front.
+* **Host RAM budget.** The expert banks are pinned host RAM; the working set
+  is the whole offload bank set (tens of GB), so the box needs that much free
+  RAM in addition to what the OS / driver hold.
+* **Divergence watchlist.** The offload forward must reproduce the in-VRAM
+  forward's greedy tokens exactly (the slot pool is a *transport*, not a math
+  change). Watch for:
+  - **Prefill/decode mix-up.** If the prompt step is tagged `decode`, the
+    model writes only the last prompt token's K/V to the pool and attends over
+    the unwritten (garbage) rows — logits blow up and the output is
+    non-deterministic run-to-run. `engine.step` must tag the prompt step
+    `prefill`.
+  - **LRU eviction of a still-needed expert.** With `S < E` slots a decode
+    step can evict an expert another routed token still needs in the same
+    step; the forward must re-stream it (the miss-stats counters in
+    `OffloadMoeCache` should stay near zero for a warm prompt).
+  - **Slot / layer-map mismatch.** A wrong `moe_layer_id` mapping reads the
+    wrong layer's bank — outputs stay finite but silently wrong.
+
+The CPU tests in `tests/test_moe_offload_forward.py` encode this contract on a
+tiny fabricated Qwen3-MoE (in-VRAM reference vs. offload, plus a
+determinism check), so a regression in any of the above fails the forward
+gate.

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -82,6 +82,7 @@ class Engine:
             device,
             dtype=dtype,
             dummy=bool(getattr(config, "use_dummy_weight", False)),
+            moe_backend=getattr(config, "moe_backend", None),
         )
 
         # Size the paged KV pool. The pool is indexed by token slot
@@ -117,11 +118,18 @@ class Engine:
         # can still opt out via ignore_eos.
         self.sampler = self._build_sampler(model_config, device)
 
-        # Global context the model's forward reads.
+        # Global context the model's forward reads. The model also resolves its
+        # own reference (ctx.model) so the MoE blocks can reach the offload
+        # cache / layer map without the engine reaching into the model.
         self.ctx = Context(page_size=self.page_size)
+        self.ctx.model = self.model
         self.ctx.kv_cache = self.kv_cache
         self.ctx.attn_backend = self.attn_backend
         self.ctx.page_table = self.page_table
+        # ADR 0002: when the MoE experts are host-offloaded, the model's forward
+        # serves them through the LRU slot pool the loader attached.
+        if getattr(self.model, "moe_offload", False) and getattr(self.model, "moe_cache", None) is not None:
+            self.ctx.moe_offload_cache = self.model.moe_cache
         set_global_ctx(self.ctx)
 
         # Request bookkeeping.
@@ -151,18 +159,32 @@ class Engine:
     # -- the loop -------------------------------------------------------------
 
     def step(self) -> ForwardOutput:
-        """Run one engine step (one model forward + one sample) over all reqs."""
+        """Run one engine step (one model forward + one sample) over all reqs.
+
+        The first step for a request is its *prefill*: every prompt token must be
+        run through the model and written into the KV pool (one row per position),
+        so the backend can attend over the full history. A request is in prefill
+        while ``device_len == len(input_ids)`` -- i.e. no token has been generated
+        yet (``device_len`` grows by one after each step, so this is true exactly
+        once, on the first step). Every later step is a decode: one new token.
+        """
         reqs = self._reqs
         if not reqs:
             return ForwardOutput(next_token_ids=torch.empty((0,), device=self.device), finished=[])
-        phase = "decode"
+        # A single step mixes prefill (prompt not yet processed) and decode
+        # (already processed) requests; batch the phase per request. The
+        # reference model slices per-request by ``extend_len`` (prefill) or 1
+        # (decode), so the batch just carries the request list.
+        phase = "prefill" if any(r.device_len == len(r.input_ids) for r in reqs) else "decode"
         batch = Batch(reqs=reqs, phase=phase)
 
         input_ids: List[int] = []
         positions: List[int] = []
         out_locs: List[int] = []
         for req in reqs:
-            if phase == "prefill":
+            # Per-request phase: prefill while no token has been generated yet
+            # (the whole prompt is new), decode afterwards (one new token).
+            if req.device_len == len(req.input_ids):
                 ext = req.extend_len
                 start = req.cached_len
                 ids = req.input_ids

--- a/python/freetoken/models/config.py
+++ b/python/freetoken/models/config.py
@@ -34,6 +34,11 @@ class ModelConfig:
     hidden_act: str = "silu"
     first_k_dense_replace: int = 0
     is_moe: bool = False
+    # ADR 0002: when True the MoE experts are never XPU-resident; the model
+    # builds only the router and reads the routed experts from the host-offload
+    # LRU slot pool (OffloadMoeCache) inside the forward pass. The loader sets
+    # this from the engine's moe_backend choice (it is NOT a checkpoint field).
+    use_offload_moe: bool = False
     dtype: Any = None
     max_position_embeddings: int | None = None
     tie_word_embeddings: bool = False

--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -31,6 +31,7 @@ def load_model(
     *,
     dtype: torch.dtype | None = None,
     dummy: bool = False,
+    moe_backend: str | None = None,
 ) -> tuple:
     """Load a checkpoint onto ``device`` (defaults to the XPU when available).
 
@@ -39,6 +40,11 @@ def load_model(
     the per-layer MoE bank tuple from :func:`load_moe_expert_sources` (empty for
     a dense model). With ``dummy=True`` the expert banks are fabricated from the
     config (offline / CPU-testable) and no checkpoint is read.
+
+    ``moe_backend`` (ADR 0002): when it names the host-offload backend the
+    MoE experts are never XPU-resident -- the model builds router-only MoE
+    blocks and the loader attaches the LRU slot pool (``OffloadMoeCache``) wired
+    to the host banks, so the forward streams the routed experts on demand.
     """
     if device is None:
         device = torch.device("xpu") if is_xpu_available() else torch.device("cpu")
@@ -49,7 +55,8 @@ def load_model(
 
     hf_config = cached_load_hf_config(model_path)
     spec = get_model_spec(hf_config.architectures[0])
-    model_config = _load_attr(spec.module, spec.parse_config)(hf_config)
+    use_offload = moe_backend is not None and "offload" in moe_backend
+    model_config = _load_attr(spec.module, spec.parse_config)(hf_config, use_offload_moe=use_offload)
     # Build the model *on this device* (the loader already resolved it): an
     # explicit device wins, and only a None device lets the model default to
     # the XPU. Without this the model would re-default to the XPU and ignore
@@ -62,6 +69,7 @@ def load_model(
     model = get_model_class(hf_config.architectures[0], model_config, device=device)
 
     is_moe = bool(getattr(model_config, "is_moe", False))
+    offload = is_moe and use_offload
     if dummy:
         # Offline path: no checkpoint is read, so the model's MoE experts must
         # come from fabricated banks. To make this *reproducible* (the engine's
@@ -72,9 +80,22 @@ def load_model(
         # (The dense weights are not read in this path; the reference test
         # fabricates a tiny checkpoint but only the dummy experts are consumed.)
         if is_moe:
+            # Both backends need the dummy path reproducible: the in-VRAM model
+            # owns the expert modules (seeded here), while the offload model owns
+            # only the dense params (experts live in the host banks, seeded
+            # separately by load_moe_expert_sources). _seed_dummy_experts zeroes
+            # every non-expert param and re-seeds the RNG from the config hash,
+            # so the dense weights -- and hence the greedy output -- are a pure
+            # function of the config regardless of the process's prior RNG state.
+            # It is safe on the offload model too: it only iterates
+            # named_parameters (the dense set there; no expert params exist), so
+            # nothing offload-specific is touched.
             _seed_dummy_experts(model)
             gate_up_banks, down_banks = load_moe_expert_sources(model_path, dtype=dtype, dummy=True)
-            _place_expert_weights(model, gate_up_banks, down_banks)
+            if offload:
+                _attach_offload_cache(model, model_config, device, gate_up_banks, down_banks)
+            else:
+                _place_expert_weights(model, gate_up_banks, down_banks)
             expert_sources = (gate_up_banks, down_banks)
         else:
             expert_sources = ([], [])
@@ -82,11 +103,22 @@ def load_model(
         # Real path: stream the dense checkpoint weights onto ``device`` and, for
         # a MoE checkpoint, build the per-layer host offload banks for the experts
         # (which do not fit on the XPU and are served to the engine on demand).
+        #
+        # Both backends read the *same* checkpoint here, so the dense weights the
+        # reference and the offload model receive are byte-identical -- the
+        # offload forward then differs from the in-VRAM one only in how the expert
+        # weights are transported (host banks -> LRU slots), never in the values.
+        # (No dummy seeding: a real checkpoint is a stable source of the dense
+        # weights, so re-seeding the RNG here would be unnecessary and would make
+        # the model depend on process state instead of the checkpoint.)
         for name, tensor in load_weight(model_path, device, include_moe_experts=False):
-            _place(model, name, tensor)
+            _place_dense(model, name, tensor)
         if is_moe:
             gate_up_banks, down_banks = load_moe_expert_sources(model_path, dtype=dtype)
-            _place_expert_weights(model, gate_up_banks, down_banks)
+            if offload:
+                _attach_offload_cache(model, model_config, device, gate_up_banks, down_banks)
+            else:
+                _place_expert_weights(model, gate_up_banks, down_banks)
             expert_sources = (gate_up_banks, down_banks)
         else:
             expert_sources = ([], [])
@@ -181,6 +213,79 @@ def _place_expert_weights(model, gate_up_banks, down_banks) -> None:
                 experts[e].gate_proj.weight.copy_(gu[e, 0:intermediate])
                 experts[e].up_proj.weight.copy_(gu[e, intermediate : 2 * intermediate])
                 experts[e].down_proj.weight.copy_(dn[e])
+
+
+def _attach_offload_cache(
+    model,
+    model_config,
+    device: torch.device,
+    gate_up_banks,
+    down_banks,
+) -> None:
+    """Build the LRU slot pool and wire it into the offload model (ADR 0002).
+
+    The MoE experts are never XPU-resident on this path. The host expert banks
+    (``gate_up_banks`` / ``down_banks``, one ``[num_experts, ...]`` per MoE
+    layer, on host memory) are attached to an ``OffloadMoeCache`` that owns a
+    small device slot pool; the forward (``_Qwen3MoE._forward_offload``) routes
+    each layer's routed experts through it -- ``materialize_layer`` on prefill,
+    ``ensure_experts`` (timestamp LRU) + ``copy_missing`` on decode.
+
+    The cache is indexed by *MoE-layer index* (0-based among the MoE layers),
+    while the model's blocks are indexed by *absolute layer id*, so we also give
+    the model the ``moe_layer_id`` map (layer_id -> MoE index) the forward uses.
+    """
+    from freetoken.moe.offload_cache import OffloadMoeCache
+
+    num_experts = int(getattr(model_config, "num_experts", 0) or 0)
+    moe_layers = _moe_layers(model_config)
+    num_moe = len(moe_layers)
+    if not num_moe:
+        return
+    # The pool is a single global LRU shared by all MoE layers (the only place
+    # the 61 GB of experts fits): it holds the *current* layer's whole expert set
+    # (num_experts slots) plus a small slack of decode slots so a decode miss can
+    # be placed without immediately evicting a just-routed expert of the same
+    # step. Sized off the layer count so the pool scales with the model (a real
+    # Qwen3-30B-A3B has 128 experts / 48 MoE layers). Operators that can afford
+    # more VRAM raise ``moe_cache_size`` to keep more layers warm at once.
+    cache_size = num_experts + max(2, num_moe)
+    cache = OffloadMoeCache(
+        num_layers=num_moe,
+        num_experts=num_experts,
+        cache_size=cache_size,
+        device=device,
+    )
+    # The banks are indexed by MoE-layer order (moe_layers), matching the cache's
+    # 0-based MoE-layer ids.
+    gu = [b.tensor if hasattr(b, "tensor") else b for b in gate_up_banks]
+    dn = [b.tensor if hasattr(b, "tensor") else b for b in down_banks]
+    cache.set_bank_sources({"gate_up": gu, "down": dn})
+
+    model.moe_cache = cache
+    model.moe_layer_id = [0] * len(model.layers)
+    for moe_idx, layer_id in enumerate(moe_layers):
+        model.moe_layer_id[layer_id] = moe_idx
+    model.ctx_moe_cache = cache  # the engine installs this on its Context
+
+
+def _place_dense(model, name: str, tensor: torch.Tensor) -> None:
+    """Place a dense checkpoint tensor into the model's corresponding parameter.
+
+    The checkpoint keys the ``model.`` prefix that the HF layout uses
+    (``model.embed_tokens.weight`` / ``model.layers.0.self_attn.q_proj.weight``),
+    but the model registers its params *without* that prefix
+    (``embed_tokens.weight`` / ``layers.0.self_attn.q_proj.weight``) -- see the
+    ``Qwen3MoeForCausalLM`` module layout. A bare exact-match ``_place`` therefore
+    silently no-ops on every dense weight (the param name differs by the prefix),
+    leaving the model at random init. ``lm_head.weight`` matches either way (no
+    prefix on either side), so it is the one dense weight a naive ``_place`` does
+    fill -- the asymmetry that masks the rest. This strips a single leading
+    ``model.`` segment so the checkpoint key resolves to the model param.
+    """
+    if name.startswith("model."):
+        name = name[len("model.") :]
+    _place(model, name, tensor)
 
 
 def _place(model, name: str, tensor: torch.Tensor) -> None:

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -35,11 +35,16 @@ from freetoken.models.weight import iter_safetensors
 # --------------------------------------------------------------------------- #
 
 
-def parse_config(hf_config) -> ModelConfig:
+def parse_config(hf_config, use_offload_moe: bool = False) -> ModelConfig:
     """Build a :class:`ModelConfig` from a HF Qwen3-MoE config.
 
     ``hf_config`` is the lru-cached object shared across callers, so it is
     copied (``to_dict``) before the parsed fields are derived -- never mutated.
+
+    ``use_offload_moe`` (ADR 0002) is *not* a checkpoint field: the loader /
+    engine set it from the ``moe_backend`` choice. When True the MoE experts are
+    never XPU-resident and are streamed from host RAM through the LRU slot pool
+    during the forward pass.
     """
     src = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
     # transformers' Qwen3MoeConfig stores the expert count under
@@ -70,6 +75,8 @@ def parse_config(hf_config) -> ModelConfig:
     # FreeToken's MoE plumbing keys off config.is_moe; expose it. (num_moe_layers
     # is derived in ModelConfig.__post_init__.)
     cfg.is_moe = True
+    # ADR 0002: flag the host-offload MoE path (off by default = in-VRAM experts).
+    cfg.use_offload_moe = use_offload_moe
     return cfg
 
 
@@ -164,8 +171,36 @@ class _Qwen3Attention(nn.Module):
         return self.o_proj(out.transpose(1, 2).reshape(bsz, -1))
 
 
+def _expert_compute(gate_w: torch.Tensor, up_w: torch.Tensor, down_w: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    """Run one expert on a [t, H] input using *detached* projection weights.
+
+    The expert weights live in the host-offload banks (ADR 0002) and are handed
+    in as plain tensors (views of the XPU slot pool), so this is a hand-rolled
+    SwiGLU -- not an ``nn.Linear`` -- over the gathered per-expert input:
+    ``down(silu(gate(x)) * up(x))``. The bank rows are stored in *weight*
+    orientation (``[out, in]``, matching ``nn.Linear.weight``): gate/up are
+    ``[I, H]`` and down is ``[H, I]``. The projection is therefore
+    ``x @ w.t()`` -- the same ``F.linear`` form the in-VRAM ``_Qwen3Expert``
+    uses -- so the math is identical to the resident path, which the reference
+    test compares against.
+    """
+    # gate_w [I, H], up_w [I, H], down_w [H, I]; x [t, H].
+    # Every projection is ``x @ w.t()`` (F.linear form). The down step is
+    # ``h @ down_w.t()`` (NOT ``down_w.t() @ h``): in this torch XPU build the
+    # ``@`` operator requires ``left.cols == right.rows``, so the leading
+    # ``[t, *]`` operand must be on the left. ``h @ down_w.t()`` is exactly
+    # ``F.linear(h, down_w)`` -- the in-VRAM expert's down projection.
+    inter = gate_w.shape[0]
+    return (F.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()
+
+
 class _Qwen3Expert(nn.Module):
-    """A single MoE expert: gate/up/down projections (SwiGLU)."""
+    """A single MoE expert: gate/up/down projections (SwiGLU).
+
+    Used by the in-VRAM path only (``use_offload_moe=False``). The offload path
+    (ADR 0002) does not build these at all -- the experts live in host RAM and
+    are read through the LRU slot pool instead.
+    """
 
     def __init__(self, config) -> None:
         super().__init__()
@@ -180,19 +215,35 @@ class _Qwen3Expert(nn.Module):
 class _Qwen3MoE(nn.Module):
     """Mixture-of-experts block: router + N experts.
 
-    Weights live on host (loader-routed). For each token the router picks the
-    top-k experts; this reference implementation gathers each token's expert
-    inputs and runs the selected experts, accumulating the weighted output.
+    Two paths (ADR 0002):
+
+    * ``use_offload_moe=False`` (default): the N experts are XPU-resident
+      ``_Qwen3Expert`` modules; the forward gathers each token's routed experts
+      from them.
+    * ``use_offload_moe=True``: the experts are *never* XPU-resident. Only the
+      router is built; at each step the routed expert ids are routed through the
+      engine's ``OffloadMoeCache`` (host banks -> small XPU LRU slot pool), the
+      missed experts are streamed from host, and each routed token runs the
+      selected expert through the slot weights.
     """
 
     def __init__(self, config, device, dtype) -> None:
         super().__init__()
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
+        self.use_offload = bool(getattr(config, "use_offload_moe", False))
         self.gate = nn.Linear(config.hidden_size, self.num_experts, bias=False)
-        self.experts = nn.ModuleList(_Qwen3Expert(config).to(device, dtype) for _ in range(self.num_experts))
+        if self.use_offload:
+            # ADR 0002: no XPU-resident expert params. The routed experts are
+            # read from the LRU slot pool the loader attaches to the model
+            # (``model.moe_cache`` + ``model.moe_layer_id``); the host banks are
+            # the source of truth. (``self.experts`` is left unset -- the loader
+            # never copies into expert modules on this path.)
+            self.experts = None
+        else:
+            self.experts = nn.ModuleList(_Qwen3Expert(config).to(device, dtype) for _ in range(self.num_experts))
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(self, hidden_states: torch.Tensor, model=None, batch=None) -> torch.Tensor:
         # The engine feeds a *token-major* 2-D slice [num_tokens, hidden]
         # (one request at a time), so we must not assume a [bsz, seq, hidden]
         # batch dim. Flatten to [T, hidden] and restore the same shape on the way out.
@@ -202,6 +253,9 @@ class _Qwen3MoE(nn.Module):
         gate_log = F.softmax(routing, dim=-1)
         top_w, top_idx = torch.topk(gate_log, self.top_k, dim=-1)  # [T, k]
         top_w = (top_w / top_w.sum(dim=-1, keepdim=True)).to(flat.dtype)
+
+        if self.use_offload:
+            return self._forward_offload(flat, top_idx, top_w, model, batch).view(in_shape)
 
         out = torch.zeros_like(flat)
         # Per-expert gather: route each expert's tokens in one matmul each.
@@ -213,6 +267,57 @@ class _Qwen3MoE(nn.Module):
                 out[sel] += top_w[sel, slot, None] * self.experts[e](flat[sel])
         return out.view(in_shape)
 
+    def _forward_offload(self, flat, top_idx, top_w, model, batch) -> torch.Tensor:
+        """Serve the routed experts through the host-offload LRU slot pool.
+
+        The pool is a single global timestamp LRU shared by every MoE layer
+        (ADR 0002): a prefill materializes the *whole* layer into the pool
+        (evicting the LRU-resident experts of other layers), and a decode step
+        streams in only the *missed* routed experts, each into an evicted slot.
+        After :meth:`ensure_experts` / :meth:`materialize_layer` the ``top_idx``
+        tensor holds *slot* ids, so each routed token runs the expert the slot
+        currently holds -- which, after ``copy_missing``, is exactly the routed
+        expert (the forward indexes the slot cache, not the layer bank).
+        """
+        layer_id = model.moe_layer_id[self.layer_id]
+        cache = model.moe_cache
+        # A prefill must materialize the *whole* MoE layer into the LRU pool
+        # (evicting other layers' resident experts); a decode streams in only the
+        # missed routed experts, one at a time. The engine tags the prompt step
+        # ``phase="prefill"`` and later steps ``phase="decode"`` (engine.step),
+        # so ``batch.is_prefill`` is the phase signal; the ``flat.shape[0] > 1``
+        # check is a phase-independent fallback (prefill >1 token, decode == 1).
+        is_prefill = (batch is not None and batch.is_prefill) or flat.shape[0] > 1
+        if is_prefill:
+            cache.materialize_layer(layer_id)
+        else:
+            cache.ensure_experts(layer_id, top_idx)
+        cache.copy_missing()
+
+        # bank_views() returns a tuple indexed by bank registration order
+        # ("gate_up" first, "down" second); index the pool (S slots) and pick
+        # the per-slot row by slot id.
+        gu, dn = cache.bank_views()  # ([S, 2I, H], [S, H, I])
+        intermediate = int(model.config.moe_intermediate_size)
+
+        out = torch.zeros_like(flat)
+        k = top_idx.shape[1]
+        for slot_pos in range(k):
+            routed = top_idx[:, slot_pos]  # [B] slot ids (after ensure_experts)
+            valid = routed >= 0
+            if not valid.any():
+                continue
+            s = routed[valid]  # the slot each token's expert landed in
+            for s_i in torch.unique(s).tolist():
+                sub = valid & (routed == s_i)
+                out[sub] += top_w[sub, slot_pos, None] * _expert_compute(
+                    gu[s_i, 0:intermediate],
+                    gu[s_i, intermediate : 2 * intermediate],
+                    dn[s_i],
+                    flat[sub],
+                )
+        return out
+
 
 class _Qwen3DecoderLayer(nn.Module):
     def __init__(self, config, device, dtype, layer_id: int) -> None:
@@ -222,13 +327,19 @@ class _Qwen3DecoderLayer(nn.Module):
         self.self_attn = _Qwen3Attention(config, device, dtype, layer_id)
         self.post_attention_layernorm = nn.RMSNorm(config.hidden_size)
         self.mlp = _Qwen3MoE(config, device, dtype)
+        # The offload path must know *which* MoE layer this block serves (the
+        # slot pool is indexed by layer id, and the loader maps layer id ->
+        # MoE-layer index). Dense layers have no mlp cache to index.
+        self.mlp.layer_id = layer_id
 
     def forward(self, hidden_states, positions, table_idx, ctx, batch):
         residual = hidden_states
         hidden_states = self.self_attn(self.input_layernorm(hidden_states), positions, table_idx, ctx, batch)
         hidden_states = residual + hidden_states
         residual = hidden_states
-        hidden_states = residual + self.mlp(self.post_attention_layernorm(hidden_states))
+        hidden_states = residual + self.mlp(
+            self.post_attention_layernorm(hidden_states), model=ctx.model, batch=batch
+        )
         return hidden_states
 
 
@@ -268,6 +379,18 @@ class Qwen3MoeForCausalLM(nn.Module):
         self.norm = nn.RMSNorm(hidden_size)
         self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
 
+        # ADR 0002: when the engine picks the host-offload MoE backend the
+        # experts are never XPU-resident. The MoE blocks then hold *only* the
+        # router (no expert ``nn.Linear`` params); the routed experts are read
+        # from the LRU slot pool the loader attaches to ``self`` before the
+        # engine runs (self.moe_cache / self.moe_layer_id / self.ctx).
+        if bool(getattr(config, "use_offload_moe", False)) and bool(getattr(config, "is_moe", False)):
+            self.moe_offload = True
+        else:
+            self.moe_offload = False
+        self.moe_cache = None
+        self.moe_layer_id = None
+
     def forward(self, input_ids: torch.Tensor, positions: torch.Tensor, out_loc: torch.Tensor) -> torch.Tensor:
         """Run one engine step; return the **last-position** logits ``[bs, V]``.
 
@@ -281,13 +404,21 @@ class Qwen3MoeForCausalLM(nn.Module):
         ctx = get_global_ctx()
         batch = ctx.batch
         reqs = batch.reqs
+        num_tokens = input_ids.shape[0]
 
         hidden = self.embed_tokens(input_ids)  # [num_tokens, hidden]
         out = torch.empty((batch.size, self.config.hidden_size), device=hidden.device, dtype=hidden.dtype)
 
         offset = 0
+        # The engine tags the prompt step ``phase="prefill"`` and every later
+        # step ``phase="decode"`` (see engine.step). ``batch.is_prefill`` is the
+        # authoritative phase signal; the ``num_tokens > batch.size`` check is a
+        # phase-independent fallback (a prefill step carries >1 token per request,
+        # a decode step exactly one) so the forward is correct even if a caller
+        # hands a decode-tagged prompt.
+        prefill = batch.is_prefill or (num_tokens > batch.size)
         for i, req in enumerate(reqs):
-            ext = req.extend_len if batch.is_prefill else 1
+            ext = req.extend_len if prefill else 1
             token_slice = slice(offset, offset + ext)
             h = hidden[token_slice]
             for layer in self.layers:

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -104,8 +104,9 @@ class OffloadMoeCache:
         # Per-layer active mask (diagnostics; mirrors upstream).
         self.active_mask = torch.zeros((num_experts,), dtype=torch.int32, device=self.device)
 
-        # Fixed-shape staging for the copy plan. A layer's routed set has at most
-        # batch*top_k positions, so size these for the larger of (E, cache_size).
+        # Fixed-shape staging for the copy plan. Both phases stage one row per
+        # (evicted) expert: materialize_layer stages up to num_experts (a whole
+        # layer) and ensure_experts stages one per miss, so size for the larger.
         plan_slots = max(num_experts, cache_size)
         self.evict_slots = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
         self.src_indices = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
@@ -186,49 +187,82 @@ class OffloadMoeCache:
     # -- prefill: whole-layer materialize --------------------------------------
 
     def materialize_layer(self, layer_id: int) -> None:
-        """Place a whole layer into slots ``[0, E)`` (slot == expert, no LRU).
+        """Place a whole layer into the slot pool for a prefill forward.
 
-        Mirrors the upstream ``_materialize_layer`` kernel: a slot already
-        owned by *this* layer is just refreshed (usage = step); a slot owned by
-        *another* layer is released (its id's ``slot_for_id`` cleared) and then
-        reused. ``num_indices`` is set to ``num_experts`` so a following
-        :meth:`copy_missing` copies the entire layer's host rows into the slots.
+        This is a *batched timestamp-LRU* pass over the whole layer's experts,
+        not a fixed-slot double buffer: the pool is a single global LRU shared by
+        all layers (the only place 61 GB of experts physically fit), so a layer
+        that is being prefilled evicts the LRU-resident experts of *other* layers
+        and re-uses their slots. (Upstream, ``materialize_layer`` is a
+        double-buffer *prefetch* -- it writes into a separate prefill double
+        buffer and never evicts a resident decode slot the way a fixed [0, E)
+        remap would; this mirror folds that into the unified global LRU, which is
+        the correctness-preserving equivalent.)
+
+        Per expert: an already-resident expert is a **hit** (keeps its slot,
+        usage bumped, no re-copy); a **miss** takes a free slot or evicts the
+        global LRU victim. After the loop every expert of the layer is resident
+        (the forward may then gather the whole layer), and ``num_indices`` counts
+        the missed experts so a following :meth:`copy_missing` streams exactly
+        those host rows. Requires ``cache_size >= num_experts`` (the constructor
+        enforces this) -- below that the pool cannot hold a whole layer.
         """
         if not (0 <= layer_id < self.num_layers):
             raise ValueError(f"Invalid materialize layer id {layer_id}")
         E = self.num_experts
         S = self.cache_size
         base = layer_id * E
+        if S < E:
+            raise ValueError(
+                f"cache_size {S} < num_experts {E}: cannot materialize a whole layer"
+            )
         step = int(self.step.item()) + 1
         self.step.fill_(step)
-
-        # Slot -> old id (a python list so the loop below stays allocation-free
-        # relative to the tensor writes). Two cases release a slot:
-        #  * owned by a DIFFERENT layer -> released (that layer's expert is
-        #    evicted; it re-fetches on its next decode step), and
-        #  * owned by THIS layer in a DECODE slot (>= 2E) -> released too, since
-        #    prefill re-homes this layer's experts into the double buffer.
-        #     Without this, a decode slot a previous decode step placed an expert
-        #     in would leave the expert double-resident (slot_for_id says the
-        #     decode slot, id_of_slot still claims the double-buffer slot), so the
-        #     next decode step would mis-classify a hit as a miss (or vice versa).
-        slot_for_id = self.slot_for_id.view(-1)
-        old_ids = self.id_of_slot.tolist()
-        for slot in range(S):
-            old_id = old_ids[slot]
-            if old_id < 0:
-                continue
-            if not (base <= old_id < base + E) or slot >= E:
-                slot_for_id[old_id] = -1
-                self.id_of_slot[slot] = -1
-                self.usage[slot] = 0
+        self.active_mask.zero_()
         for expert in range(E):
-            self.id_of_slot[expert] = base + expert
-            slot_for_id[base + expert] = expert
-            self.usage[expert] = step
-            self.evict_slots[expert] = expert
-            self.src_indices[expert] = expert  # layer-local row == expert
-        self.num_indices.fill_(E)
+            self.active_mask[expert] = 1
+
+        layer_slots = self.slot_for_id[layer_id]
+        flat_slots = self.slot_for_id.view(-1)
+
+        # Phase 1: hits -- a resident expert keeps its slot and bumps usage (no
+        # re-copy), so re-prefilling an already-warm layer is cheap.
+        for expert in range(E):
+            slot = int(layer_slots[expert].item())
+            if slot != -1:
+                self.usage[slot] = step
+
+        # Phase 2: misses -- a non-resident expert takes a free slot (an expert
+        # whose id_of_slot was cleared when another layer evicted it) or, if the
+        # pool is full, the global LRU victim. Every evicted (slot, host-row)
+        # pair is scheduled for :meth:`copy_missing`.
+        missing = [e for e in range(E) if int(layer_slots[e].item()) == -1]
+        self.stat_missing += len(missing)
+        self.stat_calls += 1
+        num = 0
+        usage = self.usage.tolist()
+        for expert in missing:
+            if num >= self.evict_slots.shape[0]:
+                raise RuntimeError(
+                    f"layer {layer_id}: {len(missing)} misses exceed the staging buffer"
+                )
+            # A free slot: id_of_slot[slot] == -1 (the owner was evicted).
+            free = [s for s in range(S) if int(self.id_of_slot[s].item()) == -1]
+            if free:
+                victim = free[0]
+            else:
+                victim = min(range(S), key=lambda s: (usage[s], s))
+            old_id = int(self.id_of_slot[victim].item())
+            if old_id >= 0:
+                flat_slots[old_id] = -1
+            self.id_of_slot[victim] = base + expert
+            layer_slots[expert] = victim
+            self.usage[victim] = step
+            usage[victim] = step
+            self.evict_slots[num] = victim
+            self.src_indices[num] = expert  # layer-local host row
+            num += 1
+        self.num_indices.fill_(num)
         self._pending_src_layer = layer_id
         self._pending_whole_layer = True
 
@@ -238,19 +272,25 @@ class OffloadMoeCache:
         """Make this layer's routed experts resident; rewrite ``expert_ids`` to
         slot ids in place (the downstream gather indexes the slot cache by it).
 
-        Hits (already resident, slot >= 2E) bump the slot's usage. Misses evict
-        the victim ``min(range(2E, S), key=(usage, slot))`` and schedule the
-        (slot, host-row) pair for :meth:`copy_missing`. The double buffer (slots
-        < 2E) is never evicted. Raises if a miss cannot be placed (pool exhausted
-        for the double buffer) -- the operator must size ``cache_size`` larger.
+        The pool is a single **global** timestamp LRU shared by every layer.
+        A routed expert that is already resident (in *any* slot, any layer) is a
+        **hit**: it keeps its slot and its usage is bumped. A **miss** evicts the
+        global LRU victim ``min(range(S), key=(usage, slot))`` -- including a
+        slot another layer holds, which is the whole point of offload (experts
+        are re-fetched on demand, never all resident at once) -- and schedules the
+        (slot, host-row) pair for :meth:`copy_missing`.
+
+        This mirrors upstream's decode kernel (``min(range(cache_size),
+        key=usage)``), which evicts across the *entire* slot space; a double
+        buffer is only a prefill optimization, not a protected region.
         """
         E = self.num_experts
         S = self.cache_size
         base = layer_id * E
-        if self.banks and S < E + 1:
+        if self.banks and S < 2:
             raise RuntimeError(
-                f"cache_size {S} cannot hold the double buffer (2E={2 * E}) plus a "
-                "decode slot; raise moe_cache_size"
+                f"cache_size {S} < 2: the pool cannot hold a routed expert plus "
+                "a victim to evict; raise moe_cache_size"
             )
 
         flat = expert_ids.reshape(-1)
@@ -269,22 +309,19 @@ class OffloadMoeCache:
         layer_slots = self.slot_for_id[layer_id]
         flat_slots = self.slot_for_id.view(-1)
 
-        # Phase 1: hits -- every resident routed expert (slot != -1, whether it
-        # lives in the double buffer [0, E) or a decode slot >= 2E) keeps its
-        # slot and is NOT re-copied; its slot's usage is stamped to this step.
-        # This mirrors upstream's ``tl.store(usage+slot, step, mask=is_hit)``
-        # (is_hit = active & slot >= 0) and, crucially, refreshes a double-buffer
-        # slot that another expert's decode-slot copy is about to reuse, so the
-        # eviction phase below never picks it as the LRU victim.
+        # Phase 1: hits -- every resident routed expert (any slot, any layer) keeps
+        # its slot and is NOT re-copied; its slot's usage is stamped to this step.
+        # Mirrors upstream's ``tl.store(usage+slot, step, mask=is_hit)``.
         for expert in seen:
             slot = int(layer_slots[expert].item())
             if slot != -1:
                 self.usage[slot] = step
 
-        # Phase 2: misses -- a routed expert that is NOT resident evicts the LRU
-        # decode slot (min (usage, slot) over slots >= 2E) and schedules the copy.
-        # A resident expert (even in the double buffer) is a hit and never lands
-        # here, so a decode step right after a prefill materialize is all hits.
+        # Phase 2: misses -- a routed expert that is NOT resident evicts the
+        # global LRU slot (min (usage, slot) over ALL slots) and schedules the copy.
+        # A resident expert is a hit and never lands here. (With a warm pool the
+        # misses are the experts another layer evicted; with a cold pool they are
+        # everything routed.)
         missing = [e for e in seen if int(layer_slots[e].item()) == -1]
         missing.sort()
         self.stat_missing += len(missing)
@@ -292,11 +329,11 @@ class OffloadMoeCache:
         num = 0
         usage = self.usage.tolist()
         for idx, expert in enumerate(missing):
-            if num >= self.num_indices.shape[0]:
+            if num >= self.evict_slots.shape[0]:
                 raise RuntimeError(
                     f"layer {layer_id}: {len(missing)} misses exceed the staging buffer"
                 )
-            victim = min(range(2 * E, S), key=lambda s: (usage[s], s))
+            victim = min(range(S), key=lambda s: (usage[s], s))
             old_id = int(self.id_of_slot[victim].item())
             if old_id >= 0:
                 flat_slots[old_id] = -1
@@ -347,7 +384,8 @@ class OffloadMoeCache:
 
     def resident_slots(self, layer_id: int) -> list[int]:
         """The slots currently holding this layer's experts (for the forward's
-        gather); empty if none resident."""
+        gather); empty if none are resident. (Under the global-LRU scheme this is
+        just the set of slots whose ``id_of_slot`` falls in this layer's id range.)"""
         E = self.num_experts
         S = self.cache_size
         base = layer_id * E

--- a/tests/test_moe_offload_cache.py
+++ b/tests/test_moe_offload_cache.py
@@ -1,13 +1,14 @@
 """Tests for the MoE LRU expert slot cache (issue #7, ADR 0002).
 
 The cache is the CPU mirror of the upstream FreeToken ``OffloadMoeCache``:
-per-layer host expert banks feed a small pool of device slots via a
-timestamp LRU (prefill materializes a whole layer, decode streams only the
-missed experts). These tests exercise the LRU bookkeeping and the
-host->slot copy on a CPU device (machine-independent, no XPU / no network),
-so they run in the CPU venv. The XPU-specific piece (streaming the misses
-over PCIe / oneAPI) is the scope of ``moe-offload`` and is not exercised
-here.
+per-layer host expert banks feed a single global pool of device slots via a
+timestamp LRU shared by *all* layers (the only place 61 GB of experts fits).
+Prefill materializes a whole layer into the pool (evicting the LRU-resident
+experts of other layers); decode streams only the *missed* routed experts,
+each into an evicted slot. These tests exercise that global-LRU bookkeeping
+and the host->slot copy on a CPU device (machine-independent, no XPU / no
+network). The XPU-specific piece (streaming the misses over PCIe / oneAPI)
+is the scope of ``moe-offload`` and is not exercised here.
 """
 from __future__ import annotations
 
@@ -18,7 +19,7 @@ torch = pytest.importorskip("torch")
 from freetoken.moe.offload_cache import OffloadMoeCache
 
 DEVICE = torch.device("cpu")
-L, E, S = 2, 4, 8  # 2 layers, 4 experts, 8 slots (== 2E, the double-buffer floor)
+L, E, S = 2, 4, 8  # 2 layers, 4 experts, 8 slots (S > E: the pool is not full)
 H, I = 16, 8  # hidden, moe intermediate (small so the banks are tiny)
 
 # Distinguishable host bank contents: bank value at (layer, expert, ...) is
@@ -36,10 +37,11 @@ def _bank_values(layer: int, expert: int) -> tuple[torch.Tensor, torch.Tensor]:
 
 @pytest.fixture
 def cache():
-    # The default pool is the double buffer plus TWO decode slots (S == 2E + 2),
-    # so a decode miss can always be placed without evicting a double-buffer
-    # slot -- this keeps the hit/miss bookkeeping tests simple. The LRU eviction
-    # tests below use a smaller pool (2E + 1) to force a real evict.
+    # The default pool S=8 > E=4, so materializing BOTH layers keeps all of each
+    # layer resident (layer 0 in the 4 slots it first took, layer 1 in the 4 free
+    # slots) -- this keeps the hit bookkeeping tests simple (a routed expert is a
+    # hit, not a miss). The LRU-eviction tests below use a smaller pool (S == E)
+    # to force a real cross-layer evict.
     c = OffloadMoeCache(L, E, S, DEVICE, prefill_overlap=False)
     c.set_bank_sources(
         {
@@ -78,122 +80,136 @@ def test_prefill_materializes_whole_layer_into_slots_0_to_e(cache):
         assert torch.equal(cache.bank_caches["down"][e], exp_dn), (e, "down")
 
 
-def test_second_layer_evicts_first_layer(cache):
-    cache.materialize_layer(0)
-    cache.copy_missing()
-    cache.materialize_layer(1)
-    # Layer 1 now owns slots [0, E): the last materialized layer is resident.
+def test_second_layer_evicts_first_layer():
+    # With a pool that holds exactly ONE layer (S == E), materializing layer 0
+    # then layer 1 FORCES a real cross-layer evict: the pool is full after layer 0,
+    # so layer 1's experts evict layer 0's (the global LRU). This is the ADR 0002
+    # core: the 61 GB of experts only fits one (or a few) layers at a time.
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)
+    c.set_bank_sources(_bank_sources())
+    c.materialize_layer(0)
+    c.copy_missing()
+    c.materialize_layer(1)
+    # Global LRU: layer 1 is the MRU layer, so all of it stays resident; layer 0
+    # is the LRU layer and is evicted (its slots are reused by layer 1).
     for e in range(E):
-        assert cache.slot_for_id[1, e].item() == e
-        assert cache.slot_for_id[0, e].item() == -1, "layer 0 must be evicted"
-    cache.copy_missing()
+        assert c.slot_for_id[1, e].item() != -1, "layer 1 (MRU) must be resident"
+        assert c.slot_for_id[0, e].item() == -1, "layer 0 (LRU) must be evicted"
+    c.copy_missing()
+    # Exactly layer 1's E experts are resident (the slot pool holds only layer 1).
+    assert c.resident_slots(1) == list(range(E))
+    assert c.resident_slots(0) == []
     # The slot cache now holds layer 1's bytes, not layer 0's.
-    assert torch.equal(_slot_gate_up_row(cache, 0), _bank_values(1, 0)[0])
+    assert torch.equal(_slot_gate_up_row(c, 0), _bank_values(1, 0)[0])
 
 
 def test_decode_hit_bumps_usage_no_copy():
-    # Use the default pool (2E + 2): after materializing layer 1, all of layer 1
-    # is resident in the double buffer, so routing any of its experts is a pure
-    # hit (no decode-slot copy, no evict).
+    # With S > E (the default 8 > 4), after materializing layer 0 then layer 1
+    # the pool is NOT full: layer 0 keeps 4 resident slots and layer 1's 4 experts
+    # land in the 4 free slots. Routing a layer-1 expert is therefore a pure HIT
+    # (already resident -> no new miss, no scheduled copy, slot id rewritten in
+    # place) -- the hit bookkeeping path under the global-LRU scheme.
     c = OffloadMoeCache(L, E, S, DEVICE, prefill_overlap=False)
     c.set_bank_sources(_bank_sources())
     c.materialize_layer(0)
-    c.materialize_layer(1)  # evicts layer 0; resident = layer 1 (double buffer)
+    c.materialize_layer(1)  # layer 0 resident (4 slots), layer 1 in the 4 free slots
+    assert c.resident_slots(0) == [0, 1, 2, 3], "layer 0 stays resident when the pool is not full"
+    assert c.resident_slots(1) == [4, 5, 6, 7], "layer 1 takes the free slots (hits on decode)"
     ids = torch.tensor([1], dtype=torch.int64)
     before_missing = c.stat_missing.item()
     c.ensure_experts(1, ids)
     # Expert 1 is already resident -> a hit: no new miss, no scheduled copy.
     assert c.stat_missing.item() == before_missing
     assert c.num_indices.item() == 0
-    # The routed position was rewritten to the expert's slot (expert 1 -> slot 1).
-    assert ids[0].item() == 1
+    # The routed position was rewritten to the expert's (hit) slot.
+    assert ids[0].item() == c.slot_for_id[1, 1].item()
     # Its slot's usage was bumped to the newest step (the LRU key moved).
-    assert c.usage[1].item() == c.step.item()
+    assert c.usage[c.slot_for_id[1, 1].item()].item() == c.step.item()
 
 
 def test_decode_miss_evicts_least_recently_used():
-    # A pool that can hold the double buffer plus exactly THREE decode experts
-    # (cache_size == 2E + 3: slots [0, E) are the non-evictable double buffer;
-    # slots 2E, 2E+1, 2E+2 are the evictable decode slots). We fill all three
-    # decode slots with layer-0 experts at three distinct, known steps, then
-    # route a 4th expert -- a MISS -- and assert the victim is the
-    # LEAST-recently-used decode slot (min (usage, slot)), never a double-buffer
-    # slot and never a more-recently-used decode slot.
-    c = OffloadMoeCache(L, E, 2 * E + 3, DEVICE, prefill_overlap=False)
+    # The pool is a single GLOBAL LRU shared by all layers (ADR 0002): a miss
+    # evicts the least-recently-used slot in the *entire* slot space (including
+    # slots other layers hold -- the whole point of offload is that experts are
+    # re-fetched on demand, never all resident at once). We seed a FULL pool whose
+    # slots have distinct, ordered usage stamps, then route a NON-resident expert
+    # -- a miss -- and assert the victim is the global LRU slot (min (usage, slot)).
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)  # pool holds exactly one layer
     c.set_bank_sources(_bank_sources())
-    c.materialize_layer(0)  # step 1: layer 0 experts in the double buffer [0, E)
-    # Fill the three decode slots with layer-0 experts at distinct steps, with
-    # slot 2E the OLDEST (LRU) and slot 2E+2 the NEWEST (MRU). We seed the maps
-    # directly (a real run would reach this via decode steps) and stamp distinct
-    # usage values so the LRU ordering is unambiguous: 2E < 2E+1 < 2E+2.
-    #   slot 2E   <- (layer 0, expert 0), usage 1  (LRU)
-    #   slot 2E+1 <- (layer 0, expert 1), usage 2
-    #   slot 2E+2 <- (layer 0, expert 2), usage 3  (MRU)
-    # The double buffer is left holding experts 3 (slot 3) and is NOT evictable.
+    c.materialize_layer(0)  # step 1: layer 0 fills slots [0, E) (usage 1)
     c.step.fill_(3)
-    # Experts 0,1,2 live in the decode slots; expert 3's double-buffer residency
-    # is consumed by the decode handoff (cleared) so it is a genuine miss.
-    c.slot_for_id[0, 0] = 2 * E
-    c.slot_for_id[0, 1] = 2 * E + 1
-    c.slot_for_id[0, 2] = 2 * E + 2
-    c.slot_for_id[0, 3] = -1  # double-buffer slot 3 freed -> expert 3 is a miss
-    c.id_of_slot[0] = -1
-    c.id_of_slot[1] = -1
-    c.id_of_slot[2] = -1
-    c.id_of_slot[3] = -1
-    c.id_of_slot[2 * E] = 0
-    c.id_of_slot[2 * E + 1] = 1
-    c.id_of_slot[2 * E + 2] = 2
-    c.usage[2 * E] = 1
-    c.usage[2 * E + 1] = 2
-    c.usage[2 * E + 2] = 3
-    c.usage[0] = 0
-    c.usage[1] = 0
-    c.usage[2] = 0
-    c.usage[3] = 0
-    # Route (layer 0, expert 3) -> a MISS. It must evict the LRU decode slot
-    # (slot 2E, expert 0, usage 1) and take its place.
-    c.ensure_experts(0, torch.tensor([3], dtype=torch.int64))
-    assert c.slot_for_id[0, 3].item() == 2 * E, "miss expert 3 must take the LRU slot 2E"
-    assert c.slot_for_id[0, 0].item() == -1, "LRU expert 0 (slot 2E) must be evicted"
-    # The more-recently-used decode slots are untouched.
-    assert c.slot_for_id[0, 1].item() == 2 * E + 1
-    assert c.slot_for_id[0, 2].item() == 2 * E + 2
+    # Give each slot a distinct LRU age (unambiguous ordering): slot s -> usage s+1.
+    c.usage[:] = torch.arange(E, dtype=torch.int64, device=DEVICE) + 1
+    # The pool is now full. Make (layer 0, expert 0) -- the LRU slot 0 --
+    # non-resident (as if layer 1 had evicted it during a later prefill) so that
+    # routing it is a genuine miss.
+    c.slot_for_id[0, 0] = -1
+    # Route (layer 0, expert 0) -> a MISS in a full pool. It must evict the
+    # global LRU slot. The other (more-recently-used) slots are owned by layer 0
+    # experts 1..3, so the only LRU candidate is slot 0 (usage 1, now free) --
+    # the miss re-acquires it. Assert the victim is the LRU, not a more-recent slot.
+    c.ensure_experts(0, torch.tensor([0], dtype=torch.int64))
+    assert c.slot_for_id[0, 0].item() == 0, "miss must take the global LRU (free) slot 0"
+    # The more-recently-used slots (experts 1..3) are untouched.
+    for e in range(1, E):
+        assert c.slot_for_id[0, e].item() == e
     c.copy_missing()
-    # Slot 2E now holds expert 3's exact host bytes (the evicted slot was reused).
-    assert torch.equal(c.bank_caches["gate_up"][2 * E], _bank_values(0, 3)[0])
-    assert torch.equal(c.bank_caches["down"][2 * E], _bank_values(0, 3)[1])
-    assert c.usage[2 * E].item() == c.step.item()  # re-stamped to the newest step
+    # Slot 0 now holds expert 0's exact host bytes (the evicted slot was reused).
+    assert torch.equal(c.bank_caches["gate_up"][0], _bank_values(0, 0)[0])
+    assert torch.equal(c.bank_caches["down"][0], _bank_values(0, 0)[1])
+    assert c.usage[0].item() == c.step.item()  # re-stamped to the newest step
+
+
+def test_decode_miss_evicts_full_pool_lru_victim():
+    # The pool is FULL (every slot owned by layer 0) and we route a LAYER-1
+    # expert: a miss, and the victim is the global LRU slot (min (usage, slot))
+    # -- which is owned by a *different* layer. This cross-layer eviction is the
+    # whole point of offload when the pool is smaller than the model's total
+    # experts (it forces the LRU layer to be evicted so the new layer can fit).
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)
+    c.set_bank_sources(_bank_sources())
+    # Seed a full pool: layer 0 owns all E slots, with slot 0 the LRU (usage 1)
+    # and slot E-1 the MRU (usage E).
+    for e in range(E):
+        c.id_of_slot[e] = e  # flat id (layer 0, expert e)
+        c.slot_for_id[0, e] = e
+    c.step.fill_(5)
+    c.usage[:] = torch.arange(E, dtype=torch.int64, device=DEVICE) + 1  # slot e -> usage e+1
+    # Route (layer 1, expert 0): a miss (no layer-1 expert resident). Evict the
+    # global LRU slot (slot 0, usage 1, currently (layer 0, expert 0)).
+    c.ensure_experts(1, torch.tensor([0], dtype=torch.int64))
+    # (layer 1, expert 0) took slot 0; (layer 0, expert 0) was evicted.
+    assert c.slot_for_id[1, 0].item() == 0, "the layer-1 miss must take the global LRU slot 0"
+    assert c.slot_for_id[0, 0].item() == -1, "the evicted (layer 0, expert 0) is no longer resident"
+    # The MRU slots (other layer-0 experts) are untouched.
+    assert c.slot_for_id[0, 1].item() == 1
+    assert c.slot_for_id[0, E - 1].item() == E - 1
+    c.copy_missing()
+    assert torch.equal(c.bank_caches["gate_up"][0], _bank_values(1, 0)[0])
 
 
 def test_copy_missing_streams_correct_host_bytes():
     # A decode miss must stream the *missed* expert's exact host bytes (gate/up
-    # and down) into the evicted slot -- the bytes the forward will read.
-    c = OffloadMoeCache(L, E, 2 * E + 1, DEVICE, prefill_overlap=False)
-    c.set_bank_sources(
-        {
-            "gate_up": [torch.stack([_bank_values(l, e)[0] for e in range(E)]) for l in range(L)],
-            "down": [torch.stack([_bank_values(l, e)[1] for e in range(E)]) for l in range(L)],
-        }
-    )
-    c.materialize_layer(1)  # layer 1 resident in the double buffer slots [0, E)
-    # Simulate the prefill->decode handoff: the decode slot 2E now holds
-    # (layer 1, expert 0) (an old usage stamp) and the double-buffer slot 0 is
-    # freed; (layer 1, expert 0) is marked NOT resident, so the next decode step
-    # that routes expert 0 is a genuine MISS that must evict slot 2E and stream
-    # expert 0's layer-1 host row back into it.
-    c.slot_for_id[1, 0] = -1  # not resident -> the next routing of expert 0 is a miss
-    c.id_of_slot[0] = -1  # free the double-buffer slot
-    c.id_of_slot[2 * E] = 4  # flat id of (layer 1, expert 0)
-    c.usage[2 * E] = 1
+    # and down) into the evicted slot -- the bytes the forward will read. We seed
+    # a FULL pool (layer 0 owns all E slots, slot 0 the LRU) and route a LAYER-1
+    # expert: the miss evicts the global LRU slot 0 and must copy (layer 1,
+    # expert 0)'s host row into it.
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)
+    c.set_bank_sources(_bank_sources())
+    c.materialize_layer(0)  # layer 0 fills slots [0, E)
+    c.step.fill_(3)
+    c.usage[:] = torch.arange(E, dtype=torch.int64, device=DEVICE) + 1  # slot e -> usage e+1
+    # Route (layer 1, expert 0): a miss (nothing of layer 1 resident). It evicts
+    # the global LRU slot 0 (held by (layer 0, expert 0), usage 1) and stages
+    # (slot 0, layer-1 host row 0) for the copy.
     c.ensure_experts(1, torch.tensor([0], dtype=torch.int64))
-    assert c.slot_for_id[1, 0].item() == 2 * E  # the miss re-acquired the decode slot
-    assert c.num_indices.item() == 1  # a miss was scheduled (evict slot 2E, copy row 0)
+    assert c.slot_for_id[1, 0].item() == 0  # the miss re-acquired the LRU slot 0
+    assert c.num_indices.item() == 1  # a miss was scheduled (evict slot 0, copy row 0)
     # Stream it: the slot must now hold expert 0's layer-1 host bytes exactly.
     c.copy_missing()
     exp_gu, exp_dn = _bank_values(1, 0)
-    assert torch.equal(c.bank_caches["gate_up"][2 * E], exp_gu)
-    assert torch.equal(c.bank_caches["down"][2 * E], exp_dn)
+    assert torch.equal(c.bank_caches["gate_up"][0], exp_gu)
+    assert torch.equal(c.bank_caches["down"][0], exp_dn)
 
 
 def test_hit_miss_counters(cache):

--- a/tests/test_moe_offload_forward.py
+++ b/tests/test_moe_offload_forward.py
@@ -1,0 +1,285 @@
+"""Forward-correctness tests for the host-offload MoE path (issue #54, ADR 0002).
+
+The contract (ADR 0002): the MoE experts are never XPU-resident. They live in
+pinned host RAM and are streamed through a small LRU slot pool on demand. The
+offload forward (:meth:`_Qwen3MoE._forward_offload`) must therefore produce the
+*same* next-token logits as the in-VRAM forward that gathers from XPU-resident
+expert modules -- because the LRU slot pool is a *transport* for the expert
+weights, not a change to the math.
+
+These tests are CPU-marked (no ``xpu`` / ``slow``), so they run in the CPU venv
+on any box: a tiny Qwen3-MoE is built twice from the same fabricated checkpoint
+-- once in-VRAM (the reference) and once offload (under test) -- and the
+engine's greedy output (which runs prefill-then-decode, so *both* the
+materialize and the LRU paths) is compared. A slot-pool bug (an expert read from
+the wrong slot, an off-by-one in the layer map, or a dtype/shape mismatch in the
+gather) changes the logits and fails the comparison, whereas a shape-only check
+would pass regardless.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.models.loader import load_model
+from freetoken.models.qwen3_moe import parse_config
+from freetoken.models.weight import _stack_expert_rows
+
+DEVICE = torch.device("cpu")
+
+# A tiny Qwen3-MoE: 2 MoE layers (first_k_dense_replace=0 -> both layers are
+# MoE), 4 experts, top-2, small hidden / vocab -- cheap to build and run on a
+# CPU. Mirrors the dense-weight layout the loader streams.
+TINY_CONFIG = {
+    "architectures": ["Qwen3MoeForCausalLM"],
+    "model_type": "qwen3_moe",
+    "hidden_size": 64,
+    "vocab_size": 32,
+    "num_hidden_layers": 2,
+    "num_local_experts": 4,
+    "num_experts_per_tok": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "intermediate_size": 32,
+    "moe_intermediate_size": 32,
+    "max_position_embeddings": 128,
+    "rope_theta": 1000000.0,
+}
+
+# A per-expert checkpoint whose values *identify* (layer, expert, projection),
+# so the reference and the offload path provably consume the same expert bytes.
+# gate (expert e, row r): 100*(e+1) + r + layer*1000; up: +1; down: +2.
+# All values are small enough to be exact in float32 (the loader's dtype here).
+def _distinguishable_experts() -> dict:
+    hidden, inter, experts, vocab, layers = 64, 32, 4, 32, 2
+    w = {
+        "model.embed_tokens.weight": torch.randn(vocab, hidden),
+        "lm_head.weight": torch.randn(vocab, hidden),
+    }
+    for layer in range(layers):
+        for e in range(experts):
+            prefix = f"model.layers.{layer}.mlp.experts.{e}"
+            base = 100 * (e + 1) + 1000 * layer
+            w[f"{prefix}.gate_proj"] = torch.arange(inter, dtype=torch.float32)[:, None].repeat(1, hidden) + base
+            w[f"{prefix}.up_proj"] = torch.arange(inter, dtype=torch.float32)[:, None].repeat(1, hidden) + base + 1
+            # down_proj is the [H, I] weight of nn.Linear(I, H): H rows (output),
+            # I cols (input). (An earlier draft wrote it [H, H]; when H != I the
+            # offload down bank -- packed as [E, H, I] -- then had the wrong inner
+            # dim and the offload forward silently diverged from the in-VRAM
+            # reference. The bank must be [H, I], matching nn.Linear(I, H).weight.)
+            w[f"{prefix}.down_proj"] = torch.arange(hidden, dtype=torch.float32)[:, None].repeat(1, inter) + base + 2
+    return w
+
+
+def _dense_weights() -> dict:
+    hidden, vocab, heads, kv, inter, experts, layers = 64, 32, 4, 2, 32, 4, 2
+    # The model derives head_dim = hidden // num_attention_heads (64 // 4 = 16)
+    # and its q/k norms are RMSNorm(head_dim) over that. The projections match the
+    # model's nn.Linear(hidden -> out): q is [heads*head_dim, hidden], k/v are
+    # [kv*head_dim, hidden] (nn.Linear stores weight as [out, in]). The q/k norms
+    # are [head_dim] (the model's RMSNorm(hidden // heads) width). The shapes
+    # below are EXACT: the loader's placement is a strict shape match, so a
+    # mismatched checkpoint weight is a hard error (it no longer silently no-ops
+    # -- see loader._place_dense).
+    head_dim = hidden // heads
+    w = {
+        "model.embed_tokens.weight": torch.randn(vocab, hidden),
+        "lm_head.weight": torch.randn(vocab, hidden),
+    }
+    for l in range(layers):
+        prefix = f"model.layers.{l}"
+        w[f"{prefix}.input_layernorm.weight"] = torch.randn(hidden)
+        w[f"{prefix}.self_attn.q_proj.weight"] = torch.randn(heads * head_dim, hidden)
+        w[f"{prefix}.self_attn.k_proj.weight"] = torch.randn(kv * head_dim, hidden)
+        w[f"{prefix}.self_attn.v_proj.weight"] = torch.randn(kv * head_dim, hidden)
+        w[f"{prefix}.self_attn.q_norm.weight"] = torch.randn(head_dim)
+        w[f"{prefix}.self_attn.k_norm.weight"] = torch.randn(head_dim)
+        w[f"{prefix}.self_attn.o_proj.weight"] = torch.randn(heads * head_dim, hidden)
+        w[f"{prefix}.post_attention_layernorm.weight"] = torch.randn(hidden)
+        # The MoE router is nn.Linear(hidden -> num_experts): weight [num_experts, hidden].
+        w[f"{prefix}.mlp.gate.weight"] = torch.randn(experts, hidden)
+    w["model.norm.weight"] = torch.randn(hidden)
+    return w
+
+
+@pytest.fixture(scope="module")
+def offload_ckpt(tmp_path_factory):
+    """A checkpoint with distinguishable per-expert weights + random dense weights.
+
+    Both the in-VRAM reference and the offload-under-test load from *this same*
+    path, so they are guaranteed to consume identical dense + expert bytes.
+    """
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen3moe-offload")
+    (path / "config.json").write_text(json.dumps(TINY_CONFIG))
+    # _dense_weights() draws from the *global* RNG (torch.randn). The fixture is
+    # module-scoped, so it builds once -- but the RNG offset at that moment
+    # depends on how much random state the *prior* tests (and the reference
+    # load_model in test_offload_forward_matches_in_vram_reference) consumed.
+    # Re-seed here so the dense weights are a fixed, order-independent value:
+    # the in-VRAM reference and the offload-under-test both load this same file,
+    # so they always consume identical dense bytes regardless of test order.
+    torch.manual_seed(1234)
+    weights = {**_dense_weights(), **_distinguishable_experts()}
+    shards = {k: v.contiguous() for k, v in weights.items()}
+    save_file(shards, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": {k: "model.safetensors" for k in shards}})
+    )
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    # Each Engine installs a global context; clear it between tests so two
+    # engines in one process never collide.
+    yield
+    reset_global_ctx()
+
+
+def _engine_config(model_path: str, *, moe_backend: str | None) -> EngineConfig:
+    return EngineConfig(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=DEVICE,
+        attention_backend="auto",
+        moe_backend=moe_backend,
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+        num_page_override=64,
+    )
+
+
+def _add_prompt(engine: Engine, output_len: int) -> None:
+    engine.add_request(
+        Req(
+            input_ids=[1, 2, 3],
+            table_idx=0,
+            cached_len=0,
+            output_len=output_len,
+            uid=0,
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+            cache_handle=None,
+        )
+    )
+
+
+def test_offload_forward_matches_in_vram_reference(offload_ckpt):
+    """The host-offload forward must reproduce the in-VRAM forward's logits.
+
+    The LRU slot pool transports the expert weights; it must not change them.
+    So the same checkpoint loaded in-VRAM (reference) and offload (under test)
+    must produce identical greedy tokens end to end (prefill + decode).
+    """
+    # Reference: in-VRAM experts (moe_backend=None -> the default resident path).
+    ref_model, ref_sources = load_model(offload_ckpt, DEVICE, dtype=torch.float32, moe_backend=None)
+    assert not getattr(ref_model, "moe_offload", False), "reference must be the in-VRAM path"
+    # The in-VRAM path must have populated the model's per-expert modules.
+    assert ref_model.layers[0].mlp.experts is not None
+
+    # Under test: host-offload experts (ADR 0002).
+    off_model, off_sources = load_model(offload_ckpt, DEVICE, dtype=torch.float32, moe_backend="offload")
+    assert off_model.moe_offload, "offload path must flag the model"
+    assert off_model.moe_cache is not None, "the loader must attach the LRU slot pool"
+    assert off_model.moe_layer_id is not None
+    assert off_model.layers[0].mlp.experts is None, "the offload path must not build XPU-resident experts"
+    # The host banks must be present and correctly shaped (the source of truth).
+    assert len(off_sources[0]) == 2  # two MoE layers
+    assert off_sources[0][0].shape == (4, 2 * 32, 64)  # [E, 2I, H]
+    assert off_sources[1][1].shape == (4, 64, 32)  # [E, H, I]
+
+    # The offload forward must be wired: run one decode step and confirm the
+    # slot pool was actually exercised (the prefill materialized the layers, so
+    # the first decode steps are hits; a later step's misses are streamed in).
+    ref_engine = Engine(_engine_config(offload_ckpt, moe_backend=None))
+    _add_prompt(ref_engine, output_len=6)
+    ref_tokens = ref_engine.generate()
+
+    off_engine = Engine(_engine_config(offload_ckpt, moe_backend="offload"))
+    _add_prompt(off_engine, output_len=6)
+    off_tokens = off_engine.generate()
+
+    # The engine's greedy output is a pure function of (weights, prompt). Same
+    # checkpoint, same prompt -> the offload path must match the reference.
+    assert off_tokens == ref_tokens, (
+        f"offload logits diverged from in-VRAM reference: {off_tokens} != {ref_tokens}"
+    )
+    # Both must actually generate (non-empty, in-vocab) tokens.
+    assert len(off_tokens[0]) == 6
+    assert all(0 <= t < TINY_CONFIG["vocab_size"] for t in off_tokens[0])
+
+
+def test_offload_forward_is_deterministic(offload_ckpt):
+    """Two offload runs of the same checkpoint must be identical.
+
+    Guards against non-determinism in the slot-pool routing (e.g. dict-order
+    dependent expert iteration, or a stale slot from a prior step leaking in).
+    """
+    from freetoken.engine.engine import Engine as _Engine
+
+    def run():
+        engine = _Engine(_engine_config(offload_ckpt, moe_backend="offload"))
+        _add_prompt(engine, output_len=5)
+        return engine.generate()
+
+    a = run()
+    b = run()
+    assert a == b
+    assert len(a[0]) == 5
+
+
+def test_offload_slots_stream_missed_experts(offload_ckpt):
+    """A decode step whose routed expert is not resident must stream it in.
+
+    With cache_size = 2E + num_moe the pool has double-buffer slots [0, 2E)
+    plus a handful of decode slots [2E, S). Prefill materializes each layer into
+    [0, E). A decode step that routes to an expert *outside* that layer's
+    materialized set is a miss: the LRU evicts a decode slot, copies the missed
+    expert's host row in, and the forward reads it from the slot. The miss
+    counter must advance -- proof the stream-in path actually ran (not just the
+    hit path).
+    """
+    # Two MoE layers with a pool that can only hold ~one layer (cache_size =
+    # E + num_moe < 2E) force REAL cross-layer eviction: materializing layer 1
+    # must evict layer 0's experts, so layer 0's decode is a genuine miss that is
+    # streamed back in. The miss counter must therefore be > 0 -- proof the
+    # stream-in (copy_missing) path ran, not just the hit path.
+    from freetoken.engine.engine import Engine as _Engine
+
+    engine = _Engine(_engine_config(offload_ckpt, moe_backend="offload"))
+    _add_prompt(engine, output_len=8)
+    engine.generate()
+    stats = engine.model.moe_cache.decode_miss_stats()
+    assert stats["calls"] > 0, "decode must call ensure_experts"
+    assert stats["missing"] > 0, "with a sub-layer pool, decode must stream (evicted) experts back in"
+
+
+def test_offload_layer_map_matches_moe_layers(offload_ckpt):
+    """The model's layer_id -> MoE-index map must match the loader's mapping.
+
+    The slot pool is indexed by *MoE-layer index* (0-based among the MoE
+    layers); the model's blocks are indexed by *absolute layer id*. A mismatch
+    here (an off-by-one in first_k_dense_replace, or a dense layer counted)
+    routes a layer to the wrong host bank -- the forward-correctness test above
+    would then fail, so pin the mapping explicitly.
+    """
+    from freetoken.models.loader import _moe_layers
+
+    model, _ = load_model(offload_ckpt, DEVICE, dtype=torch.float32, moe_backend="offload")
+    expected = {layer_id: idx for idx, layer_id in enumerate(_moe_layers(model.config))}
+    got = {layer_id: idx for layer_id, idx in enumerate(model.moe_layer_id) if idx != 0 or layer_id in expected}
+    # Every MoE layer must map to the right MoE index.
+    for layer_id, moe_idx in expected.items():
+        assert model.moe_layer_id[layer_id] == moe_idx, (layer_id, moe_idx)
+    # The cache must be sized for exactly the number of MoE layers.
+    assert model.moe_cache.num_layers == len(expected)


### PR DESCRIPTION
Closes #54 (ADR 0002 — the model half of host-offloaded MoE).

## What

`_Qwen3MoE` no longer owns XPU-resident expert `nn.Module`s (128 experts/layer
≈ 28 GB bf16 the B70 can't hold). It now keeps only the router and, per forward
step, routes each token's picked experts through the engine's **global
timestamp-LRU slot pool** (`OffloadMoeCache`):

* **prefill** → `materialize_layer` stages the *whole* MoE layer into the pool,
  evicting the LRU-resident experts of *other* layers and reusing their slots;
* **decode** → `ensure_experts` streams in only the *missed* routed experts;
* each routed token then runs the expert the slot currently holds (the pool is a
  *transport* for the expert weights, not a change to the math).

The dense path (embed, attention, router gate, norms, `lm_head`) stays
XPU-resident. The loader (#53) builds the packed host banks and attaches the
pool to the model (`moe_cache` / `moe_layer_id`); the engine installs it on the
global context so the forward reaches it without the engine poking the model.

## Bugs fixed (these made the offload output non-deterministic)

1. **`engine.step` tagged every step `"decode"`**, so its prefill branch — the
   one that writes *every* prompt token's K/V into the pool — never ran. The
   prompt's first rows stayed as uninitialized `torch.empty` and the first decode
   attended over them → logits blew up and the greedy output changed run-to-run
   (the RNG seed that backed the `torch.empty` garbage leaked into the tokens).
   `step()` now tags the prompt step `"prefill"` (per-request: prefill while no
   token has been generated yet, decode after).
2. **`model.forward` / `_forward_offload`** branch on the phase (`is_prefill`,
   with a token-count fallback) so prefill and decode take the right slot path.
3. **Loader** strips the checkpoint's `model.` prefix when placing dense weights
   (a naive exact-match no-opped on every dense weight), and the dummy path now
   seeds the dense weights on *both* backends so runs are deterministic.

## Verification

* `tests/test_moe_offload_forward.py` (new): the same tiny Qwen3-MoE loaded
  in-VRAM (reference) vs. host-offloaded (under test) must emit **identical
  greedy tokens** over prefill + decode; plus a two-run determinism check, a
  miss-streaming check, and a layer-map check.
* `tests/test_moe_offload_cache.py` (#7, updated): the global-LRU pool contract.
* Full suite: **57 passed** on the torch-XPU venv (CPU). Stable across repeated
  runs (the prior flakiness was the bug above, now fixed).
* `docs/intel-b70.md`: 61 GB Qwen3-30B-A3B offload run notes + divergence
  watchlist.

> Note: the forward tests are `importorskip("torch")` and CPU-marked, so they
> run in any torch-equipped env. The CI gate's plain CPU venv has no torch, so
> these are skipped there; the torch-XPU venv (or a torch CPU install) is the
> real forward gate.