### PR TITLE
RED-TEAM (do not merge) #45: trip the venv-contract guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ dependencies = [
     "huggingface_hub>=0.26,<3",
     "msgpack>=1.1,<2",
     "numpy>=2.0,<2.5",
+    # RED-TEAM (do not merge): torch must NOT be a [project] dependency. The
+    # dual-venv contract keeps torch OUT of the CPU venv (it lives only in
+    # .venv-xpu). Adding it here makes `import torch` succeed in the CPU CI
+    # venv, which the venv-contract guard in .github/workflows/ci.yml is
+    # designed to catch and hard-fail on.
+    "torch",
     "openai>=1.0,<3",
     "partial-json-parser>=0.2,<1",
     "prompt_toolkit>=3.0,<4",


### PR DESCRIPTION
<!-- argos-status:start -->
> 🔴 **PR-Agent Score: 0** `score-below-70` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/70#issuecomment-5452622202) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit b220061](https://github.com/Performant-Labs/FreeToken-Intel/commit/b220061afbecfd172b569b5d9e4d5d828dec7a52) · run [#33171951150](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33171951150) · 2026-08-28 06:41 MDT / 2026-08-28 12:41 UTC
<!-- argos-status:end -->

### **User description**
## RED-TEAM — do NOT merge

Closes the red-team leg of **#45** ("red-team the venv contract").

### What this does
Adds `torch` to the `[project]` dependencies in `pyproject.toml`.

This is the exact regression the venv-contract guard in
`.github/workflows/ci.yml` exists to catch: it makes `import torch`
succeed inside the torch-free CPU CI venv, which the guard treats as a
contract violation and hard-fails on.

### Expected result (this is a *successful* red-team run)
- **actionlint** job → green (workflow still parses)
- **gitleaks** job → green (no secrets)
- **Typecheck, test, and CLI smoke (CPU)** job → **RED at the venv-contract
  step**, emitting the `::error::venv-contract violated` annotation
  ("`import torch` must FAIL in the torch-free CI venv")

A green venv-contract step would mean the guard is toothless and is itself
the bug.

### Disposition
Close after the red run is captured and linked in #45. No code here ships.


___

### **PR Type**
Tests, Other


___

### **Description**
- Add `torch` to `[project]` dependencies

- Intentionally violate dual-venv contract in CPU CI

- Expected: venv-contract guard hard-fails on import

- Red-team only; do not merge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add torch to pyproject.toml"] --> B["CPU CI venv imports torch"]
  B --> C["venv-contract guard detects violation"]
  C --> D["CI job fails with error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add torch dependency to breach venv contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>torch</code> to <code>[project]</code> dependencies<br> <li> Include red-team comment explaining contract breach<br> <li> Causes <code>import torch</code> to succeed in torch-free CPU venv</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/70/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


