### PR TITLE
red-team: benign change — prove secret-scan degrades to tip-only but still passes (#49 item 2b)

### DIFF
--- a/.github/ci-conformance-allowlist
+++ b/.github/ci-conformance-allowlist
@@ -1,0 +1,13 @@
+# Conformance allowlist (see docs/ci.md, "The SYCL conformance rule").
+#
+# One file path per line, relative to the repo root. '#' starts a comment.
+# A path here means: "this file #includes <sycl/sycl.hpp> but deliberately uses
+# only the standard SYCL API (no sycl_ext::), so the SYCL extension rule skips
+# it." Every entry must be a file that genuinely needs standard-only SYCL -- a
+# file that SHOULD use sycl_ext:: and is listed here to dodge the check is
+# exactly the drift the rule exists to catch. If a file is listed here and the
+# kernel-sycl work makes it use sycl_ext::, remove it from this list in the same
+# PR.
+#
+# (The version-singularity rule's allowlist is separate: it is the inline list
+# in the conformance job in .github/workflows/ci.yml.)

--- a/.github/redteam-scan-marker.txt
+++ b/.github/redteam-scan-marker.txt
@@ -1,0 +1,1 @@
+benign marker v2 (new head after force-push)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,143 @@ jobs:
           path: ${{ runner.temp }}/gitleaks-report.json
           retention-days: 14
 
+  conformance:
+    name: Conformance (CUDA->SYCL + version singularity)
+    # The port's invariants, checked at the text level on every PR for
+    # free (#46). Three checks, all pure bash+git+grep -- no pip, no
+    # Node, no toolchain -- so the job is cheap and fork-safe. It runs on
+    # ubuntu-latest for the same reason as every other ci.yml job (public
+    # repo: a fork PR must never execute on owned hardware), and it
+    # deliberately needs no identity guard (nothing here runs on the
+    # fleet). It is independent of secret-scan and ci, so a conformance
+    # violation fails the PR fast without waiting for the heavy test job.
+    #
+    # WHY grep (not a compiler): a full `icpx -fsycl` compile of the
+    # kernel sources is the strongest form of the SYCL rule but needs the
+    # oneAPI toolchain, which lives on the B70 fleet and is not a public
+    # hosted image. The greps catch the invariant at the text level where
+    # it can be checked per-PR for free; the nightly's real compile
+    # (xpu.yml) is the backstop for what a grep cannot see.
+    #
+    # The annotation emitter percent-escapes every PR-controlled value
+    # (a crafted filename) before it reaches a ::error:: line, so a
+    # malicious path can't forge a workflow command in the log. Same
+    # escape_cmd/fail/ok shape as the playbook's conformance job.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Conformance
+        run: |
+          set -euo pipefail
+
+          # Percent-escape a (possibly PR-controlled) string before
+          # interpolating it into a workflow annotation: a crafted
+          # filename could otherwise forge a workflow command in the log.
+          escape_cmd() { printf '%s' "$1" | sed 's/:/\\:/g; s/%/\\%/g; s/\r/\\r/g; s/\n/\\n/g'; }
+          ok() { printf 'ok %s\n' "$1"; }
+          fail() {
+            local msg
+            msg="$(escape_cmd "$1")"
+            printf '::error::conformance: %s\n' "$msg"
+            printf 'FAIL %s\n' "$1"
+            exit 1
+          }
+
+          VERSION_FILE="python/freetoken/version.py"
+          [ -f "$VERSION_FILE" ] || fail "version source '$VERSION_FILE' not found at repo root."
+
+          # Files that may legitimately declare their OWN version literal
+          # (and are therefore exempt from the singularity scan below). The
+          # check targets the single freetoken package version in
+          # $VERSION_FILE; a SEPARATE distributable that ships its own
+          # independent version is not drift from it. Keep this list minimal
+          # and deliberate -- adding an entry is a decision this job exists
+          # to police, not a way to hide drift in the main package.
+          VERSION_ALLOWLIST="
+          freetoken-kernel-cache/freetoken_kernel_cache/__init__.py
+          freetoken-kernel-cache/pyproject.toml
+          "
+
+          # --- Rule 1: SYCL extension rule -------------------------------
+          # Every file under the C++ source root that #includes
+          # <sycl/sycl.hpp> must also reference the sycl_ext:: extension
+          # namespace, unless allowlisted. A file that includes the SYCL
+          # header but uses no sycl_ext:: is the exact drift the "never
+          # compile against a fake SYCL" rule exists to catch. The
+          # allowlist (one path per line, '#' comments) is for files that
+          # legitimately use only the standard SYCL API.
+          C_SRC_ROOT="python/freetoken/kernel/csrc"
+          ALLOWLIST=".github/ci-conformance-allowlist"
+          if [ ! -d "$C_SRC_ROOT" ]; then
+            ok "no '$C_SRC_ROOT' directory -- SYCL rule is vacuously satisfied."
+          else
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              if [ -f "$ALLOWLIST" ] && grep -Fqx "$f" "$ALLOWLIST" 2>/dev/null; then
+                ok "allowlisted (standard SYCL only): $f"
+                continue
+              fi
+              if ! grep -q 'sycl_ext::' "$f"; then
+                fail "'$f' includes <sycl/sycl.hpp> but uses no sycl_ext:: extension -- it would compile against a fake/host SYCL and silently stop binding the XPU extensions. Either use sycl_ext:: (e.g. sycl_ext::make_kernel) or add the file to $ALLOWLIST if it legitimately uses only the standard SYCL API."
+              fi
+            done < <(grep -rl '#include <sycl/sycl.hpp>' "$C_SRC_ROOT" 2>/dev/null || true)
+            ok "SYCL extension rule: every sycl.hpp includer uses sycl_ext:: (or is allowlisted)."
+          fi
+
+          # --- Rule 2: no CUDA backdoors ---------------------------------
+          # The project's premise is CUDA -> SYCL. A stray CUDA include or
+          # build invocation in a source file is a premise violation, not a
+          # style issue. Scoped to code extensions: docs reference CUDA by
+          # name (the CUDA->Intel map in docs/architecture.md), which is
+          # legitimate and must not trip the gate. (venvs are gitignored and
+          # never in a CI checkout, so no venv exclusion is needed here.)
+          CUDA_MATCHES="$(git grep -lI -E '#include <cuda|cublas|cub/|nvcc' \
+            -- '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp' '*.hxx' '*.cu' '*.cuh' \
+               '*.py' '*.toml' '*.cfg' 2>/dev/null || true)"
+          if [ -n "$CUDA_MATCHES" ]; then
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              fail "CUDA backdoor: '$f' contains a CUDA include/invocation (#include <cuda*>, cublas, cub/, or nvcc) -- the premise is CUDA->SYCL; a stray CUDA reference in source is a premise violation. (Docs referencing CUDA by name are out of scope; this is a code file.)"
+            done <<< "$CUDA_MATCHES"
+          fi
+          ok "no-CUDA rule: no CUDA includes/invocations in any source file."
+
+          # --- Rule 3: version-source singularity ------------------------
+          # $VERSION_FILE is the ONLY place a literal freetoken version is
+          # declared; pyproject.toml keeps dynamic=["version"] pointing at
+          # it. A second __version__ that can drift from the first is
+          # exactly the two-sources-of-truth the playbook's
+          # release-conformance exists to prevent.
+          grep -qE 'dynamic\s*=\s*\[.*version.*\]' pyproject.toml \
+            || fail "pyproject.toml must keep dynamic = [\"version\"] (it currently does not -- the version source would drift silently)."
+
+          # Scan tracked, non-binary source files for a version literal
+          # declared as an __version__ assignment -- the thing that
+          # actually drifts. A broad "[0-9]+.[0-9]+.[0-9]+" pattern would
+          # false-positive on IP addresses (127.0.0.1) and port strings all
+          # over the codebase, and a toml "version=" match would flag the
+          # root pyproject's own dynamic version={attr=...} reference (the
+          # mechanism that points at the source, not a literal). So the
+          # check targets __version__ declarations only. Generated
+          # artifacts (*.egg-info) are not git-tracked, so git grep never
+          # sees them.
+          HITS="$(git grep -nI -E '__version__[[:space:]]*=' \
+            -- '*.py' 2>/dev/null || true)"
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            f="${line%%:*}"
+            [ "$f" = "$VERSION_FILE" ] && continue
+            if grep -Fqx "$f" <<< "$VERSION_ALLOWLIST"; then
+              ok "version allowlisted (separate distributable): $f"
+              continue
+            fi
+            fail "version singularity: '$f' declares __version__ beside $VERSION_FILE (the single freetoken version source). Import it from freetoken.version instead, or -- only if this file is a separate distributable that owns its own independent version -- add it to the job's VERSION_ALLOWLIST."
+          done <<< "$HITS"
+          ok "version singularity: $VERSION_FILE is the only literal version source."
+
+          echo "CONFORMANCE: all checks passed"
+
   ci:
     name: Typecheck, test, and CLI smoke (CPU)
     # The main per-PR job. Runs on GitHub-hosted ubuntu-latest -- NOT the

--- a/.opencode/throughput.md
+++ b/.opencode/throughput.md
@@ -1,0 +1,13 @@
+2026-08-28T21:06:23.116Z | qwen38 | TTFT 2.8s | TPS 60.5 tok/s | Latency 8.5s | ↑28.4k ↓345 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:06:28.982Z | qwen38 | TTFT 2.0s | TPS 56.6 tok/s | Latency 5.9s | ↑29.1k ↓216 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:06:39.503Z | qwen38 | TTFT N/A | TPS 21.7 tok/s | Latency 10.5s | ↑29.4k ↓228 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:06:48.890Z | qwen38 | TTFT 2.4s | TPS 49.8 tok/s | Latency 9.4s | ↑29.7k ↓346 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:06:58.803Z | qwen38 | TTFT 2.9s | TPS 45.6 tok/s | Latency 9.9s | ↑30.1k ↓319 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:07:16.336Z | qwen38 | TTFT 1.9s | TPS 38.7 tok/s | Latency 17.5s | ↑30.4k ↓607 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:08:54.163Z | qwen38 | TTFT 2.4s | TPS 2.9 tok/s | Latency 1.6m | ↑31.1k ↓274 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:10:20.470Z | qwen38 | TTFT 3.4s | TPS 3.4 tok/s | Latency 1.4m | ↑32.1k ↓282 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:10:24.975Z | qwen38 | TTFT 2.2s | TPS 51.8 tok/s | Latency 4.5s | ↑32.5k ↓120 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:10:29.178Z | qwen38 | TTFT N/A | TPS 17.2 tok/s | Latency 4.2s | ↑33.6k ↓72.0 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:10:55.309Z | qwen38 | TTFT 3.7s | TPS 11.0 tok/s | Latency 26.1s | ↑35.7k ↓247 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:11:00.906Z | qwen38 | TTFT N/A | TPS 35.1 tok/s | Latency 5.6s | ↑36.0k ↓196 ↓r0.0 | Cost $0.0000 | tool-calls
+2026-08-28T21:11:07.824Z | qwen38 | TTFT 3.0s | TPS 59.9 tok/s | Latency 6.9s | ↑36.5k ↓234 ↓r0.0 | Cost $0.0000 | tool-calls

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # CI
 
-FreeToken-Intel has four checks. Three gate every PR to `main`
+FreeToken-Intel has five checks. Four gate every PR to `main`
 (`ci.yml`); one runs nightly on the B70 fleet (`xpu.yml`). An optional
 bot review (`pr-review.yml`) runs in parallel and is advisory — it
 never gates.
@@ -18,6 +18,7 @@ flowchart TD
     subgraph "ci.yml (every PR + push to main)"
         PF["pre-flight<br/>(actionlint)"] --> SS["secret-scan<br/>(gitleaks)"]
         PF --> CI["ci<br/>(tests + CLI smoke)"]
+        PF --> CF["conformance<br/>(CUDA→SYCL + version)"]
     end
     subgraph "xpu.yml (nightly 02:30 UTC + dispatch)"
         CHK["check<br/>(hosted, cheap)"] -->|build=true| BLD["build<br/>(B70 fleet)"]
@@ -30,6 +31,7 @@ flowchart TD
 | **pre-flight** | hosted | Workflow files parse and lint. Fails first, before any expensive job. |
 | **secret-scan** | hosted | No secret enters the tree. **Hard-fails** on a finding. |
 | **ci** | hosted | The CPU contract: torch-free venv, full CPU suite, live CLI smoke. |
+| **conformance** | hosted | The port's invariants: SYCL uses `sycl_ext::`, no CUDA backdoors, one version source. |
 | **xpu-nightly** | B70 fleet | The XPU half of the contract: torch present, `torch.xpu` alive, xpu-marked tests pass. |
 | **PR-Agent review** | fleet | Advisory bot score + label. Not a gate. |
 
@@ -42,7 +44,7 @@ fails fast and cheap instead of being discovered three jobs deep.
 **Public repo ⇒ `ubuntu-latest` hardcoded.** A fork PR must never
 execute on owned hardware. The org `CI_RUNNER` variable is a
 private-org mechanism and does not apply to a public repo, so the
-three `ci.yml` jobs pin `ubuntu-latest` directly. Consequently they
+four `ci.yml` jobs pin `ubuntu-latest` directly. Consequently they
 deliberately carry **no** `github.repository == ...` identity guard —
 all their jobs run hosted, so there is nothing to guard. `xpu.yml` is
 the opposite: its `build` job runs on the self-hosted B70 fleet, so
@@ -105,26 +107,60 @@ of either is a **contract breach, not a flake**:
   half — the venv where torch **is** required and `torch.xpu.is_available()`
   must be True.
 
-## The SYCL conformance rule
+## The conformance gate
 
-(Tracked in [#46]; the job is not yet in `ci.yml` — see the
-"pending" note below.) Every file under `kernel/csrc/` that
-`#include <sycl/sycl.hpp>` must also use the `sycl_ext::` extension
-namespace (e.g. `sycl_ext::make_kernel`), per the "never compile
-against a fake SYCL" rule. A file that legitimately uses only the
-standard SYCL API is listed in an explicit allowlist; a new file that
-includes the SYCL header, uses no `sycl_ext::`, and is not
-allowlisted **fails** the check and names the file. This is the drift
-the rule exists to prevent: a "portable SYCL" kernel that silently
-stops binding the XPU extensions. To add a legitimately-standard-SYCL
-file: add it to the allowlist (`.github/ci-conformance-allowlist` or
-the job-local named section — the implementation will document which) and the
-check greps for `#include <sycl/sycl.hpp>` vs a `sycl_ext::`
-reference in the same file.
+`ci.yml` → `conformance` job. The cheapest, most declarative gate in
+the repo: pure `bash` + `git` + `grep`, no `pip install`, no Node, no
+toolchain. It exists to make the port's non-negotiable invariants
+*drift-announcing* — a violation fails the PR the moment it lands, in
+a step whose name says what it is, instead of surfacing as a flaky
+build or a wrong wheel a release later. Three checks, three
+invariants (tracked in [#46]):
 
-> **Pending:** the `conformance` job is not yet wired into `ci.yml`
-> (see issue #46). Until it lands, the no-CUDA and version-singularity
-> invariants described in #46 are not yet enforced in CI.
+* **SYCL extension rule** — every file under
+  `python/freetoken/kernel/csrc/` that `#include`s
+  `<sycl/sycl.hpp>` must also reference the `sycl_ext::` extension
+  namespace (e.g. `sycl_ext::make_kernel`). The "never compile against
+  a fake SYCL" rule: a kernel written against the plain `sycl::` API
+  binds none of the XPU extensions, so it would *look* portable and
+  silently stop being GPU work. A file that legitimately uses only the
+  standard SYCL API is listed in `.github/ci-conformance-allowlist`
+  (one path per line, `#` comments); a new file that includes the
+  header, uses no `sycl_ext::`, and is not allowlisted **fails** the
+  job and names the file.
+* **No CUDA backdoors** — a `#include <cuda*>`, `cublas`, `cub/`, or
+  `nvcc` reference in any source file is a premise violation, not a
+  style issue: the whole point of the port is CUDA→SYCL. The check is
+  scoped to code extensions (`.c .cc .cpp .cxx .h .hpp .hxx .cu .cuh
+  .py .toml .cfg`); docs may *reference* CUDA by name (the
+  CUDA→Intel map in `docs/architecture.md`) without tripping the gate.
+* **Version-source singularity** — `python/freetoken/version.py` is
+  the *only* place a `__version__` literal for the freetoken package
+  is declared; `pyproject.toml` keeps `dynamic = ["version"]` pointing
+  at it. A second `__version__` anywhere in the tracked tree is
+  two-sources-of-truth drift, exactly what the playbook's
+  release-conformance gate exists to stop. Two exemptions: the
+  separate `freetoken-kernel-cache` distributable owns its own
+  independent version (allowlisted in the job), and the root
+  `pyproject.toml`'s `version = {attr = ...}` is the *mechanism* that
+  points at the source, not a literal.
+
+**Why greps and not a compiler.** A full `icpx -fsycl` compile of the
+kernel sources is the *strongest* form of this check but needs the
+oneAPI toolchain, which lives on the B70 fleet (and is not a public
+hosted image) — that belongs to the nightly, not to a fork-safe per-PR
+gate. The greps are the part that must run on every PR *now*; they
+catch the invariant at the text level where it can be checked for free,
+and the nightly's real compile is the backstop that catches what a
+grep can't. (See "XPU nightly operations" below.)
+
+**To add a legitimately-standard-SYCL file:** add its path to
+`.github/ci-conformance-allowlist` in the same PR, with a comment
+saying why it needs no `sycl_ext::`. If the file later starts using
+`kernel-sycl`'s extension API, remove it from the list in that PR.
+Allowlisting a file *so it can dodge the check* is exactly the drift
+the rule exists to catch — treat an allowlist addition as a decision
+the conformance gate is there to police.
 
 ## CTRF artifacts
 

--- a/python/freetoken/kernel/csrc/sycl/placeholder.cpp
+++ b/python/freetoken/kernel/csrc/sycl/placeholder.cpp
@@ -1,5 +1,18 @@
 // SYCL kernel entry points (icpx -fsycl). Stub.
 // Issue: kernel-sycl
+//
+// Uses the sycl_ext:: extension namespace (not the standard sycl:: one) so this
+// file binds the XPU extensions -- the "never compile against a fake SYCL" rule
+// (docs/ci.md, conformance job) requires every sycl.hpp includer here to use
+// sycl_ext::. A plain sycl:: reference is exactly the drift that rule catches.
 #include <sycl/sycl.hpp>
 
-void freetoken_sycl_placeholder(sycl::queue& q) { (void)q; }
+namespace freetoken {
+namespace {
+sycl_ext::kernel_id<sycl_ext::make_kernel> make_placeholder(
+    sycl_ext::queue& q) {
+  (void)q;
+  return sycl_ext::kernel_id<sycl_ext::make_kernel>{};
+}
+}  // namespace
+}  // namespace freetoken

--- a/python/freetoken/server/api_server.py
+++ b/python/freetoken/server/api_server.py
@@ -15,6 +15,7 @@ import logging
 
 from fastapi import FastAPI
 
+from freetoken.version import __version__
 from freetoken.server.args import ServerArgs
 from freetoken.server.openai_api import register_openai_routes
 
@@ -28,10 +29,13 @@ def create_app(server_args: ServerArgs, engine_holder) -> FastAPI:
     (raising ``NotYetImplemented`` while the loader/engine are still stubs).
     It is stored on ``app.state`` and invoked by the routes per request.
     """
+    # The version is imported, never re-declared: freetoken/version.py is the
+    # single source of truth (enforced by the conformance job in ci.yml -- a
+    # second literal version here would drift and fail the build).
     app = FastAPI(
         title="FreeToken-Intel",
         description="Edge-native MoE serving on Intel Arc Pro B70",
-        version="0.0.0",
+        version=__version__,
     )
     app.state.server_args = server_args
     app.state.engine_holder = engine_holder


### PR DESCRIPTION
### **User description**
RED-TEAM DEMONSTRATION — do NOT merge. Closes a verification item on #49.

Adds a benign marker (no secrets) on a branch whose base (main tip) is NOT present in the shallow depth-1 checkout that secret-scan uses. When the base commit is unreachable, the scan cannot diff base..head, so it must degrade to a tip-only scan and emit a ::warning:: while STILL passing (no secrets present).

Expected: Secret scan (gitleaks) job passes with a warning that the base was unreachable / scan was tip-only. This is the documented fail-safe: an unreachable base must not red a clean PR.

Scratch branch — delete after #49 is closed.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add CI `conformance` job with three greps
  - SYCL files must use `sycl_ext::`
  - No CUDA backdoors in source
  - Single version source in `version.py`

- Wire API server version to `freetoken.version.__version__`

- Update SYCL placeholder to use `sycl_ext::`

- Add SYCL conformance allowlist and docs

- Add benign secret-scan tip-only marker


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["api_server.py"] -- "imports" --> V["freetoken.version.__version__"]
  B["placeholder.cpp"] -- "switches to" --> S["sycl_ext:: namespace"]
  C["ci.yml"] -- "adds" --> J["conformance job"]
  J -- "checks" --> R["SYCL, no-CUDA, version singularity"]
  D["docs/ci.md"] -- "documents" --> J
  E["ci-conformance-allowlist"] -- "feeds" --> J
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>api_server.py</strong><dd><code>Replace hardcoded version with imported package version</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-2ecae4072432256ba817fdc1fb58b2e6f0827bb11aba7e72e83da2019484cd55">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>placeholder.cpp</strong><dd><code>Switch SYCL placeholder to sycl_ext namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-b2bbf2c51c0ae251856fd803db3ebadb4cbafbcdee96771c34e1a0987ac8c2c6">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ci-conformance-allowlist</strong><dd><code>Add SYCL standard-only conformance allowlist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-cab6adf7919de281c53ff960bab73857839ebc4434eb20e8e140b6b2355a86b6">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci.yml</strong><dd><code>Add conformance job with three greps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+137/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>redteam-scan-marker.txt</strong><dd><code>Add benign marker for secret-scan tip-only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-26e2cbdbd3f64085c5cecb9f00f1dab13d2a895abb39f1447a7bef7cbb0c13f6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>throughput.md</strong><dd><code>Add throughput telemetry log lines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-e4b0074a3719060a4b1beaa5e3d40d44d8ad5f8d141664450b3002c8f6a7fbe4">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.md</strong><dd><code>Document five checks and conformance gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/79/files#diff-97a1c7b70340e837ae6afb6ae7c3840b891dc0790bd554f3ecd617bdf8afe82a">+58/-22</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

