### PR TITLE
RED-TEAM (do not merge): broken workflow to prove pre-flight fails

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,33 @@
+# actionlint configuration for the pre-flight job (see ci.yml).
+#
+# actionlint runs shellcheck and pyflakes on every `run:` script it finds. On
+# this repo's runners those tools are installed, so a bare `actionlint`
+# invocation lints the bash in every workflow -- but shellcheck does not
+# understand GitHub Actions' `${{ }}` expression syntax and reports it as
+# SC2016 ("expressions don't expand in single quotes") whenever a `${{ ... }}`
+# expression sits inside a single-quoted string.
+#
+# That is a FALSE POSITIVE, and suppressing it is correct, not a workaround:
+# the single quotes are load-bearing. In the vendored playbook pr-review
+# workflow, `${{ }}` expressions wrap `--jq '...'` filter arguments, which MUST
+# be single-quoted -- double-quoting them would let the shell expand the
+# expression before `gh` ever saw the jq filter, breaking the jq. (The playbook
+# ships no actionlint config and tolerates the noise because its pre-flight is
+# not a required check; here pre-flight is a real gate, so we silence the false
+# positives explicitly instead of letting a required check fail on a lint
+# artifact.)
+#
+# The `ignore` list holds message REGEXES (matched with Go regexp, like the
+# `-ignore` flag). SC2016 is the ONLY shellcheck code the vendored file
+# triggers, and it fires only on those two load-bearing `${{ }}`-in-single-
+# quotes sites, so this stays narrow: every other check -- YAML/syntax errors,
+# unknown actions, undefined `needs:` targets, invalid `runs-on`, and genuine
+# shellcheck findings (unquoted expansions, etc.) -- still fails pre-flight.
+#
+# pr-review-reusable.yml is a vendored COPY of the playbook's file, changed
+# only by a deliberate re-vendoring; a new genuine shellcheck finding there
+# would stand out against this narrow ignore and be reviewed at that point.
+paths:
+  .github/workflows/pr-review-reusable.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC2016:.*'

--- a/.github/workflows/redteam-broken.yml
+++ b/.github/workflows/redteam-broken.yml
@@ -1,0 +1,8 @@
+name: redteam-broken
+on: [push]
+jobs:
+  broken:
+    runs-on: ubuntu-latest
+    needs: [a-job-that-does-not-exist]
+    steps:
+      - name: orphan step (no uses, no run)


### PR DESCRIPTION
<!-- argos-status:start -->
> 🔴 **PR-Agent Score: 5** `score-below-70` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/64#issuecomment-5445119954) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 8b74ccb](https://github.com/Performant-Labs/FreeToken-Intel/commit/8b74ccb33bb6f7e890cac6576141140c361405f2) · run [#33115583886](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33115583886) · 2026-08-27 14:56 MDT / 2026-08-27 20:56 UTC
<!-- argos-status:end -->

### **User description**
Scratch PR for the #43 red-team acceptance test. Contains a deliberately malformed workflow (undefined needs, orphan step). Expected: the pre-flight actionlint job FAILS and the test job is SKIPPED (never starts). DELETE after validation.


___

### **PR Type**
Tests, Other


___

### **Description**
- Add actionlint config ignoring SC2016 false positives.

- Add deliberately broken workflow with undefined needs.

- Expected: pre-flight fails, test job skips.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".github/actionlint.yml"] -- "scoped SC2016 ignore" --> B["Pre-flight actionlint"]
  C[".github/workflows/redteam-broken.yml"] -- "undefined needs / orphan step" --> B
  B -- "expected fail" --> D["Test job skipped"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionlint.yml</strong><dd><code>Add scoped shellcheck SC2016 ignore configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actionlint.yml

<ul><li>Add path-scoped ignore for SC2016 in <br><code>.github/workflows/pr-review-reusable.yml</code><br> <li> Document why single quotes are load-bearing for jq filters<br> <li> Limit ignore to only that vendored file and code</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/64/files#diff-c16714eb2a810ddc4b5b5be4cbc95e8512e26c917b31658839f16fdcd1486ace">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redteam-broken.yml</strong><dd><code>Add intentionally broken test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/redteam-broken.yml

<ul><li>Add deliberately broken workflow named <code>redteam-broken</code><br> <li> Set <code>needs</code> to non-existent job <code>a-job-that-does-not-exist</code><br> <li> Add orphan step with no <code>uses</code> or <code>run</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/64/files#diff-fc86befea65131e420909e37a7d4ccf3386915f86c76a6093c03f7fe51b41afd">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


