### PR TITLE
ci(fleet): run the CPU torch suite on the self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Opt this repo onto the self-hosted Uranus fleet via the org CI_RUNNER
+    # variable (value: self-hosted-linux). Until that variable is scoped to this
+    # repo, it falls back to the GitHub-hosted ubuntu-latest runner. See
+    # pl-ops-handbook > platform-ops > github-runners.md ("Repo opt-in").
+    # The fleet image bakes a CPU PyTorch (pl-runner >= 1.66.1), so the torch
+    # tests (test_engine_loop, test_moe_offload_*, test_models_loader) run here
+    # instead of being skipped on a torch-less runner.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/tests/test_engine_loop.py
+++ b/tests/test_engine_loop.py
@@ -17,7 +17,9 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-pytestmark = pytest.mark.xpu
+# No ``xpu`` marker: the tests below build the model explicitly on the CPU
+# (DEVICE = "cpu" below), so they run in the CPU CI runner. The XPU/B70 path is
+# exercised separately by the xpu-marked suite (run with ``-m xpu`` on a B70 box).
 
 from freetoken.core import Req, SamplingParams, reset_global_ctx
 from freetoken.distributed import DistributedInfo


### PR DESCRIPTION
The `pl-runner` self-hosted runner image now bakes a CPU PyTorch (>= 1.66.1), so the torch-dependent CPU tests no longer need to be skipped on a torch-less runner.

## Changes
- **test_engine_loop**: drop the `xpu` marker. The tests build the model explicitly on the CPU (`DEVICE = "cpu"`), so they belong in the CPU CI run. The B70/XPU path is still exercised separately via `-m xpu`.
- **ci.yml**: route the `test` job through the org `CI_RUNNER` variable (`self-hosted-linux`), falling back to `ubuntu-latest` until that variable is scoped to this repo.

Without the baked torch, `test_engine_loop` / `test_moe_offload_*` / `test_models_loader` were collected-but-skipped (or, on torch 2.4.1, errored at import on `torch.float8_e8m0fnu`) while CI stayed green. With the fleet image + this change, they actually run.

## CI note
This PR's `test` check runs on `ubuntu-latest` (the var is not yet scoped to this repo). Set the org `CI_RUNNER` variable to include `FreeToken-Intel` (needs `admin:org`) and re-run to validate on the fleet.

(#54)