### PR TITLE
ci(xpu): add xpu-nightly workflow + first xpu-marked tests (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     # green-looking run). docs/ci.md states this rule.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f49d1e467b517968b485431294bb39bd33f6256c # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Lint workflow files (actionlint, pinned)
         run: |
           # Pin BOTH the download script (v1.7.12 tag, not a floating `main`)
@@ -81,7 +81,7 @@ jobs:
     # repo has no op.env.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f49d1e467b517968b485431294bb39bd33f6256c # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           # pull_request's default ref is the synthetic merge commit -- fetch
@@ -271,10 +271,10 @@ jobs:
     # the torch path is verified on a trusted, main-only schedule instead.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f49d1e467b517968b485431294bb39bd33f6256c # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@2466a935960f7dc705963504bc06a51a1caedc3e # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,16 @@ jobs:
     # failure class as the playbook's "drift announces itself" rule. The job
     # has NO `needs:` and is the first job, so a broken workflow file fails
     # fast and cheap before any install/compile/test step runs.
+    # Every `uses:` in this workflow is pinned to a full commit SHA (not a
+    # floating tag) with a trailing `# vN` comment naming the release the SHA
+    # is. Rule: bump pins DELIBERATELY, one PR per action, never implicitly --
+    # an unpinned tag is the same failure class as the playbook's retired
+    # `CI_RUNNER || 'ubuntu-latest'` bug: a silent, invisible behavior change
+    # (a new action release could change checkout or upload semantics under a
+    # green-looking run). docs/ci.md states this rule.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@f49d1e467b517968b485431294bb39bd33f6256c # v4
       - name: Lint workflow files (actionlint, pinned)
         run: |
           # Pin BOTH the download script (v1.7.12 tag, not a floating `main`)
@@ -74,7 +81,7 @@ jobs:
     # repo has no op.env.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@f49d1e467b517968b485431294bb39bd33f6256c # v4
         with:
           fetch-depth: 0
           # pull_request's default ref is the synthetic merge commit -- fetch
@@ -219,7 +226,7 @@ jobs:
       - name: Upload gitleaks report
         if: always() && steps.gitleaks.outputs.leaks == 'true'
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gitleaks-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/gitleaks-report.json
@@ -234,6 +241,13 @@ jobs:
     #      job. It must never execute on owned hardware, and the org CI_RUNNER
     #      variable is a private-org mechanism that does not apply here.
     #      (pre-flight and secret-scan above are on the same footing.)
+    #
+    #      Because ALL jobs in this workflow are on ubuntu-latest, a fork PR
+    #      never reaches owned hardware -- and so this workflow deliberately
+    #      carries NO `github.repository == ...` identity guard. Contrast
+    #      xpu.yml, whose build job runs on the fleet and therefore guards
+    #      every job on repo identity. Adding a guard here would be dead
+    #      weight; omitting one where it matters would be a fleet exposure.
     #
     #   2. The dual-venv contract. This job builds the CPU `.venv` -- which by
     #      the project's load-bearing separation must NEVER contain torch.
@@ -257,10 +271,10 @@ jobs:
     # the torch path is verified on a trusted, main-only schedule instead.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@f49d1e467b517968b485431294bb39bd33f6256c # v4
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@2466a935960f7dc705963504bc06a51a1caedc3e # v5
         with:
           python-version: "3.11"
 
@@ -333,7 +347,7 @@ jobs:
       - name: Upload CTRF test report
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ctrf-reports
           path: ctrf/

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -1,0 +1,215 @@
+name: xpu-nightly
+
+on:
+  schedule:
+    # 02:30 UTC -- off-peak for the Helsinki runner and for the human's work
+    # hours. A nightly, by definition, runs on the default branch only.
+    - cron: "30 2 * * *"
+  # Manual re-run, e.g. to re-test after a fleet/runner change or to force a
+  # run at a HEAD the check job would otherwise skip. `force: true` bypasses
+  # the stamp check (upstream parity, see the check job below).
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Run even if this commit is already green on this branch"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Serialize runs: there is at most ONE B70 fleet runner and two runs must
+# never share it (a concurrent second run would interleave its steps on the
+# same machine). Parity with upstream FreeToken's nightly-wheels concurrency
+# (group on the workflow, NO cancel-in-progress). Note: this workflow has no
+# pull_request trigger, so `github.ref` is always refs/heads/<branch> here.
+concurrency:
+  group: xpu-nightly-${{ github.ref }}
+
+jobs:
+  # Decide whether HEAD needs a B70 run at all. Runs on a hosted runner so a
+  # no-op night costs nothing and never touches the (scarce) fleet.
+  #
+  # Fork-proofing: this job (and every other job in this workflow) carries an
+  # explicit repo-identity guard. Unlike the ci.yml jobs -- which run on
+  # ubuntu-latest, so a fork's code never executes on owned hardware and needs
+  # no guard (that is why ci.yml has none) -- the build job below runs on the
+  # self-hosted B70 fleet. A fork PR/dispatch must never reach it, and the
+  # org CI_RUNNER variable is a private-org mechanism that a fork does not see
+  # in the first place. The explicit guard is the belt to that suspenders: it
+  # makes the exposure visible in the file and survives an org transfer.
+  check:
+    if: github.repository == 'Performant-Labs/FreeToken-Intel'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      build: ${{ steps.decide.outputs.build }}
+    steps:
+      - name: Compare HEAD against the last green xpu-nightly run
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          # The gh CLI ships on ubuntu-latest and reads GH_TOKEN. The API lists
+          # runs newest-first, so the first one IS the last green run.
+          last_green_sha="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?workflow=xpu.yml&status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha' 2>/dev/null || true)"
+          if [ "$FORCE" = "true" ]; then
+            echo "force=true -- bypassing the stamp check."
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$last_green_sha" ] && [ "$GITHUB_SHA" = "$last_green_sha" ]; then
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "already green at $GITHUB_SHA on ${GITHUB_REF} -- skipping; a no-op night must not touch the B70."
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "last green xpu-nightly run: ${last_green_sha:-<none>}; this HEAD ($GITHUB_SHA) is untested on the B70."
+          fi
+
+  build:
+    needs: check
+    # Belt (the two lines above) and suspenders (this line) both gate the fleet:
+    # the check's repo-identity guard means a fork's run never gets a `true`,
+    # and the org CI_RUNNER variable is invisible to forks, so runs-on would be
+    # empty for them anyway. Neither mechanism depends on the other.
+    if: >
+      github.repository == 'Performant-Labs/FreeToken-Intel' &&
+      needs.check.outputs.build == 'true'
+    # The XPU fleet. NO `|| 'ubuntu-latest'` fallback -- the playbook's original
+    # `||` was a bug it has since retired (a repo that couldn't see the org
+    # variable silently ran on GitHub-hosted and stayed green; 15 of 21 repos
+    # were doing exactly that, invisibly). A missing/stale variable now yields
+    # an empty runs-on and the job fails immediately, so drift announces
+    # itself instead of being discovered months later. The CI_RUNNER variable
+    # is org-wide and visible to all repos, so it resolves here to
+    # self-hosted-linux (the Uranus fleet, which carries the B70).
+    runs-on: ${{ vars.CI_RUNNER }}
+    timeout-minutes: 60
+    steps:
+      # HARD XPU-presence guard, run FIRST (before checkout): The whole point
+      # of this nightly is torch-on-B70; if the runner we landed on has no
+      # XPU (fleet drift, a new runner image without the ICD, CI_RUNNER
+      # re-pointed at a wrong label) the venv contract below would fail
+      # opaquely and the CTRF artifact would be a wall of collection errors.
+      # Fail loudly and EARLY, in the step whose name says what happened, with
+      # a diagnostic that tells the on-call exactly which of the four causes it
+      # is. (sycl-ls is on PATH once oneAPI's setvars.sh is sourced; the fleet
+      # runner sources it at image build. If it is NOT on PATH here, that is
+      # itself fleet drift -- oneAPI is missing or un-sourced -- and fails the
+      # same way.)
+      - name: "Guard: this runner must have a real XPU"
+        id: sycl-ls-result
+        run: |
+          if ! command -v sycl-ls >/dev/null 2>&1; then
+            echo "::error::xpu-nightly: 'sycl-ls' is not on PATH on this runner. oneAPI is missing or its setvars.sh was not sourced at image build. The XPU nightly must NEVER run on a GPU-less box -- that is the exact drift this workflow exists to catch. Fix the runner image (re-point CI_RUNNER at a labeled B70 runner, or restore the ICD/oneAPI in the image)."
+            exit 1
+          fi
+          sycl-ls || { echo "::error::xpu-nightly: sycl-ls ran but found no Level Zero device -- the GPU ICD is not loaded on this host."; exit 1; }
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          echo "XPU present:"
+          sycl-ls
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Source the B70 pin (ONEAPI_DEVICE_SELECTOR=level_zero:0) + the oneAPI
+      # environment, exactly as a developer would (docs/dev-setup.md). This is
+      # what puts sycl-ls/icpx on PATH and pins the device index if an AMD iGPU
+      # shadows the Battlemage. It MUST come before the venv is activated so the
+      # venv's python resolves the XPU runtime.
+      #
+      # Persist the oneAPI/XPU environment across steps (each step is a fresh
+      # shell, so the sourced values are lost unless exported to the runner's
+      # per-step env file). CRITICAL: persist only the specific variables the
+      # XPU runtime needs (ONEAPI_*, LD_LIBRARY_PATH, PATH), NOT a blanket
+      # `env >> $GITHUB_ENV`. The oneAPI setvars.sh leaves shell FUNCTION
+      # definitions (ps4, printenv4, etc.) in the environment, and a blanket
+      # dump would write malformed `name() {...}` fragments into the env file --
+      # which the runner re-sources as `export` lines and chokes on, corrupting
+      # every subsequent step. (GITHUB_ENV is a special variable, so it is
+      # excluded by the same prefix filter.)
+      - name: Source oneAPI / XPU environment
+        run: |
+          set -a
+          . ./setvars-xpu.sh
+          set +a
+          env | grep -E '^(ONEAPI|LD_LIBRARY_PATH|PATH)=' >> "$GITHUB_ENV"
+
+      # The dual-venv contract says torch lives ONLY in .venv-xpu. The CPU CI
+      # job (ci.yml) enforces the install-side half with a hard "import torch
+      # must FAIL" guard on the CPU venv; THIS job is the other half -- the
+      # venv where torch is ALLOWED and required. The venv is expected to be
+      # pre-baked into the fleet runner image (docs/dev-setup.md step 6); if
+      # it is NOT yet baked (the image predates the XPU setup), we build it
+      # here from the documented 6-step sequence instead of failing the whole
+      # nightly -- the ephemeral containers mean the build does not persist,
+      # so it is a per-night cost until the image bakes the venv (the right
+      # end state; bake it into the pl-runner image and this branch becomes
+      # dead). If the venv is absent AND the build fails (no network to the
+      # XPU index, a broken wheel tag), the step fails loudly: that is real
+      # drift, not a "skip the torch tests" situation.
+      - name: "venv contract: .venv-xpu exists and has torch with an available XPU"
+        run: |
+          if [ ! -x .venv-xpu/bin/python ]; then
+            echo ".venv-xpu is not baked into this runner image -- building it (docs/dev-setup.md step 6)."
+            python3.11 -m venv .venv-xpu
+            # shellcheck disable=SC1091
+            . ./.venv-xpu/bin/activate
+            python -m pip install -U pip
+            python -m pip install -e ".[dev]"
+            # The XPU wheel's metadata pulls nvidia-* CUDA packages on a plain
+            # resolve, which must not land on a B70 box -- hence --no-deps and
+            # the explicit Intel-side deps below (docs/dev-setup.md).
+            python -m pip install --no-deps torch==2.13.0 \
+              --index-url https://download.pytorch.org/whl/xpu
+            python -m pip install \
+              oneccl==2022.0.0 oneccl-devel==2022.0.0 tbb==2023.0.0 \
+              umf==1.1.0 pyzes==0.1.1 tcmlib==1.5.0 triton-xpu==3.7.2 \
+              --index-url https://download.pytorch.org/whl/xpu
+            python -m pip install "sympy>=1.13.3"
+            python -m pip install \
+              onemkl-license==2026.0.0 onemkl-sycl-blas==2026.0.0 \
+              onemkl-sycl-dft==2026.0.0 onemkl-sycl-lapack==2026.0.0 \
+              onemkl-sycl-rng==2026.0.0 onemkl-sycl-sparse==2026.0.0 \
+              jinja2 networkx
+            python -m pip install --force-reinstall --no-deps \
+              intel-cmplr-lib-rt==2026.0.0 intel-cmplr-lib-ur==2026.0.0 \
+              intel-cmplr-lic-rt==2026.0.0 intel-sycl-rt==2026.0.0 \
+              intel-opencl-rt==2026.0.0 intel-openmp==2026.0.0 \
+              dpcpp-cpp-rt==2026.0.0 intel-pti==0.17.0
+          fi
+          . ./.venv-xpu/bin/activate
+          python -c "import torch; print('torch', torch.__version__); assert torch.xpu.is_available(), 'torch.xpu.is_available() is False -- the B70 ICD/oneAPI is not visible to this torch build (driver/ICD problem, not pip)'; print('XPU visible:', torch.xpu.device_count(), 'device(s)')"
+          echo "OK: .venv-xpu has torch with a live XPU (contract holds)."
+
+      # The actual nightly payload: the xpu-marked suite. The conftest.py
+      # policy deselects xpu-marked tests only when torch is ABSENT -- here
+      # torch is present, so `-m xpu` runs exactly the XPU-marked tests (the
+      # B70 path that the CPU CI job deliberately skips). The CTRF reporter
+      # writes the machine-readable result for the artifact below. If no tests
+      # carry the xpu marker yet (today's state, pre-#30), the run is a clean
+      # 0-test pass that still proves the venv+driver+GPU path is alive -- the
+      # venv-contract guard above is what makes that pass meaningful.
+      - name: XPU test suite
+        run: |
+          . ./.venv-xpu/bin/activate
+          python -m pip install -q pytest-json-ctrf
+          pytest -m xpu -v --ctrf ctrf/pytest-ctrf.json
+
+      # CTRF artifact. The ONLY continue-on-error in this workflow: an upload
+      # failure (network blip on the fleet) must never turn a red test run into
+      # a confusing third state. if: always() so a failing run still uploads its
+      # report (that is when the report is most needed). 30-day retention,
+      # parity with ci.yml. Name includes run id + attempt so a rerun cannot
+      # collide with the prior attempt's artifact.
+      - name: Upload CTRF test report
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: xpu-ctrf-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ctrf/
+          retention-days: 30
+          if-no-files-found: ignore

--- a/tests/test_xpu_smoke.py
+++ b/tests/test_xpu_smoke.py
@@ -1,0 +1,42 @@
+"""XPU smoke tests for the XPU nightly (``xpu.yml``).
+
+The per-PR ``ci`` job runs on a torch-free CPU venv, so the torch / ``torch.xpu``
+path has no per-PR coverage. The XPU nightly runs on the B70 fleet runner with
+``.venv-xpu`` activated, and this module is the first ``xpu``-marked test: the
+nightly's payload must not be empty, and these are the cheapest meaningful
+assertions about "the XPU path is alive" -- the device is visible to torch and
+the ``ft device`` report says so.
+
+Every test here is ``xpu``-marked, so ``conftest.py``'s policy deselects the
+whole module on a torch-less (CPU) venv -- these only ever run where a real
+XPU is present. The module-level ``importorskip`` is the belt; the marker is
+the suspenders (and is what ``-m xpu`` actually selects on).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# xpu-marked: the nightly runs these; the CPU per-PR job deselects them.
+pytestmark = pytest.mark.xpu
+
+
+def test_torch_xpu_is_available():
+    assert torch.xpu.is_available(), "torch.xpu.is_available() is False on the XPU nightly runner"
+    assert torch.xpu.device_count() >= 1, "torch sees zero XPU devices"
+
+
+def test_b70_device_name_is_reported():
+    from freetoken.utils.arch import xpu_device_name
+
+    name = xpu_device_name()
+    assert name, "freetoken.utils.arch.xpu_device_name() returned None on the XPU nightly runner"
+
+
+def test_ft_device_reports_xpu_available(capsys):
+    from freetoken.cli import main
+
+    assert main(["device"]) == 0
+    out = capsys.readouterr().out
+    assert "torch.xpu available: True" in out


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 87** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/69#issuecomment-5452519842) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 413693e](https://github.com/Performant-Labs/FreeToken-Intel/commit/413693ec85704eec61ba240eaa646cdf583f3d7e) · run [#33171416479](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33171416479) · 2026-08-28 06:36 MDT / 2026-08-28 12:36 UTC
<!-- argos-status:end -->

### **User description**

### **User description**
## Summary

Closes the coverage gap #67 left open: the per-PR `ci` job is torch-free by the
dual-venv contract, so the torch/XPU path had **no automated coverage at all**.
This adds `xpu.yml` — a thin nightly, patterned on upstream FreeToken's
`nightly-wheels.yml` and the playbook CI platform — that gives the B70 path real
scheduled coverage, plus the first `xpu`-marked tests so the nightly's payload
isn't empty.

This is the "scaffold + real behavior" half of epic #42's #50.

## What it does

**`xpu.yml`** — triggers: `schedule` (02:30 UTC) + `workflow_dispatch` (with a
`force` boolean). Two jobs:

- **`check`** (hosted `ubuntu-latest`): compares `GITHUB_SHA` against the last
  **green** `xpu-nightly` run on the same branch via the GitHub API (built-in
  `GITHUB_TOKEN`, no new secrets). Equal → `build=false` and the fleet job is
  skipped with a visible "already green at this commit" notice, so a no-op night
  costs nothing and never touches the scarce B70 runner. `force: true` bypasses.
- **`build`** (`runs-on: ${{ vars.CI_RUNNER }}`, **no** `|| 'ubuntu-latest'`
  fallback — the playbook retired that `||` precisely because a missing variable
  should fail loudly, not silently fall back to a GPU-less hosted runner).
  Gated on repo identity **and** `needs.check`. Steps, in order:
  1. **sycl-ls guard (first, before checkout)** — fail loudly and early if the
     runner has no XPU/oneAPI (the exact drift this workflow exists to catch).
  2. **oneAPI env** — source `setvars-xpu.sh` and persist to `GITHUB_ENV` via a
     *filtered* write (`ONEAPI*`/`LD_LIBRARY_PATH`/`PATH` only). A blanket
     `env >>` would dump `setvars.sh`'s shell-function definitions into the
     per-step env file and corrupt every later step.
  3. **`.venv-xpu` contract** — use the baked venv, or build it from the
     documented 6-step sequence if the image predates the XPU setup (ephemeral
     containers → per-night cost until it's baked into the image). Then verify
     `torch.xpu.is_available()` — the inverse of ci.yml's torch-free guard.
  4. **XPU test suite** — `pytest -m xpu` + CTRF artifact (`continue-on-error`,
     `if: always` — the only one in the workflow).

**Fork-proofing:** every `xpu.yml` job carries
`if: github.repository == 'Performant-Labs/FreeToken-Intel'`. A fork's
dispatch would otherwise pass the (empty `inputs.force`) check and land on the
fleet. `ci.yml`'s jobs run on `ubuntu-latest` so a fork's code never reaches
owned hardware — no guard needed (now noted in ci.yml).

**`ci.yml`:** SHA-pins every `uses:` (checkout `v4`, setup-python `v5`,
upload-artifact `v7.0.1`) with `# vN` comments and the deliberate-bump rule in a
comment. Bumping a pin is a behavior change to the *per-PR* gate, so it lands
here rather than in the docs PR.

**`tests/test_xpu_smoke.py`:** the first `xpu`-marked tests (torch.xpu
availability, B70 device name, `ft device` reports available). Deselected by
`conftest.py` on the torch-free CPU venv (clean skip) and collected by `-m xpu`
on the B70 venv.

## Red-team (per #49's standard) — still to do before merge

- [ ] a second `workflow_dispatch` at an **unchanged HEAD** is skipped with the
      "already green" notice (fleet job does not run)
- [ ] a **fork** dispatch cannot reach the `build` job (repo-identity guard)
- [ ] `vars.CI_RUNNER` unset → `build` job fails loudly (empty `runs-on`), does
      not fall back to a GPU-less runner

## Verification so far

- `actionlint` clean on both workflows (local, 1.7.12).
- CPU suite green: `pytest -m "not xpu and not slow and not needs_workers"` →
  31 passed / 5 skipped (the 3 new tests skip cleanly on the torch-free venv).
- `pytest -m xpu --collect-only` on `.venv-xpu` collects exactly the 3 new tests.
- The `GITHUB_ENV` filtered-write was reproduced locally against the real
  `setvars-xpu.sh`: only clean `KEY=value` lines are written; the oneAPI
  function definitions are excluded.
- Tag-to-SHA resolution (the pin mechanism) was verified on a scratch remote.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add scheduled/manual `xpu-nightly` workflow for B70 XPU coverage.

- `check` job avoids rerunning already-green commits; `build` runs on fleet.

- Enforce XPU presence, oneAPI env, and `.venv-xpu` torch contract.

- Pin `ci.yml` GitHub Actions to full commit SHAs.

- Add first `xpu`-marked torch/XPU smoke tests.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_xpu_smoke.py</strong><dd><code>Add initial xpu-marked smoke tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_xpu_smoke.py

<ul><li>Add three <code>xpu</code>-marked smoke tests for <code>torch.xpu</code> availability, B70 <br>device name, and <code>ft device</code>.<br> <li> Use module-level <code>pytest.importorskip("torch")</code> and <code>pytestmark = </code><br><code>pytest.mark.xpu</code>.<br> <li> Ensure CPU torch-free CI deselects the module cleanly.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/69/files#diff-b25a5c2a7f0c864021e159f7ec545e03cffe762b3c7732dcdaf6d27636273d59">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Pin workflow actions and document fork-safety rationale</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Pin <code>actions/checkout</code>, <code>actions/setup-python</code>, and <br><code>actions/upload-artifact</code> to full commit SHAs with <code># vN</code> comments.<br> <li> Document deliberate pin-bump rule and why <code>ci.yml</code> jobs carry no <br>repo-identity guard.<br> <li> Add comment noting fork safety for ubuntu-latest jobs and contrast <br>with XPU nightly guard.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/69/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+20/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>xpu.yml</strong><dd><code>Add xpu-nightly workflow for B70 coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/xpu.yml

<ul><li>Add <code>xpu-nightly</code> workflow triggered by schedule and manual dispatch <br>with force input.<br> <li> Add <code>check</code> job to skip already-green commits on hosted runner.<br> <li> Add <code>build</code> job on self-hosted B70 runner with sycl-ls guard, oneAPI <br>env, <code>.venv-xpu</code> contract, and <code>pytest -m xpu</code>.<br> <li> Guard all jobs on <code>github.repository == </code><br><code>'Performant-Labs/FreeToken-Intel'</code> and serialize with concurrency <br>group.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/69/files#diff-504e88eb94855465eed619a5771d2156dfe7abbb3f270a830ee614a795bf8d61">+215/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `.github/workflows/xpu.yml` nightly scheduled and manual workflow.

- Check skips already-green SHA; build job guards fleet.

- Build sources oneAPI, verifies `.venv-xpu`, runs `-m xpu`.

- Add first `xpu`-marked smoke tests; SHA-pin `ci.yml` actions.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  X["xpu.yml nightly workflow"] --> C["check job: SHA vs last green"]
  C --> B["build job: fleet runner"]
  B --> G["sycl-ls XPU guard"] --> V["oneAPI env"] --> T[".venv-xpu + pytest -m xpu"] --> A["CTRF artifact"]
  X --> S["test_xpu_smoke.py xpu-marked tests"]
  CI["ci.yml"] --> P["SHA-pin actions + guard note"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_xpu_smoke.py</strong><dd><code>First XPU smoke tests for nightly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_xpu_smoke.py

<ul><li>Add new pytest module with <code>importorskip("torch")</code> and module-level <code>xpu</code> <br>marker.<br> <li> Test <code>torch.xpu.is_available()</code> and <code>device_count >= 1</code>.<br> <li> Test B70 device name via <code>freetoken.utils.arch.xpu_device_name</code>.<br> <li> Test <code>ft device</code> CLI reports <code>torch.xpu available: True</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/69/files#diff-b25a5c2a7f0c864021e159f7ec545e03cffe762b3c7732dcdaf6d27636273d59">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>SHA-pin actions and document guard rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Pin <code>actions/checkout</code>, <code>actions/setup-python</code>, and <br><code>actions/upload-artifact</code> to full commit SHAs with <code># vN</code> comments.<br> <li> Add comments documenting deliberate pin bump rule.<br> <li> Add comment explaining why per-PR jobs need no repository identity <br>guard.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/69/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+20/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>xpu.yml</strong><dd><code>Add XPU nightly check and fleet workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/xpu.yml

<ul><li>Add new <code>xpu-nightly</code> workflow with schedule and <code>workflow_dispatch</code> <code>force</code> <br>input.<br> <li> Add <code>check</code> job comparing HEAD SHA to last green run via GitHub API.<br> <li> Add guarded <code>build</code> job using <code>vars.CI_RUNNER</code>, no <code>ubuntu-latest</code> fallback.<br> <li> Add <code>sycl-ls</code> XPU guard, filtered oneAPI env persistence, <code>.venv-xpu</code> <br>contract, <code>pytest -m xpu</code>, and CTRF upload.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/69/files#diff-504e88eb94855465eed619a5771d2156dfe7abbb3f270a830ee614a795bf8d61">+215/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


