### PR TITLE
ci: add PR-Agent automated review (DeepSeek V4 Pro)

### DIFF
--- a/.agents/pr-review.yml
+++ b/.agents/pr-review.yml
@@ -13,7 +13,6 @@ project:
   # for the CI score banner anyway.
 
 pr_agent:
-  enabled: true
   model: "deepseek/deepseek-v4-pro"
   max_tokens: 131072
   output_tokens: 64000
@@ -23,7 +22,10 @@ pr_agent:
   score_labels: true
   score_banner: true
   status_check: true
-  cancel_in_flight: true
+  # `enabled` and `cancel_in_flight` are removed keys (nothing reads them --
+  # see pipelines/pr-reviewer/README.md §1 "Keys that no longer exist"). The
+  # on-switch is the presence of .github/workflows/pr-review.yml; cancellation
+  # is hardcoded event-scoped in the workflow's concurrency block instead.
 
 local_review:
   enabled: false

--- a/.agents/pr-review.yml
+++ b/.agents/pr-review.yml
@@ -1,0 +1,50 @@
+# .agents/pr-review.yml
+# Generated for FreeToken-Intel — 2026-08-27.
+# Re-run .agents/scripts/setup-pr-review.sh --update to change settings.
+#
+# Only the CI PR-Agent path (DeepSeek V4 Pro) was requested for this repo.
+# Local review, dual review, DCO enforcement, and the PR template are left
+# off — enable any of them later with the wizard.
+
+project:
+  name: "FreeToken-Intel"
+  timezone: "America/Boise"
+  # Matches the org-wide DISPLAY_TZ repo/org variable, which overrides this
+  # for the CI score banner anyway.
+
+pr_agent:
+  enabled: true
+  model: "deepseek/deepseek-v4-pro"
+  max_tokens: 131072
+  output_tokens: 64000
+  high_stakes_label: "high-stakes"
+  skip_docs_only: false
+  skip_paths: []
+  score_labels: true
+  score_banner: true
+  status_check: true
+  cancel_in_flight: true
+
+local_review:
+  enabled: false
+  default_model: "claude-sonnet-4-6"
+  shell_alias: ""
+
+dual_review:
+  enabled: false
+  model: "gpt-5.5"
+  reasoning_effort: "auto"
+  on_brief: true
+  on_impl: true
+
+dco:
+  enabled: false
+
+pr_template:
+  enabled: false
+
+test_tiers:
+  t1_headless: true
+  t2_aria: false
+  t2_5_authenticated: false
+  t3_visual: false

--- a/.agents/scripts/check-pr-review-readiness.sh
+++ b/.agents/scripts/check-pr-review-readiness.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# check-pr-review-readiness.sh — Verify all enabled PR review methods are operational.
+#
+# Reads .agents/pr-review.yml to determine which methods are expected, then
+# checks each one. Always present in the project regardless of config.
+#
+# Usage: .agents/scripts/check-pr-review-readiness.sh
+# Run from the repo root.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+PASS="✅"; FAIL="❌"; WARN="⚠️ "
+errors=0
+
+# ── Config reader (yq with grep fallback) ──────────────────────────────────
+CONFIG_FILE=".agents/pr-review.yml"
+
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if [[ ! -f "$CONFIG_FILE" ]]; then echo "$fallback"; return; fi
+  if command -v yq &>/dev/null; then
+    local val
+    val=$(yq e "${key} // \"\"" "$CONFIG_FILE" 2>/dev/null)
+    echo "${val:-$fallback}"
+  else
+    # PATH-AWARE fallback. The previous version matched only the LEAF name and
+    # took the first hit anywhere in the file:
+    #     grep -E "^\s*${key##*.}:" … | head -1
+    # `enabled` appears under pr_agent, local_review AND dual_review, so
+    # `.dual_review.enabled` returned pr_agent's value. On a config with
+    # pr_agent enabled and dual_review disabled — the shape this pipeline
+    # installs by default — the readiness check ran the dual-review section and
+    # reported a missing dual-review.sh as an ERROR for repos that had
+    # deliberately turned it off. Same class of defect as #433: a checker
+    # reporting on something it never actually read.
+    #
+    # Walks the two-level path instead: find `^section:` at column 0, then the
+    # first `key:` indented beneath it, stopping at the next column-0 key.
+    local section="${key#.}"; section="${section%%.*}"
+    local leaf="${key##*.}"
+    local val
+    val=$(awk -v sec="$section" -v leaf="$leaf" '
+      # column-0 key: entering a new section (and leaving any previous one)
+      /^[A-Za-z_][A-Za-z0-9_]*:/ { in_sec = ($0 ~ "^" sec ":"); next }
+      in_sec && $0 ~ "^[[:space:]]+" leaf ":" {
+        sub(/^[^:]*:[[:space:]]*/, "")
+        print; exit
+      }
+    ' "$CONFIG_FILE" 2>/dev/null)
+    # Strip a trailing comment, surrounding quotes (BOTH kinds — the old sed
+    # stripped only `"`, so single-quoted values such as shell_alias: '' came
+    # back as the two-character string "''" and read as a configured alias),
+    # any trailing CR, and surrounding whitespace.
+    val="${val%%#*}"
+    val="$(printf '%s' "$val" \
+      | sed -e 's/[[:space:]]*$//' -e 's/\r//g' -e "s/^['\"]//" -e "s/['\"]$//")"
+    echo "${val:-$fallback}"
+  fi
+}
+
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PWD")")"
+
+echo ""
+echo "═══════════════════════════════════════════════"
+echo " ${PROJECT_NAME} — PR Review Readiness Check"
+echo "═══════════════════════════════════════════════"
+
+# ── Check: config file itself ────────────────────────────────────────────────
+echo ""
+echo "── Config ──"
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "${PASS} .agents/pr-review.yml present"
+else
+  echo "${WARN} .agents/pr-review.yml missing — run setup-pr-review.sh to create it"
+  echo "     (continuing with defaults: assuming all methods enabled)"
+fi
+
+PR_AGENT_ENABLED="$(cfg_get '.pr_agent.enabled' 'false')"
+LOCAL_ENABLED="$(cfg_get '.local_review.enabled' 'false')"
+DUAL_ENABLED="$(cfg_get '.dual_review.enabled' 'false')"
+DCO_ENABLED="$(cfg_get '.dco.required' "$(cfg_get '.dco.enabled' 'false')")"
+SHELL_ALIAS="$(cfg_get '.local_review.shell_alias' '')"
+
+# ── Method 1: PR-Agent (cloud, GitHub Actions) ────────────────────────────────
+if [[ "$PR_AGENT_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Method 1: PR-Agent CI (GitHub Actions) ──"
+
+  if [[ -f ".pr_agent.toml" ]]; then
+    echo "${PASS} .pr_agent.toml present"
+  else
+    echo "${FAIL} .pr_agent.toml missing — copy from playbook/pipelines/pr-reviewer/templates/"
+    ((errors++))
+  fi
+
+  if [[ -f ".github/workflows/pr-review.yml" ]]; then
+    echo "${PASS} .github/workflows/pr-review.yml present"
+  else
+    echo "${FAIL} .github/workflows/pr-review.yml missing — copy from playbook/pipelines/pr-reviewer/templates/"
+    ((errors++))
+  fi
+
+  echo "${WARN} DEEPSEEK_API_KEY — cannot verify GitHub secrets locally."
+  echo "     Confirm it is set: GitHub → repo → Settings → Secrets → Actions"
+else
+  echo ""
+  echo "── Method 1: PR-Agent CI ── DISABLED (pr_agent.enabled: false)"
+fi
+
+# ── Method 2: Local review (claude -p) ─────────────────────────────────────
+if [[ "$LOCAL_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Method 2: Local review (claude -p) ──"
+
+  if [[ -x ".agents/scripts/pr-review.sh" ]]; then
+    echo "${PASS} .agents/scripts/pr-review.sh present and executable"
+  elif [[ -f ".agents/scripts/pr-review.sh" ]]; then
+    echo "${FAIL} .agents/scripts/pr-review.sh exists but is not executable (run: chmod +x .agents/scripts/pr-review.sh)"
+    ((errors++))
+  else
+    echo "${FAIL} .agents/scripts/pr-review.sh missing — copy from playbook/pipelines/pr-reviewer/scripts/"
+    ((errors++))
+  fi
+
+  if command -v claude &>/dev/null; then
+    echo "${PASS} claude CLI found: $(command -v claude)"
+    if claude auth status &>/dev/null 2>&1; then
+      echo "${PASS} claude is authenticated"
+    else
+      echo "${WARN} claude may not be authenticated — run: claude auth login"
+    fi
+  else
+    echo "${FAIL} claude CLI not found — install Claude Code"
+    ((errors++))
+  fi
+
+  if command -v gh &>/dev/null; then
+    echo "${PASS} gh CLI found: $(command -v gh)"
+    if gh auth status &>/dev/null 2>&1; then
+      echo "${PASS} gh is authenticated"
+    else
+      echo "${WARN} gh not authenticated — run: gh auth login"
+    fi
+  else
+    echo "${FAIL} gh CLI not found — install: brew install gh"
+    ((errors++))
+  fi
+
+  if [[ -n "$SHELL_ALIAS" ]]; then
+    if [[ -f ".agents/scripts/shell-aliases.sh" ]]; then
+      echo "${PASS} shell-aliases.sh present (alias: ${SHELL_ALIAS})"
+      echo "     Source it from ~/.zshrc if you haven't already."
+    else
+      echo "${WARN} shell-aliases.sh missing — alias '${SHELL_ALIAS}' not available"
+      echo "     Copy from playbook/pipelines/pr-reviewer/scripts/"
+    fi
+  fi
+else
+  echo ""
+  echo "── Method 2: Local review ── DISABLED (local_review.enabled: false)"
+fi
+
+# ── Method 3: O3 dual-review ────────────────────────────────────────────────
+if [[ "$DUAL_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Method 3: O3 dual-review ──"
+
+  if [[ -x ".agents/scripts/dual-review.sh" ]]; then
+    echo "${PASS} .agents/scripts/dual-review.sh present and executable"
+  elif [[ -f ".agents/scripts/dual-review.sh" ]]; then
+    echo "${FAIL} .agents/scripts/dual-review.sh exists but is not executable"
+    ((errors++))
+  else
+    echo "${FAIL} .agents/scripts/dual-review.sh missing — copy from playbook/workflow/dual-review.sh"
+    ((errors++))
+  fi
+
+  # Source .env to check for key
+  # shellcheck disable=SC1091
+  if [[ -f ".env" ]]; then set -a; source .env 2>/dev/null || true; set +a; fi
+
+  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    echo "${PASS} OPENAI_API_KEY found in environment"
+  else
+    echo "${FAIL} OPENAI_API_KEY not set — dual-review.sh will fail"
+    echo "     Add it to your .env or shell profile."
+    ((errors++))
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    echo "${FAIL} jq not found — required for dual-review.sh (brew install jq)"
+    ((errors++))
+  else
+    echo "${PASS} jq found: $(command -v jq)"
+  fi
+else
+  echo ""
+  echo "── Method 3: O3 dual-review ── DISABLED (dual_review.enabled: false)"
+fi
+
+# ── DCO workflow ─────────────────────────────────────────────────────────────
+if [[ "$DCO_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── DCO enforcement ──"
+  if [[ -f ".github/workflows/dco.yml" ]]; then
+    echo "${PASS} .github/workflows/dco.yml present"
+  else
+    echo "${FAIL} .github/workflows/dco.yml missing — copy from playbook/pipelines/pr-reviewer/templates/"
+    ((errors++))
+  fi
+fi
+
+# ── Manual test hint ──────────────────────────────────────────────────────────
+if [[ "$LOCAL_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Manual local test ──"
+  echo "   .agents/scripts/pr-review.sh <PR-number>"
+  echo "   .agents/scripts/pr-review.sh <PR-number> --post"
+  if [[ -n "$SHELL_ALIAS" ]]; then
+    echo "   ${SHELL_ALIAS} <PR-number>   (if shell-aliases.sh is sourced)"
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════"
+if [[ $errors -eq 0 ]]; then
+  echo " ${PASS} All hard checks passed."
+else
+  echo " ${FAIL} ${errors} hard check(s) failed — fix them before opening a PR."
+fi
+echo "═══════════════════════════════════════════════"
+echo ""
+
+exit $errors

--- a/.agents/scripts/pr-review.sh
+++ b/.agents/scripts/pr-review.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# pr-review.sh — Spec-enforcer PR review via `claude -p`
+#
+# Usage:
+#   .agents/scripts/pr-review.sh <PR-number> [--post] [--model <model>]
+#
+#   --post            Post the review as a GitHub PR comment via `gh pr review`.
+#   --model <model>   Override the model (default: $REVIEWER_MODEL, then
+#                     local_review.default_model from .agents/pr-review.yml,
+#                     then claude-sonnet-4-6).
+#
+# Prerequisites:
+#   - `claude` CLI installed and authenticated
+#   - `gh` CLI installed and authenticated
+#   - Run from the repo root (CLAUDE.md must be in cwd)
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# ── Config reader (yq with grep fallback) ──────────────────────────────────
+CONFIG_FILE=".agents/pr-review.yml"
+
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if [[ ! -f "$CONFIG_FILE" ]]; then echo "$fallback"; return; fi
+  if command -v yq &>/dev/null; then
+    local val
+    val=$(yq e "${key} // \"\"" "$CONFIG_FILE" 2>/dev/null)
+    echo "${val:-$fallback}"
+  else
+    local stripped="${key##*.}"
+    local val
+    val=$(grep -E "^\s*${stripped}:" "$CONFIG_FILE" 2>/dev/null | head -1 \
+          | sed 's/.*: *//;s/"//g;s/\r//')
+    echo "${val:-$fallback}"
+  fi
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+PR_NUMBER="${1:-}"
+POST_TO_GH=false
+
+DEFAULT_MODEL="${REVIEWER_MODEL:-}"
+[[ -z "$DEFAULT_MODEL" ]] && DEFAULT_MODEL="$(cfg_get '.local_review.default_model' 'claude-sonnet-4-6')"
+MODEL="$DEFAULT_MODEL"
+
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "Usage: $0 <PR-number> [--post] [--model <model>]" >&2
+  exit 1
+fi
+
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --post)  POST_TO_GH=true; shift ;;
+    --model) MODEL="${2:?--model requires a value}"; shift 2 ;;
+    *)       echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Preflight checks ────────────────────────────────────────────────────────
+if [[ ! -f "CLAUDE.md" ]]; then
+  echo "Error: run from the repo root (CLAUDE.md not found in cwd)" >&2
+  exit 1
+fi
+
+for cmd in claude gh; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' not found — install it first." >&2
+    exit 1
+  fi
+done
+
+# ── Fetch PR data ────────────────────────────────────────────────────────────
+echo "→ Fetching PR #${PR_NUMBER} metadata..." >&2
+PR_META=$(gh pr view "$PR_NUMBER" \
+  --json title,body,author,headRefName,baseRefName \
+  --template '## PR: {{.title}}
+Branch: {{.headRefName}} -> {{.baseRefName}}
+Author: {{.author.login}}
+
+### Description
+{{.body}}')
+
+echo "→ Fetching diff..." >&2
+PR_DIFF=$(gh pr diff "$PR_NUMBER")
+
+# ── Build prompt (safe injection) ───────────────────────────────────────────
+# Static template uses a QUOTED heredoc ('EOF') — no variable expansion.
+# Untrusted PR content is appended with printf '%s' (literal, no interpretation).
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PWD")")"
+
+PROMPT_FILE=$(mktemp /tmp/pr-review-XXXXXX.md)
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
+cat > "$PROMPT_FILE" <<'ENDSTATIC'
+You are a Spec-enforcer. CLAUDE.md in this repo has been loaded automatically
+as your project context. Perform a thorough PR review now.
+
+## Scope gate — DO THIS FIRST
+
+0. Classify the diff. If it changes ONLY non-code files — documentation and
+   Markdown (`*.md`, `docs/**`), comments, or other prose/text with no
+   executable code — then this is a **docs-only PR** and the code conventions
+   below DO NOT apply. In that case:
+   - Do NOT require tests, version bumps, or script/file-naming alignment.
+   - Do NOT manufacture BLOCK findings about files that contain no code, and do
+     NOT cite code conventions (e.g. "tests required", "versioning") against
+     prose changes.
+   - Emit verdict **N/A** (`> [!NOTE]`) with a one-line reason, plus any genuine
+     prose nits as INFO, and STOP.
+   Only proceed to the steps below when the diff contains actual code changes.
+
+## What to do (code changes only)
+
+1. Read every file in skills/ that is relevant to this diff.
+2. Check the diff against every forbidden pattern listed in CLAUDE.md under
+   "Forbidden patterns". Each is a BLOCK finding if present.
+3. Check docs/planning/decisions.md (if it exists) — verify the diff does not
+   contradict any locked decision.
+4. Check for missing tests: new routes or public functions **in code** must have
+   corresponding test files. Never block on missing tests for docs-only or
+   comment-only changes.
+5. Check for secrets committed: credentials, API keys, tokens → BLOCK immediately.
+6. Apply any project-specific rules documented in CLAUDE.md.
+
+## Output format (GitHub-rendered markdown)
+
+Open the review with a GitHub alert callout matching the verdict:
+
+- ✅ PASS  → `> [!TIP]`      (green)
+- ⚠️ WARN  → `> [!WARNING]`  (amber)
+- ❌ BLOCK → `> [!CAUTION]`  (red)
+- N/A      → `> [!NOTE]`     (blue — docs-only PRs where no rules apply)
+
+Do NOT include opening or closing `---` separators in the body.
+Use the section headers below exactly as written.
+
+ENDSTATIC
+
+# Append the PR number (script-controlled integer — safe to expand here).
+printf '## Spec-enforcer Review — PR #%s\n\n' "$PR_NUMBER" >> "$PROMPT_FILE"
+
+cat >> "$PROMPT_FILE" <<'ENDTEMPLATE'
+> [!TIP]
+> **Verdict:** ✅ PASS — <one-sentence reason>
+
+### Findings
+
+For each finding:
+- **[BLOCK | WARN | INFO]** `file:line` — description
+  - **Rule:** skill filename or CLAUDE.md section
+  - **Fix:** specific remediation
+
+(If no findings: "No findings. All checked patterns pass.")
+
+### Summary
+
+2–3 sentence plain-English summary of what the PR does and whether it can merge.
+
+ENDTEMPLATE
+
+# Append untrusted content with printf '%s' (argument, not format string) to
+# prevent shell metacharacter expansion from PR titles, bodies, or diff lines.
+printf '## PR metadata\n' >> "$PROMPT_FILE"
+printf '%s\n' "$PR_META" >> "$PROMPT_FILE"
+printf '\n## Diff\n' >> "$PROMPT_FILE"
+printf '%s\n' "$PR_DIFF" >> "$PROMPT_FILE"
+
+# ── Run review ───────────────────────────────────────────────────────────────
+echo "→ Running Spec-enforcer review via claude -p --model ${MODEL}..." >&2
+
+START_TIME=$(date +%s)
+
+# Pass prompt via stdin (< file) — avoids command-line length limits and
+# prevents any $(...) or backtick expansion in untrusted diff content.
+#
+# --allowedTools restricts Claude to read-only file operations so that
+# prompt-injected instructions in an attacker's PR diff cannot execute
+# arbitrary shell commands. The reviewer only needs to read skills/ and
+# docs/planning/ — no write, bash, or network access required.
+REVIEW=$(claude -p --model "$MODEL" \
+  --allowedTools "Read,Glob,Grep" \
+  < "$PROMPT_FILE") || {
+  echo "Error: claude -p exited with code $?" >&2
+  echo "Tip: check \`claude auth status\` and confirm PATH includes homebrew bins." >&2
+  exit 1
+}
+
+END_TIME=$(date +%s)
+ELAPSED=$(( END_TIME - START_TIME ))
+
+# ── Append footer ────────────────────────────────────────────────────────────
+TZ_LOCAL="$(cfg_get '.project.timezone' 'America/Los_Angeles')"
+TIMESTAMP_LOCAL=$(TZ="$TZ_LOCAL" date '+%Y-%m-%d %H:%M %Z' 2>/dev/null || date '+%Y-%m-%d %H:%M %Z')
+TIMESTAMP_UTC=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+REVIEW="${REVIEW}
+
+---
+🤖 **Reviewer:** Spec-enforcer · **Project:** ${PROJECT_NAME} · **Model:** \`${MODEL}\` · **Elapsed:** ${ELAPSED}s · **Generated:** ${TIMESTAMP_LOCAL} · ${TIMESTAMP_UTC}"
+
+# ── Output ───────────────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════"
+echo "$REVIEW"
+echo "════════════════════════════════════════"
+
+if [[ "$POST_TO_GH" == "true" ]]; then
+  echo "" >&2
+  echo "→ Posting review to PR #${PR_NUMBER}..." >&2
+  gh pr review "$PR_NUMBER" --comment --body "$REVIEW"
+  echo "→ Posted." >&2
+fi

--- a/.agents/scripts/setup-pr-review.sh
+++ b/.agents/scripts/setup-pr-review.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# setup-pr-review.sh — Interactive wizard that generates .agents/pr-review.yml
+#
+# Usage:
+#   .agents/scripts/setup-pr-review.sh [--update]
+#
+# Flags:
+#   --update   Re-run over an existing config (prompts show current values as defaults)
+#
+# Prerequisites detected automatically:
+#   gh CLI authenticated, claude CLI authenticated,
+#   DEEPSEEK_API_KEY / OPENAI_API_KEY in env or .env,
+#   GitHub remote present, Playwright in package.json / pyproject.toml
+#
+# After running: copy or symlink the canonical scripts and workflow templates
+# from playbook/pipelines/pr-reviewer/ into this project.
+
+set -euo pipefail
+
+# ── Colours ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()    { echo -e "${CYAN}▸${RESET} $*"; }
+ok()      { echo -e "${GREEN}✓${RESET} $*"; }
+warn()    { echo -e "${YELLOW}⚠${RESET}  $*"; }
+err()     { echo -e "${RED}✗${RESET} $*"; }
+heading() { echo -e "\n${BOLD}$*${RESET}"; }
+divider() { echo -e "${CYAN}────────────────────────────────────────────${RESET}"; }
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+# ask <prompt> <default>  →  prints answer to stdout
+ask() {
+  local prompt="$1" default="$2"
+  local display_default=""
+  [[ -n "$default" ]] && display_default=" [${default}]"
+  echo -en "${BOLD}${prompt}${RESET}${display_default}: " >&2
+  local answer
+  read -r answer
+  echo "${answer:-$default}"
+}
+
+# ask_yn <prompt> <default y|n>  →  exits 0 for yes, 1 for no
+ask_yn() {
+  local prompt="$1" default="${2:-n}"
+  local choices="y/n"
+  [[ "$default" == "y" ]] && choices="Y/n" || choices="y/N"
+  echo -en "${BOLD}${prompt}${RESET} (${choices}): " >&2
+  local answer
+  read -r answer
+  answer="${answer:-$default}"
+  [[ "${answer,,}" == "y" ]]
+}
+
+# yq_get <file> <key> <fallback>
+yq_get() {
+  local file="$1" key="$2" fallback="${3:-}"
+  if command -v yq &>/dev/null; then
+    yq e "${key} // \"${fallback}\"" "$file" 2>/dev/null || echo "$fallback"
+  else
+    # plain-grep fallback — handles simple scalar values
+    local stripped="${key##*.}"
+    grep -E "^\s*${stripped}:" "$file" 2>/dev/null \
+      | head -1 | sed 's/.*: *//;s/"//g;s/\r//' || echo "$fallback"
+  fi
+}
+
+# ── Phase 1: Silent detection ───────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CONFIG_FILE="${PROJECT_ROOT}/.agents/pr-review.yml"
+UPDATE_MODE=false
+[[ "${1:-}" == "--update" ]] && UPDATE_MODE=true
+
+heading "PR Reviewer Setup Wizard"
+divider
+info "Detecting environment…"
+
+# Existing config
+EXISTING_CONFIG=false
+[[ -f "$CONFIG_FILE" ]] && EXISTING_CONFIG=true
+
+if $EXISTING_CONFIG && ! $UPDATE_MODE; then
+  warn "Config already exists at .agents/pr-review.yml"
+  if ! ask_yn "Re-run wizard to update it?" "n"; then
+    info "Aborting. Run with --update to force."
+    exit 0
+  fi
+  UPDATE_MODE=true
+fi
+
+# GitHub remote
+HAS_REMOTE=false
+GITHUB_REMOTE=""
+if git remote get-url origin &>/dev/null 2>&1; then
+  GITHUB_REMOTE="$(git remote get-url origin 2>/dev/null)"
+  if [[ "$GITHUB_REMOTE" == *github.com* ]]; then
+    HAS_REMOTE=true
+    ok "GitHub remote: ${GITHUB_REMOTE}"
+  else
+    warn "Remote found but not GitHub: ${GITHUB_REMOTE}"
+  fi
+else
+  warn "No git remote found — CI features will be skipped"
+fi
+
+# gh CLI
+GH_AUTHED=false
+if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+  GH_AUTHED=true
+  ok "gh CLI: authenticated"
+else
+  warn "gh CLI: not authenticated (run: gh auth login)"
+fi
+
+# claude CLI
+CLAUDE_AUTHED=false
+if command -v claude &>/dev/null; then
+  CLAUDE_AUTHED=true
+  ok "claude CLI: found"
+else
+  warn "claude CLI: not found (local review will be skipped)"
+fi
+
+# DeepSeek API key
+DEEPSEEK_KEY=false
+if [[ -n "${DEEPSEEK_API_KEY:-}" ]]; then
+  DEEPSEEK_KEY=true
+  ok "DEEPSEEK_API_KEY: found in environment"
+elif [[ -f "${PROJECT_ROOT}/.env" ]] && grep -q "DEEPSEEK_API_KEY" "${PROJECT_ROOT}/.env" 2>/dev/null; then
+  DEEPSEEK_KEY=true
+  ok "DEEPSEEK_API_KEY: found in .env"
+else
+  warn "DEEPSEEK_API_KEY: not found (PR-Agent CI will need it as a GitHub secret)"
+fi
+
+# OpenAI API key (for O3 dual-review)
+OPENAI_KEY=false
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  OPENAI_KEY=true
+  ok "OPENAI_API_KEY: found in environment"
+elif [[ -f "${PROJECT_ROOT}/.env" ]] && grep -q "OPENAI_API_KEY" "${PROJECT_ROOT}/.env" 2>/dev/null; then
+  OPENAI_KEY=true
+  ok "OPENAI_API_KEY: found in .env"
+else
+  warn "OPENAI_API_KEY: not found (O3 dual-review will be skipped)"
+fi
+
+# Playwright
+HAS_PLAYWRIGHT=false
+if [[ -f "${PROJECT_ROOT}/package.json" ]] && grep -q "playwright" "${PROJECT_ROOT}/package.json" 2>/dev/null; then
+  HAS_PLAYWRIGHT=true
+  ok "Playwright: detected in package.json"
+elif [[ -f "${PROJECT_ROOT}/pyproject.toml" ]] && grep -q "playwright" "${PROJECT_ROOT}/pyproject.toml" 2>/dev/null; then
+  HAS_PLAYWRIGHT=true
+  ok "Playwright: detected in pyproject.toml"
+else
+  warn "Playwright: not detected (test tiers T2+ will be skipped)"
+fi
+
+# Pull defaults from existing config when in update mode
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if $UPDATE_MODE && $EXISTING_CONFIG; then
+    yq_get "$CONFIG_FILE" "$key" "$fallback"
+  else
+    echo "$fallback"
+  fi
+}
+
+# ── Phase 2: Questions ──────────────────────────────────────────────────────
+
+divider
+heading "Project"
+
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PROJECT_ROOT")")"
+PROJECT_NAME="$(ask "Project name" "$PROJECT_NAME")"
+
+PROJECT_TZ="$(cfg_get '.project.timezone' "America/Los_Angeles")"
+PROJECT_TZ="$(ask "Timezone (for review footers)" "$PROJECT_TZ")"
+
+# ── PR-Agent CI ──
+# PR_AGENT_ENABLED drives what this wizard INSTALLS (the caller workflow, the
+# secret hints, the next-steps block). It is deliberately not written into
+# .agents/pr-review.yml: the presence of .github/workflows/pr-review.yml IS the
+# on-switch, and a second switch in the config that can silently disagree with
+# the first is worse than none (#490).
+PR_AGENT_ENABLED=false
+PR_AGENT_SKIP_DOCS=false
+PR_AGENT_STATUS_CHECK=true
+PR_AGENT_HIGH_STAKES="high-stakes"
+PR_AGENT_MODEL="deepseek/deepseek-v4-pro"
+
+if $HAS_REMOTE; then
+  divider
+  heading "PR-Agent CI (GitHub Actions)"
+  info "Requires DEEPSEEK_API_KEY as a GitHub secret."
+  _default_pra="$(cfg_get '.pr_agent.enabled' 'n')"; [[ "$_default_pra" == "true" ]] && _default_pra="y"
+  if ask_yn "Enable PR-Agent automated review?" "$_default_pra"; then
+    PR_AGENT_ENABLED=true
+
+    if ! $DEEPSEEK_KEY; then
+      warn "DEEPSEEK_API_KEY not found locally."
+      info "Make sure the secret is set in GitHub: gh secret set DEEPSEEK_API_KEY"
+    fi
+
+    PR_AGENT_MODEL="$(cfg_get '.pr_agent.model' 'deepseek/deepseek-v4-pro')"
+    PR_AGENT_MODEL="$(ask "PR-Agent model" "$PR_AGENT_MODEL")"
+
+    PR_AGENT_HIGH_STAKES="$(cfg_get '.pr_agent.high_stakes_label' 'high-stakes')"
+    PR_AGENT_HIGH_STAKES="$(ask "High-stakes label name" "$PR_AGENT_HIGH_STAKES")"
+
+    _default_skip="$(cfg_get '.pr_agent.skip_docs_only' 'n')"; [[ "$_default_skip" == "true" ]] && _default_skip="y"
+    ask_yn "Skip review for docs-only / planning-only PRs?" "$_default_skip" && PR_AGENT_SKIP_DOCS=true
+
+    _default_sc="$(cfg_get '.pr_agent.status_check' 'y')"; [[ "$_default_sc" == "false" ]] && _default_sc="n"
+    ask_yn "Post a commit status check (green/red) after review?" "${_default_sc:-y}" && PR_AGENT_STATUS_CHECK=true || PR_AGENT_STATUS_CHECK=false
+
+    # No cancel_in_flight prompt. Cancellation is owned by the caller workflow's
+    # `concurrency:` block, which is event-scoped on purpose:
+    #   cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
+    # A push SHOULD cancel a superseded review; a PR comment must NEVER cancel a
+    # running one, because GitHub evaluates concurrency at run CREATION, before
+    # any job-level `if`. Reducing that to a config boolean would be a
+    # regression, so the key was deleted rather than wired up (#490).
+  fi
+else
+  warn "Skipping PR-Agent CI (no GitHub remote)"
+fi
+
+# ── Local review ──
+LOCAL_ENABLED=false
+LOCAL_MODEL="claude-sonnet-4-6"
+LOCAL_ALIAS=""
+
+if $CLAUDE_AUTHED; then
+  divider
+  heading "Local review (claude -p)"
+  _default_local="$(cfg_get '.local_review.enabled' 'n')"; [[ "$_default_local" == "true" ]] && _default_local="y"
+  if ask_yn "Enable local review script (pr-review.sh)?" "$_default_local"; then
+    LOCAL_ENABLED=true
+
+    LOCAL_MODEL="$(cfg_get '.local_review.default_model' 'claude-sonnet-4-6')"
+    LOCAL_MODEL="$(ask "Default model for local review" "$LOCAL_MODEL")"
+
+    LOCAL_ALIAS="$(cfg_get '.local_review.shell_alias' '')"
+    LOCAL_ALIAS="$(ask "Shell alias (e.g. pr:review — leave blank to skip)" "$LOCAL_ALIAS")"
+  fi
+else
+  warn "Skipping local review (claude CLI not found)"
+fi
+
+# ── O3 dual-review ──
+DUAL_ENABLED=false
+DUAL_MODEL="gpt-5.5"
+DUAL_BRIEF=true
+DUAL_IMPL=true
+
+if $OPENAI_KEY; then
+  divider
+  heading "O3 dual-review (independent architecture gate)"
+  info "Fires during the implement loop: before implementation (brief) and/or after (impl)."
+  _default_dual="$(cfg_get '.dual_review.enabled' 'n')"; [[ "$_default_dual" == "true" ]] && _default_dual="y"
+  if ask_yn "Enable O3 dual-review?" "$_default_dual"; then
+    DUAL_ENABLED=true
+
+    DUAL_MODEL="$(cfg_get '.dual_review.model' 'gpt-5.5')"
+    DUAL_MODEL="$(ask "Dual-review model" "$DUAL_MODEL")"
+
+    _default_brief="$(cfg_get '.dual_review.on_brief' 'y')"; [[ "$_default_brief" == "false" ]] && _default_brief="n"
+    ask_yn "Review the task brief (Phase 4)?" "${_default_brief:-y}" || DUAL_BRIEF=false
+
+    _default_impl="$(cfg_get '.dual_review.on_impl' 'y')"; [[ "$_default_impl" == "false" ]] && _default_impl="n"
+    ask_yn "Review the implementation (Phase 7)?" "${_default_impl:-y}" || DUAL_IMPL=false
+  fi
+else
+  warn "Skipping O3 dual-review (OPENAI_API_KEY not found)"
+fi
+
+# ── DCO ──
+DCO_ENABLED=false
+
+if $HAS_REMOTE; then
+  divider
+  heading "DCO sign-off enforcement"
+  info "Adds a dco.yml GitHub Actions workflow requiring Signed-off-by on all commits."
+  _default_dco="$(cfg_get '.dco.required' 'n')"; [[ "$_default_dco" == "true" ]] && _default_dco="y"
+  ask_yn "Enable DCO enforcement?" "$_default_dco" && DCO_ENABLED=true
+fi
+
+# ── PR template ──
+PR_TEMPLATE_ENABLED=false
+
+divider
+heading "PR body template"
+info "Installs .github/pull_request_template.md with acceptance-criteria checklist."
+_default_pt="$(cfg_get '.pr_template.enabled' 'n')"; [[ "$_default_pt" == "true" ]] && _default_pt="y"
+ask_yn "Enable PR template?" "$_default_pt" && PR_TEMPLATE_ENABLED=true
+
+# ── Test tiers ──
+TIER_T1=true
+TIER_T2=false
+TIER_T25=false
+TIER_T3=false
+
+if $HAS_PLAYWRIGHT; then
+  divider
+  heading "Test tier hierarchy"
+  info "Controls which tiers the test-writer agent is expected to produce."
+  info "T1 Headless is always on. Higher tiers require Playwright."
+
+  _default_t2="$(cfg_get '.test_tiers.t2_aria' 'n')"; [[ "$_default_t2" == "true" ]] && _default_t2="y"
+  ask_yn "T2 ARIA — accessibility tree for unauthenticated routes?" "$_default_t2" && TIER_T2=true
+
+  _default_t25="$(cfg_get '.test_tiers.t2_5_authenticated' 'n')"; [[ "$_default_t25" == "true" ]] && _default_t25="y"
+  ask_yn "T2.5 Authenticated — ARIA tree for logged-in routes?" "$_default_t25" && TIER_T25=true
+
+  _default_t3="$(cfg_get '.test_tiers.t3_visual' 'n')"; [[ "$_default_t3" == "true" ]] && _default_t3="y"
+  ask_yn "T3 Visual — screenshot sign-off per design slice?" "$_default_t3" && TIER_T3=true
+else
+  warn "Skipping test tiers T2+ (Playwright not detected)"
+fi
+
+# ── Phase 3: Write config ────────────────────────────────────────────────────
+
+divider
+heading "Writing config"
+
+mkdir -p "${PROJECT_ROOT}/.agents"
+
+cat > "$CONFIG_FILE" <<YAML
+# .agents/pr-review.yml
+# Generated by setup-pr-review.sh on $(date '+%Y-%m-%d').
+# Re-run .agents/scripts/setup-pr-review.sh --update to change settings.
+
+project:
+  name: "${PROJECT_NAME}"
+  timezone: "${PROJECT_TZ}"
+
+# Every key below is read by pr-review-reusable.yml. Anything it does not
+# recognise now raises a ::warning:: annotation on the PR rather than being
+# silently discarded — see pipelines/pr-reviewer/README.md for the full schema.
+pr_agent:
+  model: "${PR_AGENT_MODEL}"
+  max_tokens: 131072
+  output_tokens: 64000
+  high_stakes_label: "${PR_AGENT_HIGH_STAKES}"
+  skip_docs_only: ${PR_AGENT_SKIP_DOCS}
+  score_labels: true
+  score_banner: true
+  status_check: ${PR_AGENT_STATUS_CHECK}
+
+local_review:
+  enabled: ${LOCAL_ENABLED}
+  default_model: "${LOCAL_MODEL}"
+  shell_alias: "${LOCAL_ALIAS}"
+
+dual_review:
+  enabled: ${DUAL_ENABLED}
+  model: "${DUAL_MODEL}"
+  on_brief: ${DUAL_BRIEF}
+  on_impl: ${DUAL_IMPL}
+
+dco:
+  required: ${DCO_ENABLED}
+
+pr_template:
+  enabled: ${PR_TEMPLATE_ENABLED}
+
+test_tiers:
+  t1_headless: ${TIER_T1}
+  t2_aria: ${TIER_T2}
+  t2_5_authenticated: ${TIER_T25}
+  t3_visual: ${TIER_T3}
+YAML
+
+ok "Written: .agents/pr-review.yml"
+
+# ── Generate shell-aliases.sh if alias configured ────────────────────────────
+if [[ -n "$LOCAL_ALIAS" ]]; then
+  ALIASES_FILE="${PROJECT_ROOT}/.agents/scripts/shell-aliases.sh"
+  TEMPLATE_SRC=""
+  # Find the template relative to this wizard (works from playbook or copied location)
+  _wizard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [[ -f "${_wizard_dir}/shell-aliases.sh" ]]; then
+    TEMPLATE_SRC="${_wizard_dir}/shell-aliases.sh"
+  fi
+
+  if [[ -n "$TEMPLATE_SRC" ]]; then
+    mkdir -p "${PROJECT_ROOT}/.agents/scripts"
+    sed "s/@@ALIAS@@/${LOCAL_ALIAS}/g" "$TEMPLATE_SRC" > "$ALIASES_FILE"
+    chmod +x "$ALIASES_FILE"
+    ok "Generated: .agents/scripts/shell-aliases.sh  (alias: ${LOCAL_ALIAS})"
+  else
+    warn "shell-aliases.sh template not found alongside wizard — generate manually."
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+divider
+heading "Summary"
+
+print_feature() {
+  local name="$1" enabled="$2" note="${3:-}"
+  if [[ "$enabled" == "true" ]]; then
+    ok "${name}${note:+  (${note})}"
+  else
+    err "${name}${note:+  — ${note}}"
+  fi
+}
+
+print_feature "PR-Agent CI"       "$PR_AGENT_ENABLED"    "$($PR_AGENT_ENABLED && echo "model: ${PR_AGENT_MODEL}" || echo "no GitHub remote or not opted in")"
+print_feature "Local review"      "$LOCAL_ENABLED"       "$($LOCAL_ENABLED && echo "model: ${LOCAL_MODEL}" || echo "claude CLI not found or not opted in")"
+print_feature "Shell alias"       "$([[ -n "$LOCAL_ALIAS" ]] && echo true || echo false)"  "${LOCAL_ALIAS:-not configured}"
+print_feature "O3 dual-review"    "$DUAL_ENABLED"        "$($DUAL_ENABLED && echo "model: ${DUAL_MODEL}" || echo "OPENAI_API_KEY not found or not opted in")"
+print_feature "DCO enforcement"   "$DCO_ENABLED"
+print_feature "PR template"       "$PR_TEMPLATE_ENABLED"
+print_feature "T2 ARIA"           "$TIER_T2"             "$($TIER_T2 || $HAS_PLAYWRIGHT && echo "" || echo "Playwright not detected")"
+print_feature "T2.5 Authenticated" "$TIER_T25"
+print_feature "T3 Visual"         "$TIER_T3"
+
+# ── Next steps ───────────────────────────────────────────────────────────────
+
+divider
+heading "Next steps"
+
+NEXT=0
+
+if $PR_AGENT_ENABLED && ! $DEEPSEEK_KEY; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Add DEEPSEEK_API_KEY to GitHub secrets:"
+  echo    "       gh secret set DEEPSEEK_API_KEY"
+fi
+
+if $PR_AGENT_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the canonical GitHub Actions workflow:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/templates/pr-review.yml .github/workflows/"
+fi
+
+if $DCO_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the DCO workflow:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/templates/dco.yml .github/workflows/"
+fi
+
+if $PR_TEMPLATE_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the PR body template:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/templates/pull_request_template.md .github/"
+fi
+
+if $LOCAL_ENABLED || $DUAL_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the canonical scripts:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/scripts/*.sh .agents/scripts/"
+  echo    "       chmod +x .agents/scripts/*.sh"
+fi
+
+if [[ -n "$LOCAL_ALIAS" ]]; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Source the shell alias in your shell config:"
+  echo    "       echo 'source \$(git rev-parse --show-toplevel)/.agents/scripts/shell-aliases.sh' >> ~/.zshrc"
+fi
+
+if $PR_AGENT_ENABLED || $LOCAL_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Verify everything is ready:"
+  echo    "       .agents/scripts/check-pr-review-readiness.sh"
+fi
+
+[[ $NEXT -eq 0 ]] && info "Nothing else to do — all features are self-contained."
+
+echo ""

--- a/.agents/scripts/shell-aliases.sh
+++ b/.agents/scripts/shell-aliases.sh
@@ -1,0 +1,32 @@
+# shell-aliases.sh — Project shell shortcuts for PR review
+#
+# Generated/installed by setup-pr-review.sh based on local_review.shell_alias
+# in .agents/pr-review.yml.
+#
+# Source this from your shell profile (zsh only — colon function names like
+# `pr:review` are legal in zsh but a parse error in bash):
+#
+#   echo 'source /path/to/project/.agents/scripts/shell-aliases.sh' >> ~/.zshrc
+#
+# Or source it per-session:
+#   source .agents/scripts/shell-aliases.sh
+#
+# The PROJECT_DIR variable is auto-detected from the location of this script.
+# Override it in your profile if needed:
+#   export PROJECT_DIR="$HOME/alt/path/to/project"
+
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)}"
+
+# @@ALIAS@@ — run the Spec-enforcer PR review via `claude -p`
+# Usage:
+#   @@ALIAS@@ <PR-number>              print review to stdout
+#   @@ALIAS@@ <PR-number> --post       also post as a PR comment
+#   @@ALIAS@@ <PR-number> --model X    override the default model
+@@ALIAS@@() {
+  if [[ ! -d "$PROJECT_DIR" ]]; then
+    echo "@@ALIAS@@: PROJECT_DIR not found: $PROJECT_DIR" >&2
+    echo "         Set PROJECT_DIR in your shell profile if the repo moved." >&2
+    return 1
+  fi
+  ( cd "$PROJECT_DIR" && ./.agents/scripts/pr-review.sh "$@" )
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,27 @@ jobs:
     # variable (value: self-hosted-linux). Until that variable is scoped to this
     # repo, it falls back to the GitHub-hosted ubuntu-latest runner. See
     # pl-ops-handbook > platform-ops > github-runners.md ("Repo opt-in").
-    # The fleet image bakes a CPU PyTorch (pl-runner >= 1.66.1), so the torch
-    # tests (test_engine_loop, test_moe_offload_*, test_models_loader) run here
-    # instead of being skipped on a torch-less runner.
+    # The fleet image bakes a CPU PyTorch (pl-runner >= 1.66.1) into the
+    # runner's SYSTEM Python (/usr/bin/python3), so the torch tests
+    # (test_engine_loop, test_moe_offload_*, test_models_loader) can run here
+    # instead of being skipped on a torch-less runner -- but only if the job
+    # actually uses that system interpreter. actions/setup-python always
+    # downloads and uses its own separate CPython build under
+    # /opt/hostedtoolcache (verified via a run log: "Version 3.12 was not
+    # found in the local cache" -> downloads python-3.12.14-linux-24.04-x64.tar.gz
+    # every time, since these runners are ephemeral), which has no relationship
+    # to the image's baked torch at all. Running it on self-hosted silently
+    # defeated the whole point of baking torch in: every torch-marked test file
+    # skipped with "could not import torch", 4 skips standing in for ~22 actual
+    # tests never collected. So: skip setup-python entirely on the self-hosted
+    # fleet (Noble already ships python3.12 + pip on PATH, and the image has
+    # torch); keep it for the ubuntu-latest fallback, which has no baked torch
+    # and needs setup-python to get any Python at all.
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        if: ${{ vars.CI_RUNNER == '' }}
         with:
           python-version: "3.12"
       - name: Install

--- a/.github/workflows/pr-review-reusable.yml
+++ b/.github/workflows/pr-review-reusable.yml
@@ -1,0 +1,713 @@
+name: PR-Agent Spec Review (reusable)
+# VENDORED COPY — this repo is public. A public repo cannot call a reusable
+# workflow hosted in a private one (`uses: Performant-Labs/playbook/...@main`
+# fails at run time with "workflow was not found", even though playbook's
+# reusable-workflow access is set to "organization" -- that setting does not
+# extend to public callers). Same fix as performantlabs.com. Keep this file in
+# sync with playbook/.github/workflows/pr-review-reusable.yml by hand; it is
+# not auto-synced.
+#
+# Called by this repo's .github/workflows/pr-review.yml via:
+#   uses: ./.github/workflows/pr-review-reusable.yml
+#   secrets:
+#     DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+#     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+# GITHUB_TOKEN is automatically available — do not pass it via secrets.
+#
+# All behaviour is driven by .agents/pr-review.yml in the CALLING repo.
+# Concurrency and triggers live in the thin caller; this file is pure logic.
+
+on:
+  workflow_call:
+    secrets:
+      DEEPSEEK_API_KEY:
+        required: false
+      ANTHROPIC_API_KEY:
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  pr-agent:
+    # Filter bots and non-slash-command issue comments here — these are fixed
+    # and not configurable. Draft filtering and skip_paths are handled inside
+    # the gate step so they can read project config first.
+    if: |
+      github.event.sender.type != 'Bot' &&
+      (github.event_name != 'issue_comment' ||
+       startsWith(github.event.comment.body, '/review') ||
+       startsWith(github.event.comment.body, '/describe') ||
+       startsWith(github.event.comment.body, '/improve') ||
+       startsWith(github.event.comment.body, '/ask'))
+    runs-on: ${{ vars.CI_RUNNER }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Ensure pyyaml is available
+        # Self-hosted runners (vars.CI_RUNNER) may ship a PEP-668
+        # externally-managed system Python (Python 3.12+), which makes a plain
+        # `pip install` hard-fail with "This environment is externally managed"
+        # and kills the job before PR-Agent ever runs. Try a normal install
+        # first; if it's blocked, retry with --break-system-packages. CI runners
+        # are disposable, so mutating the system site-packages is safe here.
+        run: |
+          python3 -m pip install pyyaml --quiet --disable-pip-version-check \
+            || python3 -m pip install pyyaml --quiet --disable-pip-version-check --break-system-packages
+
+      # ── Read project config ──────────────────────────────────────────────────
+      # Parses .agents/pr-review.yml with PyYAML.
+      # Falls back to safe defaults when the file is absent.
+      - name: Read pr-review config
+        id: cfg
+        run: |
+          python3 << 'PYEOF'
+          import yaml, json, os, sys
+
+          cfg = {}
+          try:
+              with open('.agents/pr-review.yml') as f:
+                  cfg = yaml.safe_load(f) or {}
+          except FileNotFoundError:
+              pass
+
+          pa   = cfg.get('pr_agent', {})
+          proj = cfg.get('project', {})
+
+          # ── Warn on keys nothing reads (#490) ────────────────────────────────
+          # `.agents/pr-review.yml` is ONE file with FOUR consumers: this
+          # workflow (pr_agent.* + project.timezone), pr-review.sh
+          # (local_review.*), dual-review.sh (dual_review.reasoning_effort) and
+          # check-pr-review-readiness.sh (dual_review.enabled). Until #490 this
+          # parser read its own subtree and DISCARDED the rest in silence, so a
+          # key that did nothing was indistinguishable from a key that worked —
+          # 24 of 27 repos carried `skip_docs_only` believing docs-only diffs
+          # skipped review, because playbook's own wizard emitted it.
+          #
+          # The check is deliberately SCOPED to the subtrees this workflow owns.
+          # A flat unknown-key check would warn on local_review/dual_review/dco/
+          # pr_template/test_tiers/spec — real keys belonging to the other three
+          # consumers — in every repo on every PR, and would be tuned out within
+          # a week. Top-level sections are checked against the union of all four
+          # consumers, which is what catches a mistyped SECTION name (the most
+          # expensive typo available here: it silently disables everything under
+          # it). Warnings never fail the parse.
+          KNOWN_SECTIONS = {
+              'project', 'pr_agent',       # this workflow
+              'local_review',              # pipelines/pr-reviewer/scripts/pr-review.sh
+              'dual_review',               # workflow/dual-review.sh + check-pr-review-readiness.sh
+              'dco', 'pr_template', 'test_tiers', 'spec',
+          }
+          KNOWN_PR_AGENT = {
+              'model', 'high_stakes_model', 'fallback_model', 'high_stakes_label',
+              'max_tokens', 'output_tokens', 'auto_improve', 'review_drafts',
+              'score_labels', 'score_banner', 'status_check', 'skip_paths',
+              'skip_docs_only',
+          }
+          KNOWN_PROJECT = {'name', 'timezone'}
+
+          def warn(scope, keys, known):
+              unknown = sorted(k for k in keys if k not in known)
+              if unknown:
+                  print(f'::warning file=.agents/pr-review.yml::Unrecognised '
+                        f'{scope}: {", ".join(unknown)} — nothing reads '
+                        f'{"it" if len(unknown) == 1 else "them"}. See '
+                        f'pipelines/pr-reviewer/README.md for the keys each '
+                        f'consumer actually reads.')
+
+          if isinstance(cfg, dict):
+              warn('top-level section(s) in .agents/pr-review.yml',
+                   cfg.keys(), KNOWN_SECTIONS)
+          if isinstance(pa, dict):
+              warn('pr_agent key(s)', pa.keys(), KNOWN_PR_AGENT)
+          if isinstance(proj, dict):
+              warn('project key(s)', proj.keys(), KNOWN_PROJECT)
+
+          model    = pa.get('model', 'deepseek/deepseek-v4-pro')
+          hs_model = pa.get('high_stakes_model', model)
+          fb       = pa.get('fallback_model', '')
+          # Only emit a fallback if it's set and differs from the primary.
+          fallback_models = json.dumps([fb]) if fb and fb != model else json.dumps([model])
+
+          out = open(os.environ['GITHUB_OUTPUT'], 'a')
+          def w(k, v): out.write(f'{k}={v}\n')
+
+          w('model',           model)
+          w('hs_model',        hs_model)
+          w('hs_label',        pa.get('high_stakes_label', 'high-stakes'))
+          w('fallback_models', fallback_models)
+          w('max_tokens',      str(pa.get('max_tokens', 131072)))
+          w('output_tokens',   str(pa.get('output_tokens', 64000)))
+          w('auto_improve',    'true' if pa.get('auto_improve', False) else 'false')
+          w('review_drafts',   'true' if pa.get('review_drafts', False) else 'false')
+          w('score_labels',    'true' if pa.get('score_labels', True) else 'false')
+          w('score_banner',    'true' if pa.get('score_banner', True) else 'false')
+          w('status_check',    'true' if pa.get('status_check', True) else 'false')
+          w('skip_paths',      json.dumps(pa.get('skip_paths', [])))
+          w('skip_docs_only',  'true' if pa.get('skip_docs_only', False) else 'false')
+          w('timezone',        proj.get('timezone', ''))
+          out.close()
+          PYEOF
+
+      # ── Sync high-stakes label from a linked issue ───────────────────────────
+      # GitHub does NOT copy an issue's labels onto the PR that closes it. Without
+      # this, a PR closing a high-stakes-labeled issue would silently get the
+      # default review unless someone remembered to label the PR by hand — and
+      # "Resolve PR labels" below only ever looks at the PR's OWN live labels.
+      # Parses the PR body for closing keywords (close/fix/resolve #N, GitHub's
+      # own recognized syntax); if any linked issue carries the configured
+      # high_stakes_label, copies it onto the PR. One-way sync (adds, never
+      # removes) so it can't fight a manually-applied or manually-removed label.
+      - name: Sync high-stakes label from linked issue
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HS_LABEL: ${{ steps.cfg.outputs.hs_label }}
+        run: |
+          if [[ -z "$HS_LABEL" ]]; then
+            echo "high_stakes_label not configured — nothing to sync."
+            exit 0
+          fi
+
+          BODY=$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq '.body // ""')
+          ISSUES=$(printf '%s' "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' | sort -u)
+
+          if [[ -z "$ISSUES" ]]; then
+            echo "No linked issues found in PR body — nothing to sync."
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUES; do
+            HAS_LABEL=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json labels \
+              --jq --arg l "$HS_LABEL" '[.labels[].name] | index($l) != null' 2>/dev/null || echo "false")
+            if [[ "$HAS_LABEL" == "true" ]]; then
+              echo "Issue #$ISSUE_NUM carries '$HS_LABEL' — applying to PR #$PR_NUM"
+              gh label create "$HS_LABEL" --color '5319e7' \
+                --description 'High-stakes review-rigor (see project pr-review config)' \
+                --repo "$REPO" 2>/dev/null || true
+              gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$HS_LABEL"
+              exit 0
+            fi
+          done
+          echo "No linked issue carries '$HS_LABEL' — leaving PR labels as-is."
+
+      # ── Resolve high-stakes label ────────────────────────────────────────────
+      # github.event.pull_request.labels is null for issue_comment events;
+      # fetch live labels so the high-stakes path works for /review too.
+      - name: Resolve PR labels
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HS_LABEL: ${{ steps.cfg.outputs.hs_label }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          if [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]]; then
+            echo "high_stakes=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          LABELS=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
+            --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -qF "$HS_LABEL"; then
+            echo "high_stakes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "high_stakes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Gate: draft check + skip_paths + skip_docs_only ─────────────────────
+      # Slash commands (/review etc.) always bypass both skip mechanisms — the
+      # user is explicitly requesting a review regardless of what changed.
+      - name: Gate — draft and skip_paths check
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEW_DRAFTS: ${{ steps.cfg.outputs.review_drafts }}
+          SKIP_PATHS_JSON: ${{ steps.cfg.outputs.skip_paths }}
+          SKIP_DOCS_ONLY: ${{ steps.cfg.outputs.skip_docs_only }}
+        run: |
+          # Bash prepares inputs; Python does the PurePath glob matching.
+          # python3 << 'PYEOF' must be at the run: block's base indent so that
+          # PYEOF lands at column 0 in the generated bash script (heredoc rule).
+          # Scratch files live under RUNNER_TEMP (set by Actions) so the gate's
+          # Python is hermetic and can be exercised directly by
+          # evals/harness/pr-review-skip-docs.test.mjs.
+          TMP="${RUNNER_TEMP:-/tmp}"
+          DRAFT_SKIP="false"
+          DO_CHECK="false"
+
+          if [[ "${{ github.event.pull_request.draft }}" == "true" && "$REVIEW_DRAFTS" != "true" ]]; then
+            echo "Draft PR with review_drafts=false — skipping"
+            DRAFT_SKIP="true"
+          fi
+
+          PR_NUM="${{ github.event.pull_request.number }}"
+          if [[ "$DRAFT_SKIP" == "false" \
+             && "${{ github.event_name }}" != "issue_comment" \
+             && ( "$SKIP_PATHS_JSON" != "[]" || "$SKIP_DOCS_ONLY" == "true" ) \
+             && -n "$PR_NUM" && "$PR_NUM" != "null" ]]; then
+            CHANGED=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
+              --json files --jq '[.files[].path]' 2>/dev/null || echo '[]')
+            printf '%s' "$CHANGED"         > "$TMP/changed.json"
+            printf '%s' "$SKIP_PATHS_JSON" > "$TMP/skip_paths.json"
+            DO_CHECK="true"
+          fi
+
+          printf '%s' "$DRAFT_SKIP" > "$TMP/draft_skip.txt"
+          printf '%s' "$DO_CHECK"   > "$TMP/do_check.txt"
+
+          python3 << 'PYEOF'
+          import json, os
+          from pathlib import PurePath
+
+          tmp = os.environ.get('RUNNER_TEMP') or '/tmp'
+          def _read(name):
+              with open(os.path.join(tmp, name)) as f:
+                  return f.read().strip()
+
+          draft_skip = _read('draft_skip.txt')
+          do_check   = _read('do_check.txt')
+          skip       = draft_skip
+
+          # ── skip_docs_only (#490) ────────────────────────────────────────────
+          # Implemented in the parser rather than expressed as skip_paths on
+          # purpose. skip_paths matches with PurePath.match(), which is anchored
+          # at the RIGHT and treats "**" as a single "*": "docs/**" matches
+          # docs/foo.md but NOT docs/handoffs/x/foo.md, so every directory depth
+          # has to be spelled out by hand. Making 24 repos each maintain their
+          # own depth ladder would hand every one of them the same trap. This
+          # predicate is depth-independent by construction.
+          #
+          # A file is documentation if it carries a prose extension at any depth,
+          # sits anywhere under a documentation directory (so images and other
+          # assets in docs/ count), or is one of the conventional root files.
+          DOC_SUFFIXES = {'.md', '.mdx', '.markdown', '.rst', '.adoc', '.txt'}
+          DOC_DIRS     = ('docs', 'doc', 'planning')
+          DOC_NAMES    = {'LICENSE', 'NOTICE', 'AUTHORS', 'CHANGELOG'}
+
+          def is_doc(fp):
+              p = PurePath(fp)
+              if p.suffix.lower() in DOC_SUFFIXES:
+                  return True
+              if p.name in DOC_NAMES:
+                  return True
+              return any(part in DOC_DIRS for part in p.parts[:-1])
+
+          if skip == 'false' and do_check == 'true':
+              files    = json.loads(_read('changed.json'))
+              patterns = json.loads(_read('skip_paths.json'))
+              docs_only = os.environ.get('SKIP_DOCS_ONLY') == 'true'
+              if files and (patterns or docs_only):
+                  # Either mechanism can excuse a file; the review is skipped
+                  # only when EVERY changed file is excused by one of them.
+                  def skippable(fp):
+                      if any(PurePath(fp).match(p) for p in patterns):
+                          return True
+                      return docs_only and is_doc(fp)
+
+                  if all(skippable(fp) for fp in files):
+                      skip = 'true'
+                      print('All changed files are skippable '
+                            '(skip_paths / skip_docs_only) — skipping review')
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
+              out.write(f'should_skip={skip}\n')
+          PYEOF
+
+      # ── Run-start anchor (#433) ──────────────────────────────────────────────
+      # Every score consumer below (label, banner, status check) used to read
+      # "the last bot comment containing 'Reviewer Guide'" with NO recency
+      # bound. When a review CRASHES, `continue-on-error: true` lets the job
+      # proceed, the lookup finds the PREVIOUS run's still-present Reviewer
+      # Guide comment, and that stale score is reported as this run's result —
+      # a green `pr-agent/review` for a review that produced nothing (#433:
+      # "pass — Reviewed — score 95" sitting beside the bot's own no-score
+      # comment). It reproduced under `/review` on #429 and did NOT reproduce
+      # on #437 because #437 was a fresh PR with no earlier comment to go
+      # stale. That is the entirety of the "intermittent" behaviour: it
+      # misfires exactly on PRs that already have a successful review.
+      #
+      # Prefer GITHUB'S clock over the runner's, so the anchor and the comment
+      # timestamps it is compared against come from one source and a self-hosted
+      # runner's unsynced clock (vars.CI_RUNNER may be older hardware) cannot
+      # shift the comparison.
+      #
+      # Read it from the `Date` RESPONSE HEADER of an ordinary API call. Two
+      # earlier attempts failed and are recorded so neither is tried again:
+      #
+      #   1. `gh api repos/…/actions/runs/${{ github.run_id }}` (#444) needs the
+      #      `actions: read` permission. The thin callers grant only
+      #      contents/pull-requests/issues/statuses, so it was DENIED in every
+      #      consumer repo — the anchor exited 1 and, because the consumers run
+      #      under always(), each failed the job.
+      #   2. `${{ github.run_started_at }}` (#448) is not a populated github
+      #      context property. It expanded to the empty string, producing the
+      #      same hard failure by a different route.
+      #
+      # The Date header comes back on ANY authenticated request, so it needs no
+      # permission beyond what the callers already grant.
+      #
+      # Fallback order is deliberate. The property that actually matters for
+      # #433 is that the lookup is BOUNDED AT ALL; whose clock supplies the
+      # bound is a refinement. So an unavailable header degrades to the runner
+      # clock — still bounded, still excludes prior runs — rather than failing
+      # the job. Only a total failure of both is fatal, and that cannot happen
+      # while `date` exists. Two consecutive outages here were caused by
+      # fail-closed behaviour on a NON-ESSENTIAL input; this keeps fail-closed
+      # for the thing that matters and stops treating clock provenance as
+      # load-bearing.
+      - name: Record run-start anchor
+        id: runstart
+        if: always() && steps.gate.outputs.should_skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          START=""
+          HDR=$(gh api "repos/${{ github.repository }}" -i --silent 2>/dev/null \
+                | grep -i '^date:' | head -1 | sed 's/^[Dd]ate:[[:space:]]*//' | tr -d '\r' || true)
+          if [[ -n "$HDR" ]]; then
+            START=$(date -u -d "$HDR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+          fi
+          if [[ -n "$START" ]]; then
+            echo "Run-start anchor: $START (GitHub clock, Date header)"
+          else
+            START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            echo "::warning::could not read GitHub's clock; falling back to the runner clock. The lookup stays bounded (#433); only skew resistance is reduced."
+            echo "Run-start anchor: $START (runner clock, fallback)"
+          fi
+          # Only unreachable if `date` itself failed. Fail closed here: with no
+          # anchor at all the lookup would be unbounded, which is exactly #433.
+          if [[ -z "$START" ]]; then
+            echo "::error::no clock available — refusing an unbounded comment lookup (#433)"
+            exit 1
+          fi
+          echo "run_start=$START" >> "$GITHUB_OUTPUT"
+
+      # ── PR-Agent review (default) ────────────────────────────────────────────
+      # Pinned by SHA to qodo-ai/pr-agent v0.41.0. Resolve a tag with:
+      #   gh api repos/qodo-ai/pr-agent/commits/<tag> -q '.sha'
+      #
+      # Do NOT hand-edit the version here as routine maintenance. Dependabot owns
+      # forward drift on this pin under ⛔ D4 (#421: weekly, patch and minor
+      # accepted, majors never) — 0.39.0 -> 0.41.0 arrived that way in #383.
+      #
+      # This comment named v0.39.0 for a while after the pin itself moved, which
+      # is the specific hazard of restating a version in prose beside the thing
+      # that states it: the `uses:` line is the source of truth, and Dependabot
+      # updates that line but not the sentence above it. If they disagree, the
+      # `uses:` line is right.
+      #
+      # ⛔ D3 (#421) — the MODEL pin is a separate decision and is NOT Dependabot's
+      # to move: stay on deepseek-v4-pro. Rolling the action forward must not roll
+      # the model forward with it.
+      - name: PR-Agent review (default)
+        id: review-default
+        if: |
+          steps.gate.outputs.should_skip != 'true' &&
+          steps.labels.outputs.high_stakes != 'true'
+        continue-on-error: true
+        uses: qodo-ai/pr-agent@743f52d80f3513193dfc7626f778c73478df6d0a  # v0.41.1
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG.MODEL: ${{ steps.cfg.outputs.model }}
+          CONFIG.CUSTOM_MODEL_MAX_TOKENS: ${{ steps.cfg.outputs.max_tokens }}
+          CONFIG.MAX_MODEL_TOKENS: ${{ steps.cfg.outputs.output_tokens }}
+          CONFIG.FALLBACK_MODELS: ${{ steps.cfg.outputs.fallback_models }}
+          GITHUB_ACTION_CONFIG.PR_ACTIONS: '["opened","reopened","ready_for_review","review_requested","synchronize"]'
+          GITHUB_ACTION_CONFIG.AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG.AUTO_IMPROVE: ${{ steps.cfg.outputs.auto_improve }}
+          PR_REVIEWER.REQUIRE_TICKET_ANALYSIS_REVIEW: "false"
+          PR_REVIEWER.REQUIRE_SCORE_REVIEW: "true"
+
+      # ── PR-Agent review (high-stakes) ────────────────────────────────────────
+      # Uses high_stakes_model from config — set to a more capable model for
+      # critical changes. Apply the high_stakes_label to a PR to activate.
+      - name: PR-Agent review (high-stakes)
+        id: review-highstakes
+        if: |
+          steps.gate.outputs.should_skip != 'true' &&
+          steps.labels.outputs.high_stakes == 'true'
+        continue-on-error: true
+        uses: qodo-ai/pr-agent@743f52d80f3513193dfc7626f778c73478df6d0a  # v0.41.1
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG.MODEL: ${{ steps.cfg.outputs.hs_model }}
+          CONFIG.CUSTOM_MODEL_MAX_TOKENS: ${{ steps.cfg.outputs.max_tokens }}
+          CONFIG.MAX_MODEL_TOKENS: ${{ steps.cfg.outputs.output_tokens }}
+          GITHUB_ACTION_CONFIG.PR_ACTIONS: '["opened","reopened","ready_for_review","review_requested","synchronize"]'
+          GITHUB_ACTION_CONFIG.AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG.AUTO_IMPROVE: ${{ steps.cfg.outputs.auto_improve }}
+          PR_REVIEWER.REQUIRE_TICKET_ANALYSIS_REVIEW: "false"
+          PR_REVIEWER.REQUIRE_SCORE_REVIEW: "true"
+
+      # ── Score-bracket label ──────────────────────────────────────────────────
+      - name: Apply score-bracket label
+        if: |
+          always() &&
+          steps.gate.outputs.should_skip != 'true' &&
+          steps.cfg.outputs.score_labels == 'true' &&
+          (steps.review-default.outcome == 'success' || steps.review-highstakes.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]] && { echo "No PR — skip"; exit 0; }
+
+          gh label create 'score-90+'      --color '0e8a16' --description 'PR-Agent score 90-100 (ship)'                --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create 'score-80-89'    --color 'fbca04' --description 'PR-Agent score 80-89 (review carefully)'     --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create 'score-70-79'    --color 'e99695' --description 'PR-Agent score 70-79 (address suggestions)'  --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create 'score-below-70' --color 'b60205' --description 'PR-Agent score <70 (probable blocking issues)'--repo "${{ github.repository }}" 2>/dev/null || true
+
+          # #433: bound by this run's anchor, and require the comment to be an
+          # actual review ("Reviewer Guide") rather than any bot comment — the
+          # old filter would happily match this workflow's OWN "produced no
+          # score" failure comment from an earlier run and label off it.
+          # --paginate: without it the API returns only the first 30 comments
+          # (oldest first), so `last` was the 30th-oldest, not the newest.
+          RUN_START="${{ steps.runstart.outputs.run_start }}"
+          [[ -z "$RUN_START" ]] && { echo "::error::missing run-start anchor (#433)"; exit 1; }
+          gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUM/comments" --jq '.[]' \
+            | jq -s '.' > /tmp/pr-comments-label.json
+          LATEST=$(jq -r --arg since "$RUN_START" \
+            '[.[] | select(.user.login=="github-actions[bot]")
+                  | select(.updated_at >= $since)
+                  | select(.body | contains("Reviewer Guide"))] | last.body // ""' \
+            /tmp/pr-comments-label.json)
+          SCORE=$(echo "$LATEST" | grep -oE '[Ss]core[^0-9]{0,30}[0-9]+' | grep -oE '[0-9]+' | head -1)
+          [[ -z "$SCORE" ]] && { echo "No score from THIS run — skip label"; exit 0; }
+
+          for L in 'score-90+' 'score-80-89' 'score-70-79' 'score-below-70'; do
+            gh issue edit "$PR_NUM" --remove-label "$L" --repo "${{ github.repository }}" 2>/dev/null || true
+          done
+
+          if   (( SCORE >= 90 )); then BRACKET='score-90+'
+          elif (( SCORE >= 80 )); then BRACKET='score-80-89'
+          elif (( SCORE >= 70 )); then BRACKET='score-70-79'
+          else                         BRACKET='score-below-70'
+          fi
+          gh issue edit "$PR_NUM" --add-label "$BRACKET" --repo "${{ github.repository }}"
+          echo "Applied: $BRACKET"
+
+      # ── Score banner ─────────────────────────────────────────────────────────
+      - name: Inject score banner into PR description
+        if: |
+          always() &&
+          steps.gate.outputs.should_skip != 'true' &&
+          steps.cfg.outputs.score_banner == 'true' &&
+          (steps.review-default.outcome == 'success' || steps.review-highstakes.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          DISPLAY_TZ: ${{ vars.DISPLAY_TZ }}
+          MODEL: ${{ steps.cfg.outputs.model }}
+          HS_MODEL: ${{ steps.cfg.outputs.hs_model }}
+          HIGH_STAKES: ${{ steps.labels.outputs.high_stakes }}
+          TIMEZONE: ${{ steps.cfg.outputs.timezone }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]] && { echo "No PR — skip"; exit 0; }
+
+          # #433: recency-bounded to this run (see "Record run-start anchor").
+          # A banner is the most visible artefact here — rendering a previous
+          # run's score into the PR description after a crash is the single
+          # most misleading thing this workflow can do.
+          RUN_START="${{ steps.runstart.outputs.run_start }}"
+          [[ -z "$RUN_START" ]] && { echo "::error::missing run-start anchor (#433)"; exit 1; }
+          gh api --paginate "repos/${REPO}/issues/$PR_NUM/comments" --jq '.[]' \
+            | jq -s '.' > /tmp/pr-comments.json
+          THIS_RUN='[.[] | select(.user.login=="github-actions[bot]")
+                         | select(.updated_at >= $since)
+                         | select(.body | contains("Reviewer Guide"))]'
+          REVIEW_BODY=$(jq -r --arg since "$RUN_START" "${THIS_RUN} | last.body // \"\"" /tmp/pr-comments.json)
+          REVIEW_URL=$(jq  -r --arg since "$RUN_START" "${THIS_RUN} | last.html_url // \"\"" /tmp/pr-comments.json)
+          SCORE=$(printf '%s' "$REVIEW_BODY" | grep -oE '[Ss]core[^0-9]{0,30}[0-9]+' | grep -oE '[0-9]+' | head -1)
+          [[ -z "$SCORE" ]] && { echo "No score from THIS run — skip banner"; exit 0; }
+
+          if   (( SCORE >= 90 )); then BRACKET='score-90+';     EMOJI='🟢'
+          elif (( SCORE >= 80 )); then BRACKET='score-80-89';   EMOJI='🟡'
+          elif (( SCORE >= 70 )); then BRACKET='score-70-79';   EMOJI='🟠'
+          else                         BRACKET='score-below-70'; EMOJI='🔴'
+          fi
+
+          YES="⚠️ [yes](${REVIEW_URL})"
+          printf '%s' "$REVIEW_BODY" | grep -qi  'No security concerns' && SEC="none ✅"   || SEC="$YES"
+          printf '%s' "$REVIEW_BODY" | grep -qi  'No major issues'      && MAJOR="none ✅" || MAJOR="$YES"
+          printf '%s' "$REVIEW_BODY" | grep -qiE 'Key issues to review' && MINOR="$YES"    || MINOR="none ✅"
+
+          case "$EVENT_NAME" in
+            issue_comment)
+              CMD=$(printf '%s' "$COMMENT_BODY" | grep -oE '^/[a-zA-Z]+' | head -1)
+              [[ -z "$CMD" ]] && CMD='comment'
+              TRIGGER_DESC="\`${CMD}\` by @${COMMENT_USER}"
+              SPECIFIC=" · [comment](${COMMENT_URL})" ;;
+            pull_request|pull_request_target)
+              TRIGGER_DESC="\`pull_request.${EVENT_ACTION}\`"
+              [[ -n "$HEAD_SHA" && "$HEAD_SHA" != "null" ]] \
+                && SPECIFIC=" · [commit ${HEAD_SHA:0:7}](https://github.com/${REPO}/commit/${HEAD_SHA})" \
+                || SPECIFIC="" ;;
+            *) TRIGGER_DESC="\`${EVENT_NAME}\`"; SPECIFIC="" ;;
+          esac
+
+          # Use high_stakes_model label when applicable
+          [[ "$HIGH_STAKES" == "true" ]] && ACTIVE_MODEL="$HS_MODEL" || ACTIVE_MODEL="$MODEL"
+          MODEL_SHORT="${ACTIVE_MODEL##*/}"
+
+          RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          NOW_UTC=$(date -u '+%Y-%m-%d %H:%M UTC')
+          _tz="${DISPLAY_TZ:-}"
+          # Fall back to project.timezone from config if DISPLAY_TZ repo var is unset
+          [[ -z "$_tz" ]] && _tz="${TIMEZONE:-}"
+          if [[ -n "$_tz" ]]; then
+            NOW_LOCAL=$(TZ="$_tz" date '+%Y-%m-%d %H:%M %Z')
+            NOW_DISPLAY="${NOW_LOCAL} / ${NOW_UTC}"
+          else
+            NOW_DISPLAY="$NOW_UTC"
+          fi
+
+          gh pr view "$PR_NUM" --json body --jq .body --repo "${REPO}" > /tmp/pr-body-current.md
+          sed -i.bak '/<!-- argos-status:start -->/,/<!-- argos-status:end -->/d' /tmp/pr-body-current.md
+          rm -f /tmp/pr-body-current.md.bak
+
+          {
+            echo '<!-- argos-status:start -->'
+            echo "> ${EMOJI} **PR-Agent Score: ${SCORE}** \`${BRACKET}\` · model: \`${MODEL_SHORT}\`"
+            echo "> 🔒 **Security:** ${SEC} · ⚡ **Major:** ${MAJOR} · 🔍 **Minor:** ${MINOR}"
+            echo "> **Triggered by** ${TRIGGER_DESC}${SPECIFIC} · run [#${RUN_ID}](${RUN_URL}) · ${NOW_DISPLAY}"
+            echo '<!-- argos-status:end -->'
+            echo
+          } > /tmp/pr-body-banner.md
+
+          cat /tmp/pr-body-banner.md /tmp/pr-body-current.md > /tmp/pr-body-new.md
+          gh pr edit "$PR_NUM" --body-file /tmp/pr-body-new.md --repo "${REPO}"
+          echo "Banner injected (score $SCORE)"
+
+      # ── Commit status check ──────────────────────────────────────────────────
+      # Green = PR-Agent ran and returned a score, OR the PR diff is entirely
+      #         covered by the repo's .pr_agent.toml [ignore] globs/regex — then
+      #         pr-agent logs "Empty diff for PR", reviews nothing, and no score
+      #         is expected (e.g. a docs-only PR /review'd by hand; slash
+      #         commands bypass the skip_paths gate on purpose).
+      # Red   = no score with a reviewable diff — crashed or returned empty,
+      #         not a clean pass.
+      #
+      # "Returned a score" means A SCORE FROM THIS RUN (#433). Every lookup
+      # below is bounded by steps.runstart.outputs.run_start; a Reviewer Guide
+      # comment left by an earlier run is invisible here. Without that bound a
+      # crash inherited the last green score and reported it as its own.
+      - name: PR-Agent review status check
+        if: always() && steps.gate.outputs.should_skip != 'true' && steps.cfg.outputs.status_check == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]] && { echo "No PR — skip"; exit 0; }
+
+          SHA="${{ github.event.pull_request.head.sha }}"
+          if [[ -z "$SHA" || "$SHA" == "null" ]]; then
+            SHA=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)
+          fi
+
+          # #433: the score MUST come from a review comment this run produced.
+          # Unbounded, a crashed run read the previous run's Reviewer Guide
+          # comment and reported its score as a pass.
+          RUN_START="${{ steps.runstart.outputs.run_start }}"
+          [[ -z "$RUN_START" ]] && { echo "::error::missing run-start anchor (#433)"; exit 1; }
+          gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUM/comments" --jq '.[]' \
+            | jq -s '.' > /tmp/pr-comments-status.json
+          BODY=$(jq -r --arg since "$RUN_START" \
+            '[.[] | select(.user.login=="github-actions[bot]")
+                  | select(.updated_at >= $since)
+                  | select(.body | contains("Reviewer Guide"))] | last.body // ""' \
+            /tmp/pr-comments-status.json)
+          SCORE=$(printf '%s' "$BODY" | grep -oiE 'score[^0-9]{0,20}[0-9]{1,3}' | grep -oE '[0-9]{1,3}' | head -1)
+
+          if [[ -n "$SCORE" ]]; then
+            gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+              -f state=success -f context="pr-agent/review" \
+              -f description="Reviewed — score $SCORE" >/dev/null
+            exit 0
+          fi
+
+          # No score. Distinguish "nothing reviewable" from a genuine crash:
+          # pr-agent drops [ignore]-matched files before reviewing (see its
+          # algo/file_filter.py: fnmatch.translate + re.match for glob, plain
+          # re.match for regex) — mirror that filter over the PR's changed
+          # files. Any matcher error falls through to the failure path, so a
+          # bug here can only reproduce today's behaviour, never mask a crash.
+          gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
+            --json files --jq '[.files[].path]' > /tmp/pr-files.json
+
+          python3 << 'PYEOF'
+          import fnmatch, json, re
+
+          def read_ignore_section(path):
+              # tomllib is 3.11+; self-hosted runners (vars.CI_RUNNER) may be older,
+              # so fall back to extracting the [ignore] glob/regex string arrays.
+              try:
+                  import tomllib
+                  with open(path, 'rb') as f:
+                      return tomllib.load(f).get('ignore', {})
+              except ImportError:
+                  text = open(path).read()
+                  m = re.search(r'^\[ignore\]\s*$(.*?)(?=^\[|\Z)', text, re.M | re.S)
+                  section = m.group(1) if m else ''
+                  out = {}
+                  for key in ('glob', 'regex'):
+                      arr = re.search(rf'^{key}\s*=\s*\[(.*?)\]', section, re.M | re.S)
+                      if arr:
+                          out[key] = [a or b for a, b in
+                                      re.findall(r"'([^']*)'|\"([^\"]*)\"", arr.group(1))]
+                  return out
+
+          all_ignored = False
+          try:
+              ignore = read_ignore_section('.pr_agent.toml')
+              pats  = [re.compile(fnmatch.translate(g)) for g in ignore.get('glob', [])]
+              pats += [re.compile(r) for r in ignore.get('regex', [])]
+              with open('/tmp/pr-files.json') as f:
+                  files = json.load(f)
+              if files and pats:
+                  all_ignored = all(any(p.match(fp) for p in pats) for fp in files)
+          except Exception as e:  # no .pr_agent.toml / bad pattern
+              print(f'ignore-glob check unavailable ({e}) — treating diff as reviewable')
+
+          with open('/tmp/all_ignored.txt', 'w') as out:
+              out.write('true' if all_ignored else 'false')
+          PYEOF
+
+          if [[ "$(cat /tmp/all_ignored.txt)" == "true" ]]; then
+            gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+              -f state=success -f context="pr-agent/review" \
+              -f description="Nothing reviewable — all changed files match .pr_agent.toml ignore globs" >/dev/null
+            gh pr comment "$PR_NUM" --repo "${{ github.repository }}" \
+              --body "> ℹ️ **PR-Agent had nothing to review** — every changed file matches this repo's \`.pr_agent.toml\` \`[ignore]\` globs (docs/config-only diff), so no score is expected. Not a failure."
+            echo "Empty-after-ignore diff — status set to success"
+            exit 0
+          fi
+
+          gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+            -f state=failure -f context="pr-agent/review" \
+            -f description="No score parsed — review failed or empty (not a clean pass)" >/dev/null
+          gh pr comment "$PR_NUM" --repo "${{ github.repository }}" \
+            --body "> ❌ **PR-Agent produced no score** — it likely crashed or returned an empty review. Re-run with \`/review\`."
+          exit 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,7 +33,12 @@ env:
 
 jobs:
   pr-review:
-    uses: Performant-Labs/playbook/.github/workflows/pr-review-reusable.yml@main
+    # Local vendored copy of playbook's pr-review-reusable.yml. A PUBLIC repo
+    # cannot call a reusable workflow in a PRIVATE one ("workflow was not
+    # found" at run time, even with playbook's reusable-workflow access set to
+    # "organization") -- same fix as performantlabs.com. See the header of
+    # ./pr-review-reusable.yml.
+    uses: ./.github/workflows/pr-review-reusable.yml
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,44 @@
+# Thin caller — copy this to .github/workflows/pr-review.yml in the consuming repo.
+#
+# Post-centralization (#120), all review LOGIC lives in the reusable workflow:
+#   Performant-Labs/playbook/.github/workflows/pr-review-reusable.yml
+# This caller only owns the two things a caller MUST own: the event triggers and
+# the concurrency group. All behaviour is driven by .agents/pr-review.yml in the
+# calling repo. Do not inline the reusable's logic here.
+#
+# NOTE: `cancel-in-progress` is event-scoped on purpose — see the concurrency
+# block below and the pr-reviewer README §"Issue comment trigger fires on all
+# slash commands". A comment must never cancel a running review.
+
+name: PR-Agent Spec Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Event-scoped cancellation. A push (`synchronize`) SHOULD cancel a superseded
+  # in-flight review — the new commit makes it stale. But a PR comment must NEVER
+  # cancel a running review: GitHub evaluates workflow-level `concurrency` at run
+  # CREATION, before any job-level `if`, so a comment-triggered run (ordinary reply,
+  # Tugboat "preview ready", or a `/review` buried mid-body) would abort an active
+  # review if this were an unconditional `true`, freezing the PR-Agent score.
+  cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  pr-review:
+    uses: Performant-Labs/playbook/.github/workflows/pr-review-reusable.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: write
+    secrets:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,112 @@
+# .pr_agent.toml — PR-Agent configuration for FreeToken-Intel
+# Part of playbook/pipelines/pr-reviewer/ (Universal Configurable PR Reviewer)
+#
+# Docs: https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+
+[config]
+model = "deepseek/deepseek-v4-pro"
+fallback_models = ["deepseek/deepseek-v4-pro"]
+verbosity_level = 1
+max_description_tokens = 1500
+max_commits_tokens = 1500
+custom_model_max_tokens = 131072
+max_model_tokens = 64000
+
+[pr_reviewer]
+require_score_review = true
+require_tests_review = true
+require_security_review = true
+require_focused_review = false
+require_ticket_analysis_review = false
+num_code_suggestions = 4
+inline_code_comments = true
+automatic_review = true
+persistent_comment = true
+final_update_message = false
+extra_instructions = """
+You are reviewing PRs for FreeToken-Intel: edge-native MoE serving on Intel Arc Pro B70
+(SYCL / XPU) with OpenAI- and Anthropic-compatible APIs. This repo has no CLAUDE.md or
+skills/ directory yet — ground your review in what actually exists in the repo instead:
+
+MANDATORY CONTEXT — read before scoring:
+1. pyproject.toml's [tool.pytest.ini_options] markers: `xpu` (needs real Intel GPU
+   hardware, never runs in CI), `slow` (long kernel sweeps / real-checkpoint reads),
+   `needs_weights` (needs FREETOKEN_TEST_MODEL pointing at a local checkpoint).
+2. tests/README.md — which test selection runs where.
+3. .github/workflows/ci.yml — CI runs `pytest -m "not xpu and not slow"` on the
+   self-hosted Uranus fleet's SYSTEM Python (baked CPU PyTorch), NOT via
+   actions/setup-python. A PR must not reintroduce actions/setup-python on the
+   self-hosted path -- that silently defeats the baked torch and reduces the whole
+   torch-dependent test suite (test_engine_loop, test_models_loader,
+   test_moe_offload_*) to import-time skips. = BLOCKING if reintroduced.
+
+PRIMARY JOB — correctness and drift detection:
+1. Do new/changed tests correctly declare `xpu`, `slow`, or `needs_weights` markers
+   when they need real GPU hardware, long sweeps, or a real checkpoint? A test that
+   silently needs hardware/weights without the marker will pass locally on a
+   GPU-equipped dev box and then hang or fail unpredictably in CI. = BLOCKING.
+2. Are secrets committed (credentials, API keys, tokens)? = BLOCKING.
+3. Are there missing tests for new routes, public functions, or new model/backend
+   registrations (see tests/test_registries.py's pattern)? = BLOCKING.
+4. Does new code path assume XPU/oneAPI availability without a CPU fallback or a
+   clear `xpu`-marked test boundary? Flag as BLOCKING unless clearly CPU-only by
+   design (mirrors test_serve_spine.py's "device_report_line_is_shared" pattern).
+
+SECONDARY JOB — quality:
+- Security issues (auth bypass, injection, rate-limiting, CSRF) in server/ code.
+- Runtime regressions (race conditions, leaks, unbounded queries) in the MoE
+  offload/cache paths (test_moe_offload_cache.py, test_moe_offload_forward.py).
+
+REVIEW STYLE:
+- Distinguish BLOCKING (correctness, missing/misdeclared test markers, security,
+  missing required tests, CI-defeating changes) from NIT (style, preference).
+  Every BLOCKING finding must cite the file/line it's grounded in.
+- Do not suggest rewrites or alternative architectures unrelated to the diff.
+- When in doubt between blocking and nit, prefer nit — false positives erode trust.
+
+OUTPUT SHAPE:
+- Lead with a one-line verdict: BLOCKING / NITS / CLEAN.
+- Then the standard PR-Agent sections.
+- Inline comments focus on exact lines violating a cited rule.
+"""
+
+[pr_code_suggestions]
+num_code_suggestions = 4
+summarize = true
+extra_instructions = """
+Only suggest changes that fix a correctness/security/test-marker issue described above.
+Every suggestion must cite its source (file/line or pytest marker convention).
+Do not suggest refactors or alternative patterns not required by the above.
+"""
+
+[pr_description]
+publish_description_as_comment = false
+add_original_user_description = true
+keep_original_user_title = true
+
+[github]
+publish_inline_comments = true
+publish_output = true
+publish_output_progress = false
+
+[github_action_config]
+auto_review = true
+auto_improve = false
+pr_actions = ["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]
+
+[litellm]
+drop_params = true
+max_model_len = 131072
+
+[ignore]
+glob = [
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'dist/**',
+  'coverage/**',
+  '*.min.js',
+  '*.min.css',
+  '.venv/**',
+  '.venv-xpu/**',
+]


### PR DESCRIPTION
<!-- argos-status:start -->
> 🔴 **PR-Agent Score: 55** `score-below-70` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/60#issuecomment-5443887636) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 6534d41](https://github.com/Performant-Labs/FreeToken-Intel/commit/6534d41cbd255d7ce1b91be0acf4817ec6153743) · run [#33106988006](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33106988006) · 2026-08-27 13:16 MDT / 2026-08-27 19:16 UTC
<!-- argos-status:end -->

### **User description**

### **User description**

### **User description**
## Summary
- Wires up the [Universal Configurable PR Reviewer](https://github.com/Performant-Labs/playbook/blob/main/pipelines/pr-reviewer/README.md) CI path for this repo: PR-Agent posts a structured review on every PR using DeepSeek V4 Pro.
- `.pr_agent.toml`'s `extra_instructions` is customised for this repo (no `CLAUDE.md`/`skills/` yet) — grounds review in the actual pytest marker conventions (`xpu`/`slow`/`needs_weights`) and calls out that CI must keep using the self-hosted fleet's system Python (#59) rather than `actions/setup-python`.
- Local review, dual review, DCO, and PR template left off — not requested.

## ⚠️ Needs a decision before this works
`DEEPSEEK_API_KEY`'s org secret visibility is `"private"` (auto-available to private repos only). This repo is **public**, so it currently has **no access** to that secret — the PR-Agent job will fail without it.

Did not fix this myself: switching visibility to `"selected"` requires enumerating every other private repo currently relying on the automatic `"private"` grant, and getting that list wrong silently cuts them off (same risk class as the `CI_RUNNER` org variable scare earlier). This needs a human call on how to scope it — options:
1. Add `FreeToken-Intel` to a `"selected"` list alongside every other current consumer (needs the full list)
2. Set visibility to `"all"` (broadest, simplest, more exposure)
3. Add a repo-level `DEEPSEEK_API_KEY` secret directly on `FreeToken-Intel` with its own value

## Test plan
- [x] `.agents/scripts/check-pr-review-readiness.sh` passes all hard checks
- [ ] Once the secret is scoped, open/push to a PR and confirm the `pr-agent` job appears in Checks, a score banner lands in the PR description, and a `score-*` label is applied


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add PR-Agent automated review workflow using DeepSeek V4 Pro.

- Vendor reusable workflow and repo-specific `.pr_agent.toml`.

- Add readiness, setup, and review scripts for PR review methods.

- Fix self-hosted CI to preserve system Python and baked PyTorch.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>pr-review-reusable.yml</strong><dd><code>Adds vendored reusable PR-Agent review workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-20d1ba61ec95b7f1ef8bb8a0ffa3ecc775e82704710bb4fc9cb5997614cf4c2f">+713/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.yml</strong><dd><code>Adds thin caller workflow for PR-Agent review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>check-pr-review-readiness.sh</strong><dd><code>Adds readiness check script for PR review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-77e11469ceb1bab85178db822090bbf34db60bb0313e5eda2efed102960211b6">+237/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>setup-pr-review.sh</strong><dd><code>Adds interactive PR review setup wizard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-b3c08234cc3565a9ab8b1f29bbd224d7aba56bb948f8561ae4465914a54089b7">+477/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.sh</strong><dd><code>Adds local Claude PR review script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-562fc772021536c24e03cc8b6a7ca11b56d9b7ee3cafdfce25f77532f498c451">+215/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shell-aliases.sh</strong><dd><code>Adds shell alias template for PR review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-a6462048a7f356fa5dfbc32c3a1f3db60db0253acba4be31d8d87535046b7afe">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>.pr_agent.toml</strong><dd><code>Adds repo-specific PR-Agent configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.yml</strong><dd><code>Adds PR review config enabling CI path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-0b6cdbc481d03491b022d4376467af654be2e29c7fcb8c9a695a7e5ce27d4f1e">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Conditions setup-python to preserve system torch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add vendored PR-Agent reusable workflow and thin caller

- Add `.pr_agent.toml` with repo-specific pytest marker guidance

- Add setup, readiness-check, local review, and alias scripts

- Fix self-hosted CI by skipping `actions/setup-python` so baked torch tests run


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["ci.yml"] -- "skips setup-python on self-hosted" --> B["system Python baked torch restored"]
    C["pr-review.yml"] -- "calls vendored" --> D["pr-review-reusable workflow"]
    E[".pr_agent.toml"] -- "repo-specific rules" --> D
    F[".agents/pr-review.yml"] -- "drives config" --> D
    G[".agents/scripts"] -- "setup/validate" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>check-pr-review-readiness.sh</strong><dd><code>Verify enabled PR review methods and prerequisites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-77e11469ceb1bab85178db822090bbf34db60bb0313e5eda2efed102960211b6">+237/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.sh</strong><dd><code>Run local Spec-enforcer review via claude</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-562fc772021536c24e03cc8b6a7ca11b56d9b7ee3cafdfce25f77532f498c451">+215/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>setup-pr-review.sh</strong><dd><code>Interactive wizard generating PR review config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-b3c08234cc3565a9ab8b1f29bbd224d7aba56bb948f8561ae4465914a54089b7">+477/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shell-aliases.sh</strong><dd><code>Shell alias wrapper for local PR review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-a6462048a7f356fa5dfbc32c3a1f3db60db0253acba4be31d8d87535046b7afe">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>pr-review.yml</strong><dd><code>Enable PR-Agent CI path with DeepSeek model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-0b6cdbc481d03491b022d4376467af654be2e29c7fcb8c9a695a7e5ce27d4f1e">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review-reusable.yml</strong><dd><code>Vendored reusable PR-Agent workflow logic with scoring</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-20d1ba61ec95b7f1ef8bb8a0ffa3ecc775e82704710bb4fc9cb5997614cf4c2f">+713/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.yml</strong><dd><code>Thin caller triggering PR-Agent review workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.pr_agent.toml</strong><dd><code>PR-Agent configuration with pytest marker conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+112/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Skip setup-python on self-hosted fleet to use baked torch</code></dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add PR-Agent DeepSeek V4 Pro review workflow

- Configure `.pr_agent.toml` with repo-specific pytest guidance

- Add setup, readiness, and local review scripts

- Fix self-hosted CI skipping `setup-python` to preserve torch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR events"] -- "trigger" --> B[".github/workflows/pr-review.yml"]
  B -- "calls" --> C["pr-review-reusable.yml"]
  C -- "reads config" --> D[".agents/pr-review.yml"]
  C -- "posts review/score" --> E["PR-Agent DeepSeek V4 Pro"]
  F["ci.yml test job"] -- "skips setup-python on self-hosted" --> G["system Python with baked torch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>check-pr-review-readiness.sh</strong><dd><code>Add readiness checker for enabled review methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-77e11469ceb1bab85178db822090bbf34db60bb0313e5eda2efed102960211b6">+237/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.sh</strong><dd><code>Add local spec-enforcer PR review script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-562fc772021536c24e03cc8b6a7ca11b56d9b7ee3cafdfce25f77532f498c451">+215/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>setup-pr-review.sh</strong><dd><code>Add interactive PR review setup wizard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-b3c08234cc3565a9ab8b1f29bbd224d7aba56bb948f8561ae4465914a54089b7">+477/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shell-aliases.sh</strong><dd><code>Add shell alias for local PR review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-a6462048a7f356fa5dfbc32c3a1f3db60db0253acba4be31d8d87535046b7afe">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review-reusable.yml</strong><dd><code>Vendor reusable PR-Agent review workflow logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-20d1ba61ec95b7f1ef8bb8a0ffa3ecc775e82704710bb4fc9cb5997614cf4c2f">+713/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.yml</strong><dd><code>Add thin caller workflow for PR review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pr-review.yml</strong><dd><code>Configure PR-Agent CI path for repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-0b6cdbc481d03491b022d4376467af654be2e29c7fcb8c9a695a7e5ce27d4f1e">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.pr_agent.toml</strong><dd><code>Configure PR-Agent model and repo-specific instructions</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+112/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Skip setup-python on self-hosted fleet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/60/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


