### PR TITLE
feat(attn-triton): sliding-window (SWA) attention in the reference backend

### DIFF
--- a/python/freetoken/attention/triton.py
+++ b/python/freetoken/attention/triton.py
@@ -31,12 +31,15 @@ class TritonMetadata(BaseAttnMetadata):
 class TritonAttentionBackend(BaseAttnBackend):
     """Pure-torch grouped-query attention.
 
-    ``forward(q, k, v, layer_id, batch, attn_spec)`` takes ``q`` as
-    ``[num_tokens, num_heads, head_dim]`` and ``k`` / ``v`` as
-    ``[num_tokens, num_kv_heads, head_dim]`` (the *new* tokens this step), and
-    returns ``[num_tokens, num_heads, head_dim]``. K/V for the whole sequence
-    are read from the KV pool via the page table, so the buffer holds the full
-    history and each step only appends the new tokens.
+    ``forward(q, k, v, layer_id, batch, attn_spec)`` takes ``q`` / ``k`` / ``v``
+    head-major ``[heads, tokens, head_dim]`` (the *new* tokens this step) and
+    returns ``[heads, tokens, head_dim]``. K/V for the whole sequence are read
+    from the KV pool via the page table, so the buffer holds the full history
+    and each step only appends the new tokens.
+
+    Supports both ``AttnType.FULL`` (plain causal) and ``AttnType.SWA``: when
+    ``attn_spec.sliding_window > 0`` a query attends only the most recent
+    ``sliding_window`` keys (matching the SYCL kernel's branch-free mask).
     """
 
     def __init__(self, config) -> None:
@@ -95,6 +98,11 @@ class TritonAttentionBackend(BaseAttnBackend):
         # attend the whole q against that request's history in one shot. Without
         # it (a caller passing the whole batch's tokens) we walk the batch by
         # global token offset -- the original behavior.
+        # SWA: the layer's sliding-window size (0 / None => plain full causal).
+        # Read once here and passed into _attend_one, so the mask in both call paths
+        # (per-request and whole-batch) is identical.
+        window = int(attn_spec.sliding_window) if (attn_spec is not None and attn_spec.sliding_window) else 0
+
         if table_idx is not None:
             req = next((r for r in batch.reqs if r.table_idx == table_idx), batch.reqs[0])
             ext = q.shape[1]
@@ -103,7 +111,7 @@ class TritonAttentionBackend(BaseAttnBackend):
             is_decode = req.device_len != len(req.input_ids)
             written = req.device_len if is_decode else ext
             q_pos = self._request_positions(batch, table_idx, ext)
-            out[:] = self._attend_one(req, q, q_pos, written, repeat, scale)
+            out[:] = self._attend_one(req, q, q_pos, written, repeat, scale, window)
             return out
 
         # Whole-batch call (table_idx is None): q/k/v span all requests, so walk
@@ -116,11 +124,11 @@ class TritonAttentionBackend(BaseAttnBackend):
             written = req.device_len if is_decode else req.extend_len
             qh = q[:, token_idx : token_idx + ext, :]
             q_pos = batch.positions[token_idx : token_idx + ext]
-            out[:, token_idx : token_idx + ext, :] = self._attend_one(req, qh, q_pos, written, repeat, scale)
+            out[:, token_idx : token_idx + ext, :] = self._attend_one(req, qh, q_pos, written, repeat, scale, window)
             token_idx += ext
         return out
 
-    def _attend_one(self, req, qh, q_pos, written, repeat, scale) -> torch.Tensor:
+    def _attend_one(self, req, qh, q_pos, written, repeat, scale, window: int = 0) -> torch.Tensor:
         """Attend a block of query rows against one request's KV history."""
         ctx = _get_ctx()
         kv_cache = ctx.kv_cache
@@ -137,11 +145,16 @@ class TritonAttentionBackend(BaseAttnBackend):
             # `repeat_interleave` gives the correct h // repeat mapping.
             k_all = k_all.repeat_interleave(repeat, dim=0)  # [num_heads, written, D]
             v_all = v_all.repeat_interleave(repeat, dim=0)
-        # scores = qh @ k_all^T -> [heads, qlen, written]. Causal mask is
+        # scores = qh @ k_all^T -> [heads, qlen, written]. The mask is
         # [1, qlen, written] (broadcast over the head dim), comparing query
-        # positions (dim 1) against key positions (dim 2).
+        # positions (dim 1) against key positions (dim 2). Causal: a query at
+        # position q attends keys at position <= q. SWA (window > 0) additionally
+        # restricts to the most recent `window` keys: q - keypos < window. This
+        # matches the SYCL kernel's branch-free mask exactly.
         key_pos = torch.arange(written, device=dev)
         allowed = q_pos[None, :, None] >= key_pos[None, None, :]
+        if window > 0:
+            allowed = allowed & ((q_pos[None, :, None] - key_pos[None, None, :]) < window)
         scores = torch.matmul(qh, k_all.transpose(-1, -2)) * scale
         scores = torch.where(allowed, scores, torch.full_like(scores, float("-inf")))
         return torch.matmul(torch.softmax(scores, dim=-1), v_all)  # [heads, qlen, D]

--- a/tests/test_attention_triton.py
+++ b/tests/test_attention_triton.py
@@ -1,0 +1,278 @@
+"""Tests for the Triton/Intel reference attention backend (issue ``attn-triton``, #4).
+
+Acceptance bar (#4): prefill + decode for ``AttnType.FULL`` **and** ``AttnType.SWA``
+on the B70, registered as ``triton``, with a numerical check vs a reference path.
+
+Two halves:
+
+* CPU-safe (the per-PR ``ci`` job, torch-free): ``triton`` is registered and
+  *declares* SWA as a supported type (so the registry's capability advertising is
+  honest even before an XPU is present).
+
+* ``xpu``-marked (the B70 nightly, ``.venv-xpu``): the backend is driven directly
+  against a controlled KV pool and its output compared to a hand-written pure-torch
+  grouped-query + sliding-window reference. The reference is the same math the SYCL
+  kernel uses (causal ``keypos <= qpos`` AND ``qpos - keypos < window``), so agreement
+  to float32 epsilon means the triton SWA mask is correct.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_triton_backend_registered_and_declares_swa():
+    """No torch needed: the registry advertises FULL + SWA for the triton backend.
+
+    This is the CPU-safe half. The triton backend *declares* ``AttnType.SWA`` in its
+    BackendInfo; the numerical xpu tests below prove the declaration is real.
+    """
+    from freetoken.attention import attention_backend_info
+    from freetoken.attention.base import AttnType
+
+    info = attention_backend_info("triton")
+    assert AttnType.SWA in info.supported_types
+    assert AttnType.FULL in info.supported_types
+    # The backend consumes the attn_spec (it reads sliding_window off it).
+    assert info.consumes_attn_spec
+
+
+# --- XPU: drive the triton backend against a controlled KV pool -----------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    """Reset the global context around every test (the xpu tests set it)."""
+    yield
+    from freetoken.core import reset_global_ctx
+
+    reset_global_ctx()
+
+
+# A tiny GQA config: 4 query heads, 2 KV heads (repeat 2), head_dim 16.
+TINY_CONFIG = {
+    "architectures": ["Qwen3MoeForCausalLM"],
+    "model_type": "qwen3_moe",
+    "hidden_size": 64,
+    "vocab_size": 32,
+    "num_hidden_layers": 1,
+    "num_local_experts": 2,
+    "num_experts_per_tok": 1,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "intermediate_size": 32,
+    "moe_intermediate_size": 32,
+    "max_position_embeddings": 128,
+    "rope_theta": 1000000.0,
+}
+
+
+def _gqa_windowed_reference(q, k_all, v_all, q_pos, window, *, scale):
+    """Reference grouped-query + sliding-window attention over a token history.
+
+    ``q`` is ``[num_heads, qlen, head_dim]``. ``k_all`` / ``v_all`` are already
+    head-expanded to ``[num_heads, written, head_dim]`` (the same ``h -> h //
+    repeat`` interleave the backend uses). ``q_pos`` is the absolute position of
+    each query row; a key at position ``keypos`` is attended iff ``keypos <=
+    qpos`` (causal) and ``qpos - keypos < window`` (sliding window; window<=0 is
+    unbounded). Returns ``[num_heads, qlen, head_dim]``.
+    """
+    import torch
+
+    written = k_all.shape[1]
+    key_pos = torch.arange(written, device=q.device)
+    mask = q_pos[None, :, None] >= key_pos[None, None, :]
+    if window > 0:
+        mask = mask & ((q_pos[None, :, None] - key_pos[None, None, :]) < window)
+    scores = torch.matmul(q, k_all.transpose(-1, -2)) * scale
+    scores = torch.where(mask, scores, torch.full_like(scores, float("-inf")))
+    return torch.matmul(torch.softmax(scores, dim=-1), v_all)
+
+
+def _drive_triton_backend(dev, *, q, k_hist, v_hist, q_pos, written, window):
+    """Set up a global ctx (KV pool with known history) and run the triton backend.
+
+    ``k_hist`` / ``v_hist`` are token-major ``[written, num_kv, head_dim]`` -- the
+    full history stored in the pool (positions 0..written-1). The request is framed
+    as a *decode* step whose `device_len == written` (so ``forward`` reads the whole
+    stored history), and the new query block ``q`` (``[num_heads, qlen, head_dim]``,
+    ``qlen == q_pos.numel()``) attends at absolute positions ``q_pos`` under sliding
+    window ``window``. Returns the backend's output ``[num_heads, qlen, head_dim]``.
+    """
+    import torch
+    from freetoken.core import Batch, Context, Req, SamplingParams, set_global_ctx
+    from freetoken.kvcache.base import BaseKVCachePool
+
+    config = type("Cfg", (), dict(TINY_CONFIG))()
+    num_kv = TINY_CONFIG["num_key_value_heads"]
+    head_dim = TINY_CONFIG["hidden_size"] // TINY_CONFIG["num_attention_heads"]
+
+    pool = BaseKVCachePool(config, page_size=1, num_pages=written, device=dev, dtype=torch.float32)
+    # Identity page table: slot == position. Row 0 is the single request.
+    pool.attach_page_table(torch.arange(written, device=dev, dtype=torch.int32).reshape(1, written))
+    pool.write_kv(k_hist.transpose(0, 1), v_hist.transpose(0, 1), torch.arange(written, device=dev))
+
+    ctx = Context(page_size=1)
+    ctx.kv_cache = pool
+    from freetoken.attention.triton import TritonAttentionBackend
+
+    backend = TritonAttentionBackend(config)
+    ctx.attn_backend = backend
+    set_global_ctx(ctx)
+
+    # Frame as a decode step: device_len == written (the full stored history) while
+    # input_ids is shorter, so `is_decode` (device_len != len(input_ids)) is True and
+    # `forward` reads the whole history (`written = device_len`), not just the new
+    # tokens. qlen new tokens attend over that history at positions `q_pos`.
+    qlen = q_pos.numel()
+    req = Req(
+        input_ids=list(range(max(1, written - qlen))),
+        table_idx=0,
+        cached_len=0,
+        output_len=0,
+        uid=0,
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=1),
+        cache_handle=None,
+    )
+    req.device_len = written  # override: the full history length (decode framing)
+    batch = Batch(reqs=[req], phase="decode", positions=q_pos)
+
+    from freetoken.attention.base import AttentionSpec
+
+    # The *new* k/v passed to forward() are not read by _attend_one (it gathers the
+    # full history from the pool); forward only needs their head count + a valid
+    # shape to size its output buffer. num_kv (not num_heads) KV heads.
+    out = backend.forward(
+        q,
+        _dummy_new_kv(num_kv, num_kv, head_dim, dev),
+        _dummy_new_kv(num_kv, num_kv, head_dim, dev),
+        layer_id=0,
+        batch=batch,
+        attn_spec=AttentionSpec(sliding_window=window),
+        table_idx=0,
+    )
+    return out
+
+
+def _dummy_new_kv(num_kv, num_kv_, head_dim, dev):
+    """A zero [num_kv, 1, head_dim] tensor -- the *new* k/v the backend's forward()
+    needs a shape for, but ``_attend_one`` never reads (it gathers history from the
+    pool). Only the head count (dim 0) and a valid shape matter."""
+    import torch
+
+    return torch.zeros((num_kv, 1, head_dim), device=dev, dtype=torch.float32)
+
+
+def _reference_for_drive(q, k_hist, v_hist, q_pos, written, window):
+    num_heads = TINY_CONFIG["num_attention_heads"]
+    num_kv = TINY_CONFIG["num_key_value_heads"]
+    repeat = num_heads // num_kv
+    head_dim = TINY_CONFIG["hidden_size"] // num_heads
+    scale = 1.0 / (head_dim**0.5)
+    # GQA: query head h attends KV head h // repeat -> an *interleave* of the KV
+    # head axis (the exact mapping the triton backend's _attend_one uses).
+    k_all = k_hist.transpose(0, 1).contiguous()
+    v_all = v_hist.transpose(0, 1).contiguous()
+    if repeat != 1:
+        k_all = k_all.repeat_interleave(repeat, dim=0)
+        v_all = v_all.repeat_interleave(repeat, dim=0)
+    return _gqa_windowed_reference(q, k_all, v_all, q_pos, window, scale=scale)
+
+
+@pytest.mark.xpu
+def test_triton_swa_prefill_matches_reference_on_xpu():
+    """Prefill: a multi-token query block attends over its own growing history under
+    a sliding window. window=3 means each query sees only its 3 most recent keys."""
+    import torch
+
+    assert torch.xpu.is_available(), "this test runs on the B70 XPU nightly"
+    dev = torch.device("xpu")
+
+    heads, num_kv, head_dim = 4, 2, 16
+    written = 6
+    qlen = 4  # the new query block (positions 2..5 attending over the history)
+    q_pos = torch.tensor([2, 3, 4, 5], device=dev, dtype=torch.int64)
+    gen = torch.Generator(device=dev).manual_seed(7)
+    q = torch.randn(heads, qlen, head_dim, generator=gen, device=dev) * 0.5
+    k_hist = torch.randn(written, num_kv, head_dim, generator=gen, device=dev) * 0.5
+    v_hist = torch.randn(written, num_kv, head_dim, generator=gen, device=dev) * 0.5
+
+    for window in (3, 5):
+        out = _drive_triton_backend(
+            dev, q=q, k_hist=k_hist, v_hist=v_hist, q_pos=q_pos, written=written, window=window
+        )
+        ref = _reference_for_drive(q, k_hist, v_hist, q_pos, written, window)
+        assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5), (
+            f"triton SWA (window={window}) diverged: max err "
+            f"{torch.max((out - ref).abs()):.3e}"
+        )
+    from freetoken.core import reset_global_ctx
+
+    reset_global_ctx()
+
+
+@pytest.mark.xpu
+def test_triton_swa_decode_matches_reference_on_xpu():
+    """Decode: a single new token attends over a long history under a sliding window.
+
+    This is the case where a wrong window (e.g. off-by-one, or a window that
+    includes one too many / too few old keys) changes the output, because the new
+    token sees a bounded suffix of the history."""
+    import torch
+
+    assert torch.xpu.is_available()
+    dev = torch.device("xpu")
+
+    heads, num_kv, head_dim = 4, 2, 16
+    written = 8  # the pool holds the full history at positions 0..7
+    # The new token is the LAST slot (position written-1): by decode time its own
+    # K/V is already in the pool, so `device_len == written` and the newest key is
+    # at position written-1 (not a separate `written`-th slot). The reference and
+    # the backend both mask `qpos - keypos < window` over keypos 0..written-1.
+    q_pos = torch.tensor([written - 1], device=dev, dtype=torch.int64)
+    gen = torch.Generator(device=dev).manual_seed(11)
+    q = torch.randn(heads, 1, head_dim, generator=gen, device=dev) * 0.5
+    k_hist = torch.randn(written, num_kv, head_dim, generator=gen, device=dev) * 0.5
+    v_hist = torch.randn(written, num_kv, head_dim, generator=gen, device=dev) * 0.5
+
+    # window=1 now selects only the newest key (keypos written-1 == the new token
+    # itself, which is in the pool) -> well-defined, so the full range is exercised.
+    for window in (1, 2, 3, 8, 16):  # 1=self only; 2=newest 2; 3=small; 8=whole history; 16=> history
+        out = _drive_triton_backend(
+            dev, q=q, k_hist=k_hist, v_hist=v_hist, q_pos=q_pos, written=written, window=window
+        )
+        ref = _reference_for_drive(q, k_hist, v_hist, q_pos, written, window)
+        assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5), (
+            f"triton SWA decode (window={window}) diverged: max err "
+            f"{torch.max((out - ref).abs()):.3e}"
+        )
+    from freetoken.core import reset_global_ctx
+
+    reset_global_ctx()
+
+
+@pytest.mark.xpu
+def test_triton_swa_window_larger_than_history_equals_full_on_xpu():
+    """A window >= the history length must be numerically identical to plain FULL
+    causal attention (the window truncates nothing)."""
+    import torch
+
+    assert torch.xpu.is_available()
+    dev = torch.device("xpu")
+
+    heads, num_kv, head_dim = 4, 2, 16
+    written = 5
+    q_pos = torch.tensor([5], device=dev, dtype=torch.int64)
+    gen = torch.Generator(device=dev).manual_seed(13)
+    q = torch.randn(heads, 1, head_dim, generator=gen, device=dev) * 0.5
+    k_hist = torch.randn(written, num_kv, head_dim, generator=gen, device=dev) * 0.5
+    v_hist = torch.randn(written, num_kv, head_dim, generator=gen, device=dev) * 0.5
+
+    out_full = _drive_triton_backend(dev, q=q, k_hist=k_hist, v_hist=v_hist, q_pos=q_pos, written=written, window=0)
+    out_big = _drive_triton_backend(dev, q=q, k_hist=k_hist, v_hist=v_hist, q_pos=q_pos, written=written, window=32)
+    assert torch.allclose(out_full, out_big, atol=1e-6, rtol=1e-6), (
+        f"a window larger than the history must equal FULL causal: max err "
+        f"{torch.max((out_full - out_big).abs()):.3e}"
+    )
+    from freetoken.core import reset_global_ctx
+
+    reset_global_ctx()


### PR DESCRIPTION
### **User description**
## Summary

Completes the attention half of the CUDA→SYCL port's reference path: the **Triton/Intel reference backend** (the default `--attention-backend` on Intel) now supports **`AttnType.SWA`** (sliding-window attention), closing the last gap in issue #4's acceptance criteria.

**Closes #4 (`attn-triton`).**

## The gap

The registry already *declared* SWA for the `triton` backend (`BackendInfo.supported_types = {FULL, SWA}`, `consumes_attn_spec=True`), but the implementation ignored it: `forward()` accepted `attn_spec` yet `_attend_one` always applied a plain full-causal mask. So the declaration was aspirational, not real.

## The change

- Thread the layer's `sliding_window` (from `attn_spec`) into `_attend_one` for **both** call paths (the per-request `table_idx` path and the whole-batch path), so the mask is identical regardless of how the model calls the backend.
- `window 0 / None` → plain full causal (behavior unchanged). `window > 0` → each query attends only its most recent `window` keys via `qpos - keypos < window`, matching the SYCL kernel's branch-free mask exactly (the #5 kernel uses the same predicate).
- Corrected a stale class docstring that described token-major shapes (`[num_tokens, heads, head_dim]`) when the code is head-major (`[heads, tokens, head_dim]`), and documented the FULL + SWA support.

## Verification (B70)

New `tests/test_attention_triton.py`:
- **CPU-safe** (per-PR CI, torch-free): `triton` is registered and declares FULL + SWA + `consumes_attn_spec`.
- **XPU** (B70 nightly): the backend is driven against a controlled KV pool and compared to a hand-written pure-torch grouped-query + sliding-window reference (the same `keypos <= qpos AND qpos - keypos < window` predicate the SYCL kernel uses):
  - prefill: a multi-query block under windows 3 and 5;
  - decode: a single newest token under windows 1/2/3/8/16 (window==1 selects just the newest key; the range spans self-only through the whole history);
  - a window ≥ the history length is numerically identical to FULL causal.

  All agree to float32 epsilon.

- **Full XPU suite: 11 passed** (no regressions in the just-merged #5 SYCL tests). **CPU suite: 47 passed, 9 skipped** (CI's exact `-m "not xpu and not slow and not needs_weights"`).
- **No new ruff findings** (the one `BLE001` in `triton.py` is pre-existing; the repo has no ruff lint gate yet). **Conformance Rules 1+2** unchanged and passing (SYCL `sycl::ext::oneapi` + no CUDA backdoors).

## Notes

- This is pure-torch (no SYCL compile), so it runs in the XPU nightly without a toolchain build — fast.
- The qwen3_moe model does not currently set `sliding_window` in its `AttentionSpec`, so under the *real* model `window` stays 0 (FULL) and behavior is byte-identical to before; the SWA path is exercised by the direct-backend tests here. A model that opts a layer into SWA (e.g. a sliding-window model) will get correct windowed attention for free.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `sliding_window` mask to `_attend_one` for FULL/SWA parity.

- Pass `window` through both `forward` call paths.

- Add CPU registration and XPU numerical reference tests.

- Update docstring and comments for head-major SWA support.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    attn_spec["attn_spec.sliding_window"] -- "extract window" --> forward["forward()"]
    forward -- "pass window" --> attend["_attend_one()"]
    attend -- "update mask" --> mask["causal AND qpos-keypos < window"]
    tests["tests/test_attention_triton.py"] -- "compare" --> attend
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>triton.py</strong><dd><code>Add sliding-window mask to Triton backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/attention/triton.py

<ul><li>Extract <code>window</code> from <code>attn_spec.sliding_window</code> in <code>forward</code>.<br> <li> Pass <code>window</code> to <code>_attend_one</code> for per-request and whole-batch paths.<br> <li> Extend causal mask with <code>qpos - keypos < window</code> when window > 0.<br> <li> Update class docstring for head-major shapes and SWA support.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/84/files#diff-818a55a2203b4bd840161ef989795eda5653e2508e412689e4aa674ee4297562">+24/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_attention_triton.py</strong><dd><code>Add Triton SWA registration and XPU tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_attention_triton.py

<ul><li>Add CPU-safe test for <code>triton</code> backend declaring FULL/SWA.<br> <li> Add XPU prefill, decode, and window-larger-than-history numerical <br>tests.<br> <li> Implement pure-torch GQA sliding-window reference for comparison.<br> <li> Drive backend via controlled KV pool and decode framing.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/84/files#diff-40237d7c9acd0eae2fa3b459bd0162d832f8d2bc5dda58d95585808cecfefa7e">+278/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

