### PR TITLE
ci(#50): pin the last floating action; red-team the stamp-skip

### DIFF
--- a/.github/workflows/pr-review-reusable.yml
+++ b/.github/workflows/pr-review-reusable.yml
@@ -50,7 +50,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      # SHA-pinned, not a floating tag: a floating `@v7` is the exact failure
+      # class #50's "pin everything" rule exists to eliminate (an upstream
+      # checkout release could change fetch/credential semantics under a
+      # green-looking run, invisibly). This is the same v7.0.1 commit xpu.yml
+      # pins; bump deliberately, one PR per action, never implicitly.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -216,11 +216,12 @@ better, so we borrowed them:
 
 ## Rules
 
-* **Pin actions deliberately.** Every `uses:` in `ci.yml` and
-  `xpu.yml` is pinned to a full commit SHA (not a floating tag) with a
-  trailing `# vN` comment naming the release the SHA is. Bump pins
-  **deliberately, one PR per action, never implicitly** — an unpinned
-  tag is the same failure class as the playbook's retired
+* **Pin actions deliberately.** Every `uses:` in `ci.yml`, `xpu.yml`,
+  and the vendored `pr-review-reusable.yml` (invoked by ci.yml's
+  PR-agent job) is pinned to a full commit SHA (not a floating tag)
+  with a trailing `# vN` comment naming the release the SHA is. Bump
+  pins **deliberately, one PR per action, never implicitly** — an
+  unpinned tag is the same failure class as the playbook's retired
   `CI_RUNNER || 'ubuntu-latest'` bug: a silent, invisible behavior
   change (a new action release could change checkout or upload
   semantics under a green-looking run).


### PR DESCRIPTION
### **User description**
## Closes #50

## Already in place (from #75/#76, verified)
Items 1, 2, and 5 were implemented when xpu.yml was created and documented:
- **1. SHA-stamp idempotency** — xpu.yml `check` job (hosted) compares GITHUB_SHA to the last green xpu-nightly head_sha; equal -> build=false + visible notice; `force: true` dispatch bypasses; per-branch concurrency, no cancel-in-progress.
- **2. Fork-proofing** — every xpu.yml job carries the `github.repository == 'Performant-Labs/FreeToken-Intel'` guard; ci.yml has a comment (docs/ci.md "Why these shapes") explaining its hosted jobs need none.
- **5. docs/ci.md** — "Upstream comparison (vs FlashML)" table + the deliberate-bump pin rule + the build/publish credential-quarantine principle for #31.

## This PR adds (the two remaining gaps)
- **3. SHA-pin the last floating action.** ci.yml and xpu.yml were pinned, but the vendored pr-review-reusable.yml still used `actions/checkout@v7` — a floating tag on a job that runs on the self-hosted fleet. Now pinned to the same v7.0.1 commit xpu.yml uses (3d3c42e5...), with a comment. No floating `uses:` remain in any workflow. The pin rule in docs/ci.md now names pr-review-reusable.yml explicitly.

## Red-team pass (per #49's standard) — real runs
- **Unchanged HEAD is skipped:** dispatched xpu.yml at the current main head (bae3b8c, already green) -> check printed "already green at bae3b8c... on refs/heads/main -- skipping; a no-op night must not touch the B70." and the B70 build job was **SKIPPED**. Run: https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33215010801
- **force:true bypasses:** dispatched xpu.yml with force=true at the same HEAD -> check printed "force=true -- bypassing the stamp check." and the B70 build job **RAN** (green). Run: https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33215065146
- **A fork's dispatch cannot reach the fleet job** — the check job's `if: github.repository == ...` guard means a fork run never emits build=true, and the build job carries the same guard (belt + suspenders). A real fork dispatch cannot be generated from this repo, so this is recorded as the enforced-by-construction path (both guards are in the file and actionlint-verified).

All four acceptance bullets are satisfied.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Pin `actions/checkout` in vendored `pr-review-reusable.yml` from floating `@v7` to full SHA `3d3c42e5aac5ba805825da76410c181273ba90b1`.

- Add comment documenting the pin rule and deliberate bump policy.

- Update `docs/ci.md` rule scope to include `pr-review-reusable.yml`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Floating actions/checkout@v7 in pr-review-reusable.yml"] -- "pin to full SHA" --> B["checkout@3d3c42e... # v7.0.1"]
  B -- "update scope" --> C["docs/ci.md pin rule includes pr-review-reusable.yml"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-review-reusable.yml</strong><dd><code>Pin checkout action to full SHA</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-review-reusable.yml

<ul><li>Pin <code>actions/checkout</code> from floating <code>@v7</code> to full commit SHA <br><code>3d3c42e5aac5ba805825da76410c181273ba90b1</code>.<br> <li> Add explanatory comment about avoiding silent drift from upstream <br>action releases.<br> <li> Align pin with same <code>v7.0.1</code> commit used by <code>xpu.yml</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/80/files#diff-20d1ba61ec95b7f1ef8bb8a0ffa3ecc775e82704710bb4fc9cb5997614cf4c2f">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.md</strong><dd><code>Update CI pin rule documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ci.md

<ul><li>Expand <code>uses:</code> pin rule to explicitly include vendored <br><code>pr-review-reusable.yml</code>.<br> <li> Reflow wording to list all covered workflows.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/80/files#diff-97a1c7b70340e837ae6afb6ae7c3840b891dc0790bd554f3ecd617bdf8afe82a">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

