### PR TITLE
probe: capture pre-flight actionlint log (DELETE ME)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,50 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual re-run without a new commit (e.g. re-run a flaky pre-flight, or the
+  # red-team validation of a gate on a fixed tree). The pre-flight job reads
+  # the workflow files out of the checked-out tree, so a dispatch exercises the
+  # exact same path as a push/PR.
+  workflow_dispatch:
+
+# Cancel a stale in-flight run when a newer commit lands on the same ref, so a
+# force-push or a rapid follow-up push doesn't leave two full runs racing to
+# completion. `github.repository` is included (not just `github.workflow`) so
+# the group is unique per (repo, ref) and can't collide with another repo that
+# shares this workflow name. Parity with the playbook's ci-reusable.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  pre-flight:
+    name: Pre-flight (actionlint)
+    # Repo is public: this gate runs on GitHub-hosted, NEVER on the self-hosted
+    # fleet. A fork PR must never execute on owned hardware, and the org
+    # CI_RUNNER variable is a private-org mechanism that does not apply to a
+    # public repo. (The test job below is the exception that opts onto the
+    # fleet for the baked torch -- it only ever runs on our own runners, never
+    # for untrusted fork content, so that's safe.)
+    #
+    # actionlint is a HARD FAIL: a workflow file that fails lint is the same
+    # failure class as the playbook's "drift announces itself" rule. The job
+    # has NO `needs:` and is the first job, so a broken workflow file fails
+    # fast and cheap before any install/compile/test step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint workflow files (actionlint, pinned)
+        run: |
+          # Pin BOTH the download script (v1.7.12 tag, not a floating `main`)
+          # and the tool version it fetches (1.7.12) so the gate is
+          # reproducible and never silently picks up a newer actionlint with a
+          # different rule set. The script's own default is 1.7.12, but we pass
+          # it explicitly -- the pin must live in the workflow file, not be
+          # inherited from the upstream script's `version="..."` default, which
+          # someone upstream could bump.
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+          ./actionlint .github/workflows/*.yml
+
   test:
     # Opt this repo onto the self-hosted Uranus fleet via the org CI_RUNNER
     # variable (value: self-hosted-linux). Until that variable is scoped to this


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 7d47e3a](https://github.com/Performant-Labs/FreeToken-Intel/commit/7d47e3afee9d8778cb69d9ffa410242904174942) · run [#33113415624](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33113415624) · 2026-08-27 14:30 MDT / 2026-08-27 20:30 UTC
<!-- argos-status:end -->

### **User description**
Probe: my token cannot read the ci workflow logs (log_url is 404/MISSING for the ci run). This PR carries the same ci.yml pre-flight change so the PR-Agent (pr-review) run -- whose logs ARE readable -- can be inspected. If the pre-flight actionlint step's output is echoed, I can finally see the real error. DELETE THIS PR after diagnosis. It is NOT for merge.


___

### **PR Type**
Enhancement


___

### **Description**
- Add pre-flight actionlint hard-fail job for workflow files.

- Add workflow_dispatch trigger and concurrency cancellation.

- Pin actionlint script and tool version to v1.7.12.

- Run pre-flight on GitHub-hosted ubuntu-latest.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".github/workflows/ci.yml"] --> B["Add workflow_dispatch trigger"]
  A --> C["Add concurrency cancel-in-progress"]
  A --> D["Add pre-flight actionlint job"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add pre-flight actionlint lint workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add <code>workflow_dispatch</code> trigger for manual re-runs.<br> <li> Add <code>concurrency</code> group with <code>cancel-in-progress</code> to avoid stale runs.<br> <li> Add <code>pre-flight</code> job running pinned actionlint v1.7.12 on <code>ubuntu-latest</code>.<br> <li> Document runner security and lint-failure rationale.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/62/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


