### PR TITLE
RED-TEAM(#45, do not merge): torch in [project] deps must trip the venv-contract guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,40 +225,110 @@ jobs:
           path: ${{ runner.temp }}/gitleaks-report.json
           retention-days: 14
 
-  test:
-    # Opt this repo onto the self-hosted Uranus fleet via the org CI_RUNNER
-    # variable (value: self-hosted-linux). Until that variable is scoped to this
-    # repo, it falls back to the GitHub-hosted ubuntu-latest runner. See
-    # pl-ops-handbook > platform-ops > github-runners.md ("Repo opt-in").
-    # The fleet image bakes a CPU PyTorch (pl-runner >= 1.66.1) into the
-    # runner's SYSTEM Python (/usr/bin/python3), so the torch tests
-    # (test_engine_loop, test_moe_offload_*, test_models_loader) can run here
-    # instead of being skipped on a torch-less runner -- but only if the job
-    # actually uses that system interpreter. actions/setup-python always
-    # downloads and uses its own separate CPython build under
-    # /opt/hostedtoolcache (verified via a run log: "Version 3.12 was not
-    # found in the local cache" -> downloads python-3.12.14-linux-24.04-x64.tar.gz
-    # every time, since these runners are ephemeral), which has no relationship
-    # to the image's baked torch at all. Running it on self-hosted silently
-    # defeated the whole point of baking torch in: every torch-marked test file
-    # skipped with "could not import torch", 4 skips standing in for ~22 actual
-    # tests never collected. So: skip setup-python entirely on the self-hosted
-    # fleet (Noble already ships python3.12 + pip on PATH, and the image has
-    # torch); keep it for the ubuntu-latest fallback, which has no baked torch
-    # and needs setup-python to get any Python at all.
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+  ci:
+    name: Typecheck, test, and CLI smoke (CPU)
+    # The main per-PR job. Runs on GitHub-hosted ubuntu-latest -- NOT the
+    # self-hosted fleet. Two reasons:
+    #
+    #   1. Fork safety. This repo is public, so a fork PR's code runs in this
+    #      job. It must never execute on owned hardware, and the org CI_RUNNER
+    #      variable is a private-org mechanism that does not apply here.
+    #      (pre-flight and secret-scan above are on the same footing.)
+    #
+    #   2. The dual-venv contract. This job builds the CPU `.venv` -- which by
+    #      the project's load-bearing separation must NEVER contain torch.
+    #      torch (the XPU build) lives only in the separate `.venv-xpu`. That
+    #      contract is enforced by the CUDA-import guard step below, which fails
+    #      if `import torch` ever succeeds in this venv.
+    #
+    # Python 3.11, not the 3.12 the previous revision used: the dev venvs
+    # (.venv AND .venv-xpu) are both 3.11, so the CPU CI venv must match the
+    # XPU venv's minor to keep wheel tags (cp311) aligned. A CPU venv on a
+    # different minor than the XPU venv is a silent divergence trap. (docs/
+    # dev-setup.md previously said "CI uses 3.12" -- that line is corrected in
+    # the same change.)
+    #
+    # Because this venv has no torch, the torch-dependent tests
+    # (test_engine_loop, test_models_loader, test_moe_offload_*) SKIP here via
+    # their module-level `pytest.importorskip("torch")` -- a clean skip, never
+    # a collection error. Their real coverage now lives on the XPU nightly
+    # (xpu.yml, #50), which runs them on the GPU runner where torch is present.
+    # This is the deliberate trade: per-PR CI stays fork-safe and torch-free;
+    # the torch path is verified on a trusted, main-only schedule instead.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        if: ${{ vars.CI_RUNNER == '' }}
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
+
       - name: Install
-        run: pip install -e ".[dev]"
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e ".[dev]"
+
+      # Typecheck-before-lint ordering (playbook: a lint pass can mask a type
+      # error -- flotilla #236). We have no mypy/ruff yet, so the analogs are
+      # (a) byte-compile every module, then (b) the full CPU test suite.
+      - name: Byte-compile (syntax-class check)
+        run: python -m compileall -q python/
+
+      # Full CPU suite. xpu + slow + needs_weights are all excluded: xpu needs
+      # a GPU (nightly), slow is a long sweep, needs_weights needs a real
+      # checkpoint (FREETOKEN_TEST_MODEL) that CI does not have. The CTRF
+      # reporter (pytest-json-ctrf, installed in Install) writes the machine-
+      # readable result to ctrf/pytest-ctrf.json for the artifact below.
       - name: Unit tests (CPU)
-        run: pytest -m "not xpu and not slow" -q
+        run: |
+          python -m pip install -q pytest-json-ctrf
+          pytest -m "not xpu and not slow and not needs_weights" -q \
+            --ctrf ctrf/pytest-ctrf.json
+
+      # HARD venv-contract guard. The dual-venv split (.venv = CPU, never
+      # torch; .venv-xpu = the only place torch lives) is load-bearing: the
+      # whole CUDA->SYCL premise rests on the CPU side never importing a CUDA/
+      # CPU torch. Nothing else enforces it, so this step does. If `import
+      # torch` SUCCEEDS in the CI venv, someone added torch to [project]
+      # dependencies or [dev] -- that is a contract breach and fails the build
+      # with an explanatory annotation rather than failing opaquely inside a
+      # test.
+      - name: "venv contract: torch must NOT be importable"
+        run: |
+          if python -c "import torch" 2>/dev/null; then
+            echo "::error::venv-contract violated: 'import torch' SUCCEEDED in the CPU CI venv. The dual-venv contract (see docs/dev-setup.md) requires torch to live ONLY in .venv-xpu -- the CPU [.dev]/[project] dependency set must never pull in torch (CUDA or CPU). Remove it; if torch is genuinely needed on the CPU side that is a design change to discuss, not a silent dependency."
+            exit 1
+          fi
+          echo "OK: torch is not importable in the CPU venv (contract holds)."
+
+      # CLI smoke. Hardened from the previous `ft device || true`: on a
+      # GPU-less runner, `ft device` reporting an XPU as available is exactly
+      # the drift this check exists to catch, and `|| true` made it invisible.
+      # A runner that somehow has a GPU is a fleet misconfiguration -- let it
+      # fail loudly instead of silently passing.
       - name: CLI smoke
         run: |
           ft --version
           ft --help
-          ft device || true
+          set -o pipefail
+          ft device | tee device.out
+          grep -q "xpu available: False" device.out \
+            || { echo "::error::ft device did not report 'xpu available: False' on a GPU-less runner -- either the runner unexpectedly has a GPU (fleet misconfiguration) or the device-detection drift this check guards against has regressed."; cat device.out; exit 1; }
+          echo "OK: ft device reports 'xpu available: False'."
+
+      # CTRF artifact. The ONLY continue-on-error in this workflow: an artifact
+      # upload failure (network blip) must never turn a green or red test run
+      # into a confusing third state. if: always() so a failing run still
+      # uploads its report (that is when the report is most needed). 30-day
+      # retention, playbook parity. There is no PR check-run summary for CTRF
+      # (playbook parity) -- reading it today means downloading the artifact.
+      - name: Upload CTRF test report
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctrf-reports
+          path: ctrf/
+          retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,11 +307,18 @@ jobs:
       # the drift this check exists to catch, and `|| true` made it invisible.
       # A runner that somehow has a GPU is a fleet misconfiguration -- let it
       # fail loudly instead of silently passing.
+      #
+      # The assertion reads the tee'd file with a plain `grep` (NO pipe): the
+      # `ft device | tee` pipeline above is kept for human log visibility only.
+      # A `pipefail` + `grep -q` on the same pipe is a latent false-negative --
+      # grep -q exits 0 the moment it finds the match, but the upstream
+      # producer can then die on SIGPIPE, and with pipefail the pipeline's
+      # exit status becomes that producer's non-zero, not grep's 0. So the
+      # pass/fail decision must come from a separate, pipe-free grep.
       - name: CLI smoke
         run: |
           ft --version
           ft --help
-          set -o pipefail
           ft device | tee device.out
           grep -q "xpu available: False" device.out \
             || { echo "::error::ft device did not report 'xpu available: False' on a GPU-less runner -- either the runner unexpectedly has a GPU (fleet misconfiguration) or the device-detection drift this check guards against has regressed."; cat device.out; exit 1; }

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -54,7 +54,7 @@ sudo apt install -y \
   ninja-build \
   curl \
   pkg-config
-python3 --version    # 3.10 or newer (CI uses 3.12)
+python3 --version    # 3.10 or newer (CI uses 3.11)
 ```
 
 `python3-venv` is required for `python3 -m venv`. Without it Ubuntu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "tqdm>=4.66,<5",
     "transformers>=4.45,<6",
     "uvicorn>=0.30,<1",
+    "torch",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared pytest policy for the suite: the "no torch -> no xpu tests" rule.
+
+The load-bearing rule is the **dual-venv contract**: the CPU venv (``.venv``,
+which the per-PR CI job builds) must *never* contain ``torch``; the torch (XPU)
+build lives only in ``.venv-xpu``. The CI job enforces the install side of that
+contract with a hard ``import torch`` guard. This conftest is the
+collection-time half: when torch is absent (i.e. we are in the CPU venv), any
+``xpu``-marked test is *deselected with a clear reason* instead of erroring at
+import/call time.
+
+Today the torch-dependent modules (``test_engine_loop``, ``test_models_loader``,
+``test_moe_offload_*``) already self-skip via a module-level
+``pytest.importorskip("torch")``, and no test carries the ``xpu`` marker yet
+(those live on the XPU nightly, #50). This hook is the single authoritative place
+for the policy and future-proofs the CPU venv against a future xpu-marked test
+that does *not* import torch at module scope -- which ``importorskip`` alone
+would not catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+# Stash of the full collected item list, populated by the tryfirst hookwrapper
+# below and consumed by the non-wrapper hook, so a single module-level name
+# bridges the two hooks without relying on `config` identity.
+_all_items: list = []
+
+
+def pytest_collection_modifyitems(config, items):
+    if importlib.util.find_spec("torch") is not None:
+        # torch present (e.g. .venv-xpu on a B70 box) -> run everything.
+        return
+    deselected = [item for item in _all_items if item.get_closest_marker("xpu") is not None]
+    if not deselected:
+        return
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = [item for item in _all_items if item.get_closest_marker("xpu") is None]
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def _populate_all_items(config, items):
+    _all_items.clear()
+    _all_items.extend(items)
+    yield


### PR DESCRIPTION
<!-- argos-status:start -->
> 🔴 **PR-Agent Score: 20** `score-below-70` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/68#issuecomment-5448070447) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit e77fb6f](https://github.com/Performant-Labs/FreeToken-Intel/commit/e77fb6fea9995e54a588766f82afc17042f71c3b) · run [#33139090945](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33139090945) · 2026-08-27 21:34 MDT / 2026-08-28 03:34 UTC
<!-- argos-status:end -->

### **User description**
## Red-team — DO NOT MERGE

Scratch PR validating the **venv-contract guard** added in #45.

It adds `torch` to `[project] dependencies`. That means the CI job's
`pip install -e ".[dev]"` now installs torch into the **CPU** venv — a direct
violation of the dual-venv contract (torch must live only in `.venv-xpu`).

**Expected: the 'venv contract: torch must NOT be importable' step FAILS with a
clear `::error::venv-contract violated` annotation.** If this job goes green,
the guard is broken.

This branch is deleted after validation.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace self-hosted 3.12 job with CPU `ci` job
  - Python 3.11, compileall, pytest CTRF, artifact upload

- Add hard venv contract guard: `import torch` fails

- Add `conftest.py` deselecting `xpu` tests without torch

- Deliberately add `torch` to project dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["ci.yml: CPU Python 3.11 job"] -- "adds venv-contract guard" --> Guard["import torch must fail"]
  Pyproject["pyproject.toml: adds torch dependency"] -- "breaches" --> Guard
  Conftest["conftest.py: deselect xpu tests"] -- "supports" --> CI
  Docs["dev-setup.md: CI version 3.11"] -- "updates" --> CI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add pytest hook to deselect xpu tests without torch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add shared pytest policy deselecting <code>xpu</code>-marked tests when torch is <br>absent.<br> <li> Implement hookwrapper to populate item list for collection-time <br>filtering.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/68/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Replace test job with CPU ci job including venv guard</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Replace <code>test</code> job with <code>ci</code> job on <code>ubuntu-latest</code> Python 3.11.<br> <li> Add byte-compile, pytest CTRF, and artifact upload steps.<br> <li> Add hard venv-contract guard that fails if <code>import torch</code> succeeds.<br> <li> Harden CLI smoke assertion; fix pipefail/grep false-negative.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/68/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+105/-28</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dev-setup.md</strong><dd><code>Correct CI Python version in dev setup docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/dev-setup.md

- Update CI Python version from 3.12 to 3.11.


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/68/files#diff-6a10aca6fb48bf9b93079bd5b76607312628c0519fca4aebfdea98fc93a99e8e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add torch to core dependencies as red-team breach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>torch</code> to <code>[project] dependencies</code>, intentionally violating dual-venv <br>contract.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/68/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


