### PR TITLE
ci(preflight): ignore the vendored pr-review shellcheck false-positives (#43)

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,33 @@
+# actionlint configuration for the pre-flight job (see ci.yml).
+#
+# actionlint runs shellcheck and pyflakes on every `run:` script it finds. On
+# this repo's runners those tools are installed, so a bare `actionlint`
+# invocation lints the bash in every workflow -- but shellcheck does not
+# understand GitHub Actions' `${{ }}` expression syntax and reports it as
+# SC2016 ("expressions don't expand in single quotes") whenever a `${{ ... }}`
+# expression sits inside a single-quoted string.
+#
+# That is a FALSE POSITIVE, and suppressing it is correct, not a workaround:
+# the single quotes are load-bearing. In the vendored playbook pr-review
+# workflow, `${{ }}` expressions wrap `--jq '...'` filter arguments, which MUST
+# be single-quoted -- double-quoting them would let the shell expand the
+# expression before `gh` ever saw the jq filter, breaking the jq. (The playbook
+# ships no actionlint config and tolerates the noise because its pre-flight is
+# not a required check; here pre-flight is a real gate, so we silence the false
+# positives explicitly instead of letting a required check fail on a lint
+# artifact.)
+#
+# The `ignore` list holds message REGEXES (matched with Go regexp, like the
+# `-ignore` flag). SC2016 is the ONLY shellcheck code the vendored file
+# triggers, and it fires only on those two load-bearing `${{ }}`-in-single-
+# quotes sites, so this stays narrow: every other check -- YAML/syntax errors,
+# unknown actions, undefined `needs:` targets, invalid `runs-on`, and genuine
+# shellcheck findings (unquoted expansions, etc.) -- still fails pre-flight.
+#
+# pr-review-reusable.yml is a vendored COPY of the playbook's file, changed
+# only by a deliberate re-vendoring; a new genuine shellcheck finding there
+# would stand out against this narrow ignore and be reviewed at that point.
+paths:
+  .github/workflows/pr-review-reusable.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC2016:.*'


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 2b45aeb](https://github.com/Performant-Labs/FreeToken-Intel/commit/2b45aebfa07e79809ebfbd6760a1ce5c5f53d729) · run [#33115124217](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33115124217) · 2026-08-27 14:50 MDT / 2026-08-27 20:50 UTC
<!-- argos-status:end -->

### **User description**
## Context
The pre-flight actionlint job (already on main from the first #43 pass) **fails** on runners: actionlint runs **shellcheck** on every run: script, and on this fleet's runners shellcheck is installed, so it flags the **vendored** playbook pr-review workflow (pr-review-reusable.yml, added in #60) at lines 178 & 526 as **SC2016** ("expressions don't expand in single quotes").

Those are **false positives**: the single quotes wrap `gh --jq '...'` filter args that MUST be single-quoted, and shellcheck doesn't understand GitHub Actions' ${{ }} syntax. The playbook itself ships no actionlint config (its pre-flight isn't a required check, so it tolerates the noise). Here pre-flight is a real gate, so we silence the false positives explicitly.

## Why the first pass looked green locally but failed in CI
My local actionlint had **no shellcheck/pyflakes installed**, so those rules were silently skipped and it reported 0 findings. On the runner they're present, so the real findings appear. Installing shellcheck locally reproduces the exact 2 findings.

## This PR
Adds `.github/actionlint.yml` with a **path-scoped** ignore: only SC2016 findings in `pr-review-reusable.yml` are suppressed.

## Verified narrow (not a blanket hush)
- With the config: the 2 vendored SC2016 findings are gone, actionlint exit 0.
- A genuine SC2016 in any **other** workflow file (e.g. a real single-quoted \$var) **still fails** pre-flight.
- All non-shellcheck checks (undefined needs, orphan steps, bad runs-on, unknown actions) are unaffected and still fail.

## Acceptance (#43)
- [x] pre-flight job is first in ci.yml, runs on every PR/push, hard-fails, no needs.
- [x] actionlint pinned (v1.7.12 script tag + 1.7.12 tool version) in ci.yml.
- [ ] Live green: pre-flight passes on this PR (the config suppresses the 2 false-positives).
- [x] A deliberately malformed workflow fails pre-flight (validated locally + on a scratch run).

Closes #43


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `.github/actionlint.yml` path-scoped ignore

- Suppress only SC2016 in vendored `pr-review-reusable.yml`

- Keep other actionlint checks failing normally

- Document `${{ }}` single-quote false-positive rationale


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add .github/actionlint.yml"] --> B["Path-scoped ignore for pr-review-reusable.yml"]
  B --> C["Suppress SC2016 false positives"]
  C --> D["Keep all other actionlint checks active"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionlint.yml</strong><dd><code>Add actionlint config to ignore vendored SC2016 false positives</code></dd></summary>
<hr>

.github/actionlint.yml

<ul><li>Adds path-scoped <code>ignore</code> for <code>.github/workflows/pr-review-reusable.yml</code><br> <li> Suppresses shellcheck SC2016 false positives from <code>${{ }}</code> inside <br>single-quoted <code>--jq</code> filters<br> <li> Documents why the ignore is narrow and preserves all other checks</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/63/files#diff-c16714eb2a810ddc4b5b5be4cbc95e8512e26c917b31658839f16fdcd1486ace">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


