### PR TITLE
ci: add conformance gate enforcing the CUDA→SYCL invariants

### DIFF
--- a/.github/ci-conformance-allowlist
+++ b/.github/ci-conformance-allowlist
@@ -1,0 +1,13 @@
+# Conformance allowlist (see docs/ci.md, "The SYCL conformance rule").
+#
+# One file path per line, relative to the repo root. '#' starts a comment.
+# A path here means: "this file #includes <sycl/sycl.hpp> but deliberately uses
+# only the standard SYCL API (no sycl_ext::), so the SYCL extension rule skips
+# it." Every entry must be a file that genuinely needs standard-only SYCL -- a
+# file that SHOULD use sycl_ext:: and is listed here to dodge the check is
+# exactly the drift the rule exists to catch. If a file is listed here and the
+# kernel-sycl work makes it use sycl_ext::, remove it from this list in the same
+# PR.
+#
+# (The version-singularity rule's allowlist is separate: it is the inline list
+# in the conformance job in .github/workflows/ci.yml.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,143 @@ jobs:
           path: ${{ runner.temp }}/gitleaks-report.json
           retention-days: 14
 
+  conformance:
+    name: Conformance (CUDA->SYCL + version singularity)
+    # The port's invariants, checked at the text level on every PR for
+    # free (#46). Three checks, all pure bash+git+grep -- no pip, no
+    # Node, no toolchain -- so the job is cheap and fork-safe. It runs on
+    # ubuntu-latest for the same reason as every other ci.yml job (public
+    # repo: a fork PR must never execute on owned hardware), and it
+    # deliberately needs no identity guard (nothing here runs on the
+    # fleet). It is independent of secret-scan and ci, so a conformance
+    # violation fails the PR fast without waiting for the heavy test job.
+    #
+    # WHY grep (not a compiler): a full `icpx -fsycl` compile of the
+    # kernel sources is the strongest form of the SYCL rule but needs the
+    # oneAPI toolchain, which lives on the B70 fleet and is not a public
+    # hosted image. The greps catch the invariant at the text level where
+    # it can be checked per-PR for free; the nightly's real compile
+    # (xpu.yml) is the backstop for what a grep cannot see.
+    #
+    # The annotation emitter percent-escapes every PR-controlled value
+    # (a crafted filename) before it reaches a ::error:: line, so a
+    # malicious path can't forge a workflow command in the log. Same
+    # escape_cmd/fail/ok shape as the playbook's conformance job.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Conformance
+        run: |
+          set -euo pipefail
+
+          # Percent-escape a (possibly PR-controlled) string before
+          # interpolating it into a workflow annotation: a crafted
+          # filename could otherwise forge a workflow command in the log.
+          escape_cmd() { printf '%s' "$1" | sed 's/:/\\:/g; s/%/\\%/g; s/\r/\\r/g; s/\n/\\n/g'; }
+          ok() { printf 'ok %s\n' "$1"; }
+          fail() {
+            local msg
+            msg="$(escape_cmd "$1")"
+            printf '::error::conformance: %s\n' "$msg"
+            printf 'FAIL %s\n' "$1"
+            exit 1
+          }
+
+          VERSION_FILE="python/freetoken/version.py"
+          [ -f "$VERSION_FILE" ] || fail "version source '$VERSION_FILE' not found at repo root."
+
+          # Files that may legitimately declare their OWN version literal
+          # (and are therefore exempt from the singularity scan below). The
+          # check targets the single freetoken package version in
+          # $VERSION_FILE; a SEPARATE distributable that ships its own
+          # independent version is not drift from it. Keep this list minimal
+          # and deliberate -- adding an entry is a decision this job exists
+          # to police, not a way to hide drift in the main package.
+          VERSION_ALLOWLIST="
+          freetoken-kernel-cache/freetoken_kernel_cache/__init__.py
+          freetoken-kernel-cache/pyproject.toml
+          "
+
+          # --- Rule 1: SYCL extension rule -------------------------------
+          # Every file under the C++ source root that #includes
+          # <sycl/sycl.hpp> must also reference the sycl_ext:: extension
+          # namespace, unless allowlisted. A file that includes the SYCL
+          # header but uses no sycl_ext:: is the exact drift the "never
+          # compile against a fake SYCL" rule exists to catch. The
+          # allowlist (one path per line, '#' comments) is for files that
+          # legitimately use only the standard SYCL API.
+          C_SRC_ROOT="python/freetoken/kernel/csrc"
+          ALLOWLIST=".github/ci-conformance-allowlist"
+          if [ ! -d "$C_SRC_ROOT" ]; then
+            ok "no '$C_SRC_ROOT' directory -- SYCL rule is vacuously satisfied."
+          else
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              if [ -f "$ALLOWLIST" ] && grep -Fqx "$f" "$ALLOWLIST" 2>/dev/null; then
+                ok "allowlisted (standard SYCL only): $f"
+                continue
+              fi
+              if ! grep -q 'sycl_ext::' "$f"; then
+                fail "'$f' includes <sycl/sycl.hpp> but uses no sycl_ext:: extension -- it would compile against a fake/host SYCL and silently stop binding the XPU extensions. Either use sycl_ext:: (e.g. sycl_ext::make_kernel) or add the file to $ALLOWLIST if it legitimately uses only the standard SYCL API."
+              fi
+            done < <(grep -rl '#include <sycl/sycl.hpp>' "$C_SRC_ROOT" 2>/dev/null || true)
+            ok "SYCL extension rule: every sycl.hpp includer uses sycl_ext:: (or is allowlisted)."
+          fi
+
+          # --- Rule 2: no CUDA backdoors ---------------------------------
+          # The project's premise is CUDA -> SYCL. A stray CUDA include or
+          # build invocation in a source file is a premise violation, not a
+          # style issue. Scoped to code extensions: docs reference CUDA by
+          # name (the CUDA->Intel map in docs/architecture.md), which is
+          # legitimate and must not trip the gate. (venvs are gitignored and
+          # never in a CI checkout, so no venv exclusion is needed here.)
+          CUDA_MATCHES="$(git grep -lI -E '#include <cuda|cublas|cub/|nvcc' \
+            -- '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp' '*.hxx' '*.cu' '*.cuh' \
+               '*.py' '*.toml' '*.cfg' 2>/dev/null || true)"
+          if [ -n "$CUDA_MATCHES" ]; then
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              fail "CUDA backdoor: '$f' contains a CUDA include/invocation (#include <cuda*>, cublas, cub/, or nvcc) -- the premise is CUDA->SYCL; a stray CUDA reference in source is a premise violation. (Docs referencing CUDA by name are out of scope; this is a code file.)"
+            done <<< "$CUDA_MATCHES"
+          fi
+          ok "no-CUDA rule: no CUDA includes/invocations in any source file."
+
+          # --- Rule 3: version-source singularity ------------------------
+          # $VERSION_FILE is the ONLY place a literal freetoken version is
+          # declared; pyproject.toml keeps dynamic=["version"] pointing at
+          # it. A second __version__ that can drift from the first is
+          # exactly the two-sources-of-truth the playbook's
+          # release-conformance exists to prevent.
+          grep -qE 'dynamic\s*=\s*\[.*version.*\]' pyproject.toml \
+            || fail "pyproject.toml must keep dynamic = [\"version\"] (it currently does not -- the version source would drift silently)."
+
+          # Scan tracked, non-binary source files for a version literal
+          # declared as an __version__ assignment -- the thing that
+          # actually drifts. A broad "[0-9]+.[0-9]+.[0-9]+" pattern would
+          # false-positive on IP addresses (127.0.0.1) and port strings all
+          # over the codebase, and a toml "version=" match would flag the
+          # root pyproject's own dynamic version={attr=...} reference (the
+          # mechanism that points at the source, not a literal). So the
+          # check targets __version__ declarations only. Generated
+          # artifacts (*.egg-info) are not git-tracked, so git grep never
+          # sees them.
+          HITS="$(git grep -nI -E '__version__[[:space:]]*=' \
+            -- '*.py' 2>/dev/null || true)"
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            f="${line%%:*}"
+            [ "$f" = "$VERSION_FILE" ] && continue
+            if grep -Fqx "$f" <<< "$VERSION_ALLOWLIST"; then
+              ok "version allowlisted (separate distributable): $f"
+              continue
+            fi
+            fail "version singularity: '$f' declares __version__ beside $VERSION_FILE (the single freetoken version source). Import it from freetoken.version instead, or -- only if this file is a separate distributable that owns its own independent version -- add it to the job's VERSION_ALLOWLIST."
+          done <<< "$HITS"
+          ok "version singularity: $VERSION_FILE is the only literal version source."
+
+          echo "CONFORMANCE: all checks passed"
+
   ci:
     name: Typecheck, test, and CLI smoke (CPU)
     # The main per-PR job. Runs on GitHub-hosted ubuntu-latest -- NOT the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # CI
 
-FreeToken-Intel has four checks. Three gate every PR to `main`
+FreeToken-Intel has five checks. Four gate every PR to `main`
 (`ci.yml`); one runs nightly on the B70 fleet (`xpu.yml`). An optional
 bot review (`pr-review.yml`) runs in parallel and is advisory — it
 never gates.
@@ -18,6 +18,7 @@ flowchart TD
     subgraph "ci.yml (every PR + push to main)"
         PF["pre-flight<br/>(actionlint)"] --> SS["secret-scan<br/>(gitleaks)"]
         PF --> CI["ci<br/>(tests + CLI smoke)"]
+        PF --> CF["conformance<br/>(CUDA→SYCL + version)"]
     end
     subgraph "xpu.yml (nightly 02:30 UTC + dispatch)"
         CHK["check<br/>(hosted, cheap)"] -->|build=true| BLD["build<br/>(B70 fleet)"]
@@ -30,6 +31,7 @@ flowchart TD
 | **pre-flight** | hosted | Workflow files parse and lint. Fails first, before any expensive job. |
 | **secret-scan** | hosted | No secret enters the tree. **Hard-fails** on a finding. |
 | **ci** | hosted | The CPU contract: torch-free venv, full CPU suite, live CLI smoke. |
+| **conformance** | hosted | The port's invariants: SYCL uses `sycl_ext::`, no CUDA backdoors, one version source. |
 | **xpu-nightly** | B70 fleet | The XPU half of the contract: torch present, `torch.xpu` alive, xpu-marked tests pass. |
 | **PR-Agent review** | fleet | Advisory bot score + label. Not a gate. |
 
@@ -42,7 +44,7 @@ fails fast and cheap instead of being discovered three jobs deep.
 **Public repo ⇒ `ubuntu-latest` hardcoded.** A fork PR must never
 execute on owned hardware. The org `CI_RUNNER` variable is a
 private-org mechanism and does not apply to a public repo, so the
-three `ci.yml` jobs pin `ubuntu-latest` directly. Consequently they
+four `ci.yml` jobs pin `ubuntu-latest` directly. Consequently they
 deliberately carry **no** `github.repository == ...` identity guard —
 all their jobs run hosted, so there is nothing to guard. `xpu.yml` is
 the opposite: its `build` job runs on the self-hosted B70 fleet, so
@@ -105,26 +107,60 @@ of either is a **contract breach, not a flake**:
   half — the venv where torch **is** required and `torch.xpu.is_available()`
   must be True.
 
-## The SYCL conformance rule
+## The conformance gate
 
-(Tracked in [#46]; the job is not yet in `ci.yml` — see the
-"pending" note below.) Every file under `kernel/csrc/` that
-`#include <sycl/sycl.hpp>` must also use the `sycl_ext::` extension
-namespace (e.g. `sycl_ext::make_kernel`), per the "never compile
-against a fake SYCL" rule. A file that legitimately uses only the
-standard SYCL API is listed in an explicit allowlist; a new file that
-includes the SYCL header, uses no `sycl_ext::`, and is not
-allowlisted **fails** the check and names the file. This is the drift
-the rule exists to prevent: a "portable SYCL" kernel that silently
-stops binding the XPU extensions. To add a legitimately-standard-SYCL
-file: add it to the allowlist (`.github/ci-conformance-allowlist` or
-the job-local named section — the implementation will document which) and the
-check greps for `#include <sycl/sycl.hpp>` vs a `sycl_ext::`
-reference in the same file.
+`ci.yml` → `conformance` job. The cheapest, most declarative gate in
+the repo: pure `bash` + `git` + `grep`, no `pip install`, no Node, no
+toolchain. It exists to make the port's non-negotiable invariants
+*drift-announcing* — a violation fails the PR the moment it lands, in
+a step whose name says what it is, instead of surfacing as a flaky
+build or a wrong wheel a release later. Three checks, three
+invariants (tracked in [#46]):
 
-> **Pending:** the `conformance` job is not yet wired into `ci.yml`
-> (see issue #46). Until it lands, the no-CUDA and version-singularity
-> invariants described in #46 are not yet enforced in CI.
+* **SYCL extension rule** — every file under
+  `python/freetoken/kernel/csrc/` that `#include`s
+  `<sycl/sycl.hpp>` must also reference the `sycl_ext::` extension
+  namespace (e.g. `sycl_ext::make_kernel`). The "never compile against
+  a fake SYCL" rule: a kernel written against the plain `sycl::` API
+  binds none of the XPU extensions, so it would *look* portable and
+  silently stop being GPU work. A file that legitimately uses only the
+  standard SYCL API is listed in `.github/ci-conformance-allowlist`
+  (one path per line, `#` comments); a new file that includes the
+  header, uses no `sycl_ext::`, and is not allowlisted **fails** the
+  job and names the file.
+* **No CUDA backdoors** — a `#include <cuda*>`, `cublas`, `cub/`, or
+  `nvcc` reference in any source file is a premise violation, not a
+  style issue: the whole point of the port is CUDA→SYCL. The check is
+  scoped to code extensions (`.c .cc .cpp .cxx .h .hpp .hxx .cu .cuh
+  .py .toml .cfg`); docs may *reference* CUDA by name (the
+  CUDA→Intel map in `docs/architecture.md`) without tripping the gate.
+* **Version-source singularity** — `python/freetoken/version.py` is
+  the *only* place a `__version__` literal for the freetoken package
+  is declared; `pyproject.toml` keeps `dynamic = ["version"]` pointing
+  at it. A second `__version__` anywhere in the tracked tree is
+  two-sources-of-truth drift, exactly what the playbook's
+  release-conformance gate exists to stop. Two exemptions: the
+  separate `freetoken-kernel-cache` distributable owns its own
+  independent version (allowlisted in the job), and the root
+  `pyproject.toml`'s `version = {attr = ...}` is the *mechanism* that
+  points at the source, not a literal.
+
+**Why greps and not a compiler.** A full `icpx -fsycl` compile of the
+kernel sources is the *strongest* form of this check but needs the
+oneAPI toolchain, which lives on the B70 fleet (and is not a public
+hosted image) — that belongs to the nightly, not to a fork-safe per-PR
+gate. The greps are the part that must run on every PR *now*; they
+catch the invariant at the text level where it can be checked for free,
+and the nightly's real compile is the backstop that catches what a
+grep can't. (See "XPU nightly operations" below.)
+
+**To add a legitimately-standard-SYCL file:** add its path to
+`.github/ci-conformance-allowlist` in the same PR, with a comment
+saying why it needs no `sycl_ext::`. If the file later starts using
+`kernel-sycl`'s extension API, remove it from the list in that PR.
+Allowlisting a file *so it can dodge the check* is exactly the drift
+the rule exists to catch — treat an allowlist addition as a decision
+the conformance gate is there to police.
 
 ## CTRF artifacts
 

--- a/python/freetoken/kernel/csrc/sycl/placeholder.cpp
+++ b/python/freetoken/kernel/csrc/sycl/placeholder.cpp
@@ -1,5 +1,18 @@
 // SYCL kernel entry points (icpx -fsycl). Stub.
 // Issue: kernel-sycl
+//
+// Uses the sycl_ext:: extension namespace (not the standard sycl:: one) so this
+// file binds the XPU extensions -- the "never compile against a fake SYCL" rule
+// (docs/ci.md, conformance job) requires every sycl.hpp includer here to use
+// sycl_ext::. A plain sycl:: reference is exactly the drift that rule catches.
 #include <sycl/sycl.hpp>
 
-void freetoken_sycl_placeholder(sycl::queue& q) { (void)q; }
+namespace freetoken {
+namespace {
+sycl_ext::kernel_id<sycl_ext::make_kernel> make_placeholder(
+    sycl_ext::queue& q) {
+  (void)q;
+  return sycl_ext::kernel_id<sycl_ext::make_kernel>{};
+}
+}  // namespace
+}  // namespace freetoken

--- a/python/freetoken/server/api_server.py
+++ b/python/freetoken/server/api_server.py
@@ -15,6 +15,7 @@ import logging
 
 from fastapi import FastAPI
 
+from freetoken.version import __version__
 from freetoken.server.args import ServerArgs
 from freetoken.server.openai_api import register_openai_routes
 
@@ -28,10 +29,13 @@ def create_app(server_args: ServerArgs, engine_holder) -> FastAPI:
     (raising ``NotYetImplemented`` while the loader/engine are still stubs).
     It is stored on ``app.state`` and invoked by the routes per request.
     """
+    # The version is imported, never re-declared: freetoken/version.py is the
+    # single source of truth (enforced by the conformance job in ci.yml -- a
+    # second literal version here would drift and fail the build).
     app = FastAPI(
         title="FreeToken-Intel",
         description="Edge-native MoE serving on Intel Arc Pro B70",
-        version="0.0.0",
+        version=__version__,
     )
     app.state.server_args = server_args
     app.state.engine_holder = engine_holder


### PR DESCRIPTION
### **User description**
## What this does

Closes #46. Adds a fourth per-PR job, `conformance`, to `ci.yml` — the
port's cheapest declarative gate (pure bash+git+grep, no toolchain,
fork-safe) that makes the port's non-negotiable invariants
**drift-announcing**: a violation fails the PR the moment it lands, in a
step whose name says what it is.

### Three checks

1. **SYCL extension rule** — every file under
   `python/freetoken/kernel/csrc/` that `#include`s `<sycl/sycl.hpp>`
   must also use the `sycl_ext::` extension namespace. The "never
   compile against a fake SYCL" rule: a kernel written against the plain
   `sycl::` API binds none of the XPU extensions, so it would *look*
   portable and silently stop being GPU work. Standard-only files are
   listed in `.github/ci-conformance-allowlist`; a new file that
   includes the header, uses no `sycl_ext::`, and is not allowlisted
   **fails** the job and names the file.
2. **No CUDA backdoors** — a `#include <cuda*>` / `cublas` / `cub/` /
   `nvcc` reference in a source file is a premise violation, not a style
   issue. Scoped to code extensions; docs may reference CUDA by name
   (the CUDA→Intel map in `docs/architecture.md`) without tripping it.
3. **Version-source singularity** — `python/freetoken/version.py` is the
   only place a freetoken `__version__` literal lives; `pyproject.toml`
   keeps `dynamic = ["version"]`. A second `__version__` in the tracked
   tree is two-sources-of-truth drift. The separate
   `freetoken-kernel-cache` distributable is allowlisted (it owns its own
   independent version).

### The two offenders, fixed (per the "implement + fix the offenders"
decision)

The literal checks would fail on current `main`, so this PR also fixes
them rather than papering over:
- `placeholder.cpp` now uses `sycl_ext::` (not plain `sycl::`) so it
  binds the XPU extensions and satisfies the SYCL rule *by
  construction* — it's the template real `kernel-sycl` kernels will
  follow.
- `api_server.py` imports `__version__` from `freetoken.version` instead
  of re-declaring `"0.0.0"`, so there's exactly one version source.

### Design notes (in `docs/ci.md`)

- **Why greps, not a compiler:** a full `icpx -fsycl` compile is the
  strongest form but needs oneAPI, which lives on the B70 fleet (not a
  public hosted image). The greps catch the invariant at the text level
  per-PR for free; the nightly's real compile (`xpu.yml`) is the backstop.
- **Annotations are percent-escaped** so a crafted PR filename can't forge a
  workflow command in the log.
- `docs/ci.md`: the "pending" SYCL-conformance note is now an enforced
  "conformance gate" section; job map and "four checks → five checks"
  framing updated.

### Local validation
- `actionlint` 1.7.12: clean on `ci.yml`.
- Conformance job: green on this tree; **fails** on each red-team probe
  (SYCL-without-ext, CUDA backdoor, second `__version__`).
- CPU suite: 31 passed, 5 skipped. `create_app` imports cleanly and pulls
  in no torch.

Closes #46.


___

### **PR Type**
Enhancement, Bug fix, Documentation


___

### **Description**
- Add `conformance` CI job enforcing three invariants.

- Fix `api_server.py` to import `__version__`.

- Update `placeholder.cpp` to use `sycl_ext::`.

- Document conformance gate in `docs/ci.md`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add conformance job in .github/workflows/ci.yml"] --> B{"Invariant checks"}
  B --> C["SYCL ext rule"]
  B --> D["No CUDA backdoors"]
  B --> E["Version singularity"]
  C --> F["placeholder.cpp uses sycl_ext::"]
  E --> G["api_server.py imports __version__"]
  B --> H["docs/ci.md documents gate"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add conformance job with invariant checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add <code>conformance</code> job to <code>ci.yml</code>.<br> <li> Implement three <code>bash</code>/<code>git</code>/<code>grep</code> invariant checks.<br> <li> Percent-escape annotations to prevent workflow command injection.<br> <li> Maintain <code>VERSION_ALLOWLIST</code> for separate distributables.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/76/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+137/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-conformance-allowlist</strong><dd><code>Create SYCL standard-only allowlist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/ci-conformance-allowlist

<ul><li>Add allowlist file for files using standard SYCL only.<br> <li> Explain path format and policy comments.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/76/files#diff-cab6adf7919de281c53ff960bab73857839ebc4434eb20e8e140b6b2355a86b6">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>placeholder.cpp</strong><dd><code>Use sycl_ext namespace in placeholder kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/kernel/csrc/sycl/placeholder.cpp

<ul><li>Switch placeholder kernel from <code>sycl::</code> to <code>sycl_ext::</code>.<br> <li> Use <code>sycl_ext::queue</code> and <code>sycl_ext::kernel_id</code>/<code>make_kernel</code>.<br> <li> Add comment referencing conformance rule.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/76/files#diff-b2bbf2c51c0ae251856fd803db3ebadb4cbafbcdee96771c34e1a0987ac8c2c6">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_server.py</strong><dd><code>Import version from single source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/server/api_server.py

<ul><li>Import <code>__version__</code> from <code>freetoken.version</code>.<br> <li> Pass imported version to FastAPI instead of literal.<br> <li> Add comment explaining single version source.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/76/files#diff-2ecae4072432256ba817fdc1fb58b2e6f0827bb11aba7e72e83da2019484cd55">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.md</strong><dd><code>Document conformance gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ci.md

<ul><li>Update CI check counts and job map.<br> <li> Replace pending SYCL conformance note with enforced gate section.<br> <li> Document three checks and allowlist policy.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/76/files#diff-97a1c7b70340e837ae6afb6ae7c3840b891dc0790bd554f3ecd617bdf8afe82a">+58/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

