### PR TITLE
ci: stop shadowing the runner's baked torch with setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,27 @@ jobs:
     # variable (value: self-hosted-linux). Until that variable is scoped to this
     # repo, it falls back to the GitHub-hosted ubuntu-latest runner. See
     # pl-ops-handbook > platform-ops > github-runners.md ("Repo opt-in").
-    # The fleet image bakes a CPU PyTorch (pl-runner >= 1.66.1), so the torch
-    # tests (test_engine_loop, test_moe_offload_*, test_models_loader) run here
-    # instead of being skipped on a torch-less runner.
+    # The fleet image bakes a CPU PyTorch (pl-runner >= 1.66.1) into the
+    # runner's SYSTEM Python (/usr/bin/python3), so the torch tests
+    # (test_engine_loop, test_moe_offload_*, test_models_loader) can run here
+    # instead of being skipped on a torch-less runner -- but only if the job
+    # actually uses that system interpreter. actions/setup-python always
+    # downloads and uses its own separate CPython build under
+    # /opt/hostedtoolcache (verified via a run log: "Version 3.12 was not
+    # found in the local cache" -> downloads python-3.12.14-linux-24.04-x64.tar.gz
+    # every time, since these runners are ephemeral), which has no relationship
+    # to the image's baked torch at all. Running it on self-hosted silently
+    # defeated the whole point of baking torch in: every torch-marked test file
+    # skipped with "could not import torch", 4 skips standing in for ~22 actual
+    # tests never collected. So: skip setup-python entirely on the self-hosted
+    # fleet (Noble already ships python3.12 + pip on PATH, and the image has
+    # torch); keep it for the ubuntu-latest fallback, which has no baked torch
+    # and needs setup-python to get any Python at all.
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        if: ${{ vars.CI_RUNNER == '' }}
         with:
           python-version: "3.12"
       - name: Install


### PR DESCRIPTION
## Summary
- `actions/setup-python@v5` downloads its own separate CPython build into `/opt/hostedtoolcache` on every run (these self-hosted runners are ephemeral, so nothing persists between jobs) — confirmed from the actual run log: `Version 3.12 was not found in the local cache` → downloads `python-3.12.14-linux-24.04-x64.tar.gz`.
- That downloaded interpreter is unrelated to the runner image's baked CPU PyTorch, which lives in the *system* Python's site-packages (`/usr/local/lib/python3.12/dist-packages`, installed via `pip3 --break-system-packages` at image build time).
- Net effect: every CI run on the self-hosted fleet silently skipped `test_engine_loop.py`, `test_models_loader.py`, `test_moe_offload_cache.py`, `test_moe_offload_forward.py` with `could not import torch: No module named 'torch'` — 4 reported skips actually standing in for ~22 individual tests never collected (57 tests exist total; only 35 were ever collected in CI).
- Reproduced the exact failure in a stock `python:3.12-slim` container (no torch, 31 passed/4 skipped, identical skip reasons) to confirm the mechanism before touching anything.

## Fix
Skip `actions/setup-python` entirely when running on the self-hosted fleet (`vars.CI_RUNNER` set) — Ubuntu Noble already ships `python3.12` + `pip` on PATH there, and that's where the baked torch actually lives. Keep `setup-python` for the `ubuntu-latest` fallback path, which has no baked torch and needs it to get any Python at all.

## Test plan
- [ ] CI run on this PR should show significantly more than 31 passed/4 skipped once it runs under system Python
- [x] Reproduced the failing state locally against the exact commit CI tested
- [x] Confirmed via `docker exec` on a live Uranus runner container that `/usr/bin/python3` has torch 2.13.0+cpu importable