### PR TITLE
feat(models): Qwen3.5/3.6 (qwen3_5_moe) config + weight adapters

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -8,7 +8,7 @@ tunes first, and 32 GB is enough with offload.
 
 | Model | Status | Issue |
 | --- | --- | --- |
-| Qwen3.6 / Qwen3.5 MoE (`Qwen3_5Moe*`) | stub | `models-qwen35` |
+| Qwen3.6 / Qwen3.5 MoE (`Qwen3_5Moe*`) | config + weights (forward pending) | `models-qwen35` |
 | Qwen3-MoE | stub | `models-qwen3-moe` |
 | Qwen3 / Qwen2 / Llama / Mistral / Gemma-4 dense | stub | `models-dense` |
 | gpt-oss | stub | `models-gpt-oss` |

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1,21 +1,303 @@
-"""Model package stub: qwen3_5_moe.
+"""Model adapter: Qwen3.5 / Qwen3.6 hybrid linear-attention + MoE (``qwen3_5_moe``).
 
-Upstream NVIDIA path: python/freetoken/models/qwen3_5_moe/
-Fill in: GitHub issue `models-qwen35` (see docs/architecture.md).
+The hero model for the Intel Arc Pro B70 target (issue #18). Qwen3.5/3.6 is a
+*hybrid-attention, multimodal MoE*: most layers are **linear attention**
+(Gated-DeltaNet -- a cheap, recurrent, O(1)-per-token state) with a few
+**full-attention** (gated, GQA) layers interleaved, on top of a 256-way
+top-8 MoE with an always-on shared expert. The language tower lives under
+``text_config`` / ``model.language_model.*`` (a vision tower ``model.visual.*``
+sits alongside it and is out of scope for text serving).
+
+This module owns the two *checkpoint adapters* the loader calls:
+
+* :func:`parse_config` -- torch-free; reads the (nested, multimodal) HF
+  ``config.json`` and produces a :class:`freetoken.models.config.ModelConfig`
+  with the MoE plumbing the bank fabricator reads (``is_moe``, ``num_experts``,
+  ``moe_intermediate_size``, ``num_moe_layers``), stowing the full raw
+  ``text_config`` in ``config.attrs`` for the forward pass.
+* :func:`iter_weights` -- torch-gated; drops the vision tower, remaps the
+  ``model.language_model.*`` prefix to ``model.*`` (so the loader's MoE-bank
+  plumbing resolves the keys), and routes the routed experts to host (offload
+  banks) and everything else to the dense device.
+
+The forward pass (linear-attention recurrent state + full attention + MoE) is a
+later issue; :class:`Qwen3_5MoEForCausalLM` is a forward-only stub for now.
+Instantiating it is torch-gated (the constructor rebinds the instance to a real
+``nn.Module``), but *importing* this module never requires torch.
 """
+
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from typing import Any, Dict, Optional
+
+from freetoken._stub import NotYetImplemented
+from freetoken.models.config import ModelConfig
+
+__all__ = ["parse_config", "iter_weights", "Qwen3_5MoEForCausalLM"]
+
+# The text tower's prefix inside the multimodal checkpoint; remapped to
+# ``model.*`` so the loader's MoE-bank plumbing (and the forward pass) sees
+# plain ``model.*`` keys, exactly like the dense qwen3_moe model.
+_LANGUAGE_PREFIX = "model.language_model."
+_LANGUAGE_TARGET = "model."
+_VISUAL_PREFIX = "model.visual."
+
+# The one checkpoint weight that the routed-expert bank fabricator expects to be
+# an *untransposed* [n_experts, hidden, inter] (see qwen3_moe._transpose_down):
+# the down proj of a routed expert. The shared expert's down proj is a *dense*
+# weight (it stays on the device, not in the host banks), so it keeps the
+# transposed [hidden, inter] layout and must NOT be caught by the key heuristic.
+# Matching on the key (not the shape) keeps the dense shared expert out of the
+# bank transpose even when its shape would otherwise look like an expert.
+_MOE_ROUTED_DOWN_KEY = "mlp.experts.down_proj"
 
 
-def parse_config(*args, **kwargs):
-    unimplemented("parse_config", "models-qwen35")
-def iter_weights(*args, **kwargs):
-    unimplemented("iter_weights", "models-qwen35")
+def _expert_source_names(cfg: ModelConfig) -> set:
+    """The (remapped) key suffixes that are routed-expert weights: these go to
+    the host offload banks, everything else stays dense on the device.
+
+    Mirrors qwen3_moe's ``_is_expert_key`` so the loader's MoE-bank plumbing
+    (``load_moe_expert_sources`` / ``stream_moe_expert_sources``) can resolve the
+    experts out of the remapped ``model.*`` keys. A routed-expert weight carries
+    a ``.experts.`` segment; the dense shared expert (``mlp.shared_expert.*``)
+    does not, so it stays on the device.
+    """
+    names = set()
+    if cfg.is_moe:
+        for i in range(cfg.first_k_dense_replace, cfg.num_moe_layers + cfg.first_k_dense_replace):
+            mlp = f"model.layers.{i}.mlp.experts"
+            for suffix in ("gate_proj.weight", "up_proj.weight", "down_proj.weight"):
+                names.add(f"{mlp}.{suffix}")
+            # The real (packed) Qwen3.5/3.6 layout also uses the fused / un-suffixed
+            # names; accept both so a checkpoint in either spelling routes correctly.
+            names.add(f"{mlp}.gate_up_proj")
+            names.add(f"{mlp}.down_proj")
+    return names
+
+
+def _first(d: dict, *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in d and d[key] is not None:
+            return d[key]
+    return default
+
+
+def _rope_theta(text_config: dict) -> float:
+    """Qwen's RoPE theta: it may live under ``rope_parameters.rope_theta`` (the
+    Qwen3.6 spelling) or the flat ``rope_theta``. Returns the resolved scalar
+    (the nested ``rope_parameters`` -- partial_rotary_factor etc. -- stays
+    reachable through ``attrs['text_config']`` for the partial-rotary
+    full-attention projection in the forward pass)."""
+    theta = _first(text_config, "rope_theta", default=None)
+    if theta is None:
+        params = text_config.get("rope_parameters")
+        if isinstance(params, dict):
+            theta = params.get("rope_theta")
+    return float(theta) if theta is not None else 10000.0
+
+
+def parse_config(hf_config: Any, *, use_offload_moe: bool = False) -> ModelConfig:
+    """Build a :class:`ModelConfig` from a (multimodal) Qwen3.5/3.6 HF config.
+
+    Torch-free. The language tower is nested under ``text_config`` (the config is
+    multimodal); when the given config is already the flat text object (no
+    ``text_config`` sub-dict), its own fields are used instead. The MoE fields
+    the bank fabricator reads (``num_experts`` -- stored under ``num_experts``
+    here, sometimes ``num_local_experts`` -- plus ``moe_intermediate_size``)
+    are set first-class, and ``is_moe``/``num_moe_layers`` are derived so the
+    loader routes the routed experts to host. The full raw ``text_config`` is
+    stowed in ``config.attrs`` for the forward pass (it needs ``layer_types``,
+    ``partial_rotary_factor``, the output-gate flag, and the linear-attention
+    head dims, none of which are first-class ``ModelConfig`` fields).
+    """
+    raw = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    # Multimodal config: the language tower is nested under text_config. If the
+    # config handed in is already the flat text object, use its own fields.
+    text_config = raw.get("text_config")
+    if not isinstance(text_config, dict):
+        text_config = raw
+
+    hidden = int(_first(text_config, "hidden_size", default=0))
+    num_layers = int(_first(text_config, "num_hidden_layers", default=0))
+    num_attention_heads = int(_first(text_config, "num_attention_heads", default=0))
+    num_key_value_heads = int(
+        _first(text_config, "num_key_value_heads", "num_kv_heads", default=0)
+    )
+    vocab_size = int(_first(text_config, "vocab_size", default=0))
+    max_position_embeddings = int(
+        _first(text_config, "max_position_embeddings", default=0)
+    )
+    # Qwen3.5/3.6 stores the expert count under num_experts; some transformers
+    # configs spell it num_local_experts. Prefer the explicit one, fall back to
+    # the other. (The bank fabricator reads cfg.num_experts.)
+    num_experts = int(
+        _first(text_config, "num_local_experts", "num_experts", default=0)
+    )
+    moe_intermediate_size = int(
+        _first(
+            text_config,
+            "moe_intermediate_size",
+            "intermediate_size",
+            default=0,
+        )
+    )
+    first_k_dense_replace = int(_first(text_config, "first_k_dense_replace", default=0))
+    head_dim = int(_first(text_config, "head_dim", default=0))
+
+    cfg = ModelConfig(
+        architectures=list(_first(raw, "architectures", default=[]) or []),
+        hidden_size=hidden,
+        vocab_size=vocab_size,
+        num_layers=num_layers,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        max_position_embeddings=max_position_embeddings,
+        moe_intermediate_size=moe_intermediate_size,
+        first_k_dense_replace=first_k_dense_replace,
+    )
+    # The MoE plumbing: set is_moe explicitly (the text_config is a separate
+    # dict from the top-level raw, so ModelConfig.__post_init__ can't infer it),
+    # and re-derive num_moe_layers (post_init only sets it when is_moe was true
+    # at construction). All Qwen3.5/3.6 layers are MoE (no dense prefix).
+    cfg.is_moe = bool(num_experts > 0)
+    if cfg.is_moe:
+        cfg.num_experts = num_experts
+        cfg.num_experts_per_tok = int(_first(text_config, "num_experts_per_tok", default=0))
+        cfg.num_moe_layers = num_layers - first_k_dense_replace
+    cfg.use_offload_moe = bool(use_offload_moe)
+
+    # rope_theta is a first-class ModelConfig field (the rope builder reads it);
+    # resolve it (it may live under rope_parameters.rope_theta) and set the field.
+    cfg.rope_theta = _rope_theta(text_config)
+
+    # The forward pass reads the full raw text tower (layer_types,
+    # partial_rotary_factor, attn_output_gate, the linear-attention dims, ...),
+    # none of which are first-class ModelConfig fields.
+    attrs: Dict[str, Any] = {"text_config": dict(text_config), "head_dim": head_dim}
+    cfg.attrs.update(attrs)
+    return cfg
+
+
+def iter_weights(
+    model_path: str,
+    device: Any,
+    *,
+    include_moe_experts: bool = True,
+    include_non_moe: bool = True,
+    dtype: Any = None,
+) -> Any:
+    """Stream Qwen3.5/3.6 weights from ``model_path`` as ``(name, tensor)``.
+
+    torch-gated (imports ``torch`` + the safetensors streamer lazily inside the
+    generator body, so importing this module stays torch-free). The checkpoint
+    is multimodal:
+
+    * ``model.visual.*`` (the vision tower) is **dropped** -- text serving does
+      not run the image encoder.
+    * ``model.language_model.*`` is **remapped** to ``model.*`` so the loader's
+      MoE-bank plumbing (and the forward pass) see the same key shape as the
+      dense qwen3_moe model.
+    * Routed experts (``.experts.*``) go to **host** (offload banks); everything
+      else -- including the always-on shared expert and the linear-attention
+      weights -- goes to the dense ``device``.
+
+    ``include_moe_experts`` / ``include_non_moe`` follow the loader contract:
+    the MoE-bank path passes ``include_non_moe=False`` (experts only); the dense
+    placement passes ``include_moe_experts=False`` (everything else, including
+    the shared expert).
+    """
+    # Lazy torch import: keeps this module importable on a torch-free box.
+    import torch
+
+    from freetoken.models.weight import iter_safetensors
+
+    # Routed-expert key set (remapped names) for the routing decision. The loader
+    # always has a resolved config (it parses the checkpoint before calling
+    # iter_weights), but fall back to the substring heuristic if not.
+    cfg = _cfg_for_path(model_path)
+    routed = _expert_source_names(cfg) if cfg is not None else None
+
+    for raw_name, tensor in iter_safetensors(model_path, device=device):
+        # Drop the vision tower outright (text serving does not run the
+        # image encoder).
+        if raw_name.startswith(_VISUAL_PREFIX):
+            continue
+        # Remap the language tower to the plain model.* prefix so the loader's
+        # MoE-bank plumbing (and the forward pass) see the same key shape as the
+        # dense qwen3_moe model.
+        name = (
+            _LANGUAGE_TARGET + raw_name[len(_LANGUAGE_PREFIX):]
+            if raw_name.startswith(_LANGUAGE_PREFIX)
+            else raw_name
+        )
+        if routed is not None:
+            expert = name in routed
+        else:
+            expert = ".experts." in name
+        # The loader's contract: include_moe_experts=False (dense placement)
+        # drops the routed experts; include_non_moe=False (bank fabricator)
+        # keeps only the routed experts.
+        if not include_moe_experts and expert:
+            continue
+        if not include_non_moe and not expert:
+            continue
+        if dtype is not None and tensor.dtype != dtype:
+            tensor = tensor.to(dtype)
+        # Routed experts stream to host (offload banks); the rest (dense: the
+        # shared expert, linear-attention weights, embeddings, norms, lm_head)
+        # goes to the dense device. The loader banks the experts and moves them
+        # to the xpu per-token at decode time.
+        if expert and tensor.device.type != "cpu":
+            tensor = tensor.to("cpu")
+        yield name, tensor
+
+
+def _cfg_for_path(model_path: str) -> Optional[ModelConfig]:
+    """Best-effort resolve of the ModelConfig for ``model_path`` (to build the
+    exact routed-expert key set). Returns None when the path has no readable
+    config (the iterator then falls back to the substring heuristic)."""
+    try:
+        from freetoken.utils.hf import cached_load_hf_config
+
+        return parse_config(cached_load_hf_config(model_path))
+    except Exception:
+        return None
+
+
 class Qwen3_5MoEForCausalLM:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    """Hybrid linear-attention + MoE text model.
+
+    **Phase 1 (this issue):** a forward-only stub. The constructor rebinds the
+    *instance* to a real ``torch.nn.Module`` (so the loader's
+    ``named_parameters()`` / bookkeeping runs) while keeping the class object a
+    plain object -- that way this module imports without torch and only the
+    instantiation (the torch loader/engine path) needs it. ``forward`` fails
+    loud (NotImplementedError) until the hybrid forward (linear-attention
+    recurrent state + gated full attention + MoE with shared expert + the
+    engine's recurrent-state decode path) lands in a later issue.
+    """
+
+    def __init__(self, config, device=None) -> None:
+        import torch
+
+        # Make *this instance* a real nn.Module: rebind the instance's
+        # __class__ to nn.Module FIRST, then run the module bookkeeping. torch's
+        # Module.__init__ only executes the init body when the instance's class
+        # resolves to nn.Module, so the rebind has to precede the call. The
+        # class *object* keeps its plain base, so importing this module never
+        # needs torch -- only instantiating it (the torch loader/engine path)
+        # does.
+        self.__class__ = torch.nn.Module
+        torch.nn.Module.__init__(self)
+        object.__setattr__(self, "config", config)
+        object.__setattr__(self, "device", device)
 
     def forward(self, *args, **kwargs):
-        unimplemented("Qwen3_5MoEForCausalLM.forward", "models-qwen35")
-
+        raise NotYetImplemented(
+            "Qwen3.5/3.6 (qwen3_5_moe) forward pass",
+            "models-qwen35",
+            "The hybrid linear-attention + MoE forward (Gated-DeltaNet recurrent "
+            "state + gated full attention + 256-way shared-expert MoE + the "
+            "engine's recurrent-state decode path) is a later issue; this adapter "
+            "currently wires config/weights only (issue #18, phase 1).",
+        )

--- a/tests/test_models_qwen35_config.py
+++ b/tests/test_models_qwen35_config.py
@@ -1,0 +1,167 @@
+"""Tests for the Qwen3.5/3.6 (``qwen3_5_moe``) config adapter -- torch-free.
+
+The hero model is a **hybrid-attention multimodal MoE**: 30 linear-attention
+(Gated-DeltaNet) layers + 10 full-GQA layers, a 256-way router top-8 **plus an
+always-on shared expert** per MoE layer, and a text tower nested under
+``text_config`` (the vision tower is out of scope for text serving).
+
+``parse_config`` is the one checkpoint adapter that needs no torch, so it runs
+on the CPU-only ``.venv`` (no torch there). The weight-routing half
+(``iter_weights``) and the full ``load_model`` path need torch and live in
+``test_models_qwen35_loader.py`` (torch-gated; run under the XPU venv / nightly).
+
+The forward pass is a later issue; here we only assert the parsed config carries
+the fields the loader reads (the MoE bank fabricator keys off ``is_moe`` /
+``num_moe_layers`` / ``num_experts`` / ``moe_intermediate_size``) and stashes the
+full raw ``text_config`` (``layer_types``, partial-RoPE, the output-gate flag,
+the linear-attention head dims) in ``config.attrs`` for the forward pass.
+"""
+from __future__ import annotations
+
+from freetoken.models.config import ModelConfig
+from freetoken.models.qwen3_5_moe import parse_config
+from freetoken.utils.hf import RawConfigShim
+
+# A text tower shaped like the real Qwen3.6-35B-A3B config (small dims so a test
+# could also run it under torch if needed). 4 layers, every 4th full-attention
+# (3 linear + 1 full), matching the hero model's full_attention_interval=4.
+_TEXT_CONFIG = {
+    "hidden_size": 128,
+    "num_hidden_layers": 4,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 2,
+    "head_dim": 256,
+    "num_experts": 256,
+    "num_experts_per_tok": 8,
+    "moe_intermediate_size": 512,
+    "shared_expert_intermediate_size": 512,
+    "vocab_size": 1000,
+    "max_position_embeddings": 4096,
+    "full_attention_interval": 4,
+    "layer_types": [
+        "linear_attention",
+        "linear_attention",
+        "linear_attention",
+        "full_attention",
+    ],
+    "partial_rotary_factor": 0.25,
+    "attn_output_gate": True,
+    "linear_num_key_heads": 16,
+    "linear_num_value_heads": 32,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+    "linear_conv_kernel_dim": 4,
+    "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.25},
+    "rope_theta": 10000000.0,
+}
+
+
+def _hf_config(overrides=None):
+    """A multimodal HF-style config (nested ``text_config``), as ``config.json``
+    ships it: the top level carries the vision fields, the language tower is
+    nested under ``text_config``."""
+    text_config = dict(_TEXT_CONFIG)
+    if overrides:
+        text_config.update(overrides)
+    return RawConfigShim(
+        {
+            "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+            "model_type": "qwen3_5_moe",
+            "vision_config": {"hidden_size": 7, "num_chunks": 3},
+            "text_config": text_config,
+        }
+    )
+
+
+# --- parse_config: the fields the loader reads --------------------------------
+
+
+def test_parse_config_multimodal_reads_text_config():
+    cfg = parse_config(_hf_config())
+    assert cfg.architectures == ["Qwen3_5MoeForConditionalGeneration"]
+    # Read off the nested text tower, not the vision top-level.
+    assert cfg.hidden_size == 128
+    assert cfg.vocab_size == 1000
+    assert cfg.num_layers == 4
+    assert cfg.num_attention_heads == 16
+    assert cfg.num_key_value_heads == 2
+    assert cfg.max_position_embeddings == 4096
+    assert cfg.rope_theta == 10000000.0
+
+
+def test_parse_config_moe_plumbing_fields():
+    cfg = parse_config(_hf_config())
+    # The MoE bank fabricator / loader keys off these first-class fields.
+    assert cfg.is_moe is True
+    assert cfg.num_experts == 256
+    assert cfg.moe_intermediate_size == 512
+    assert cfg.num_experts_per_tok == 8
+    # No leading dense layers -> every layer is MoE (num_moe_layers = 4).
+    assert cfg.first_k_dense_replace == 0
+    assert cfg.num_moe_layers == 4
+    assert isinstance(cfg, ModelConfig)
+
+
+def test_parse_config_stows_full_text_config_in_attrs():
+    cfg = parse_config(_hf_config())
+    tc = cfg.attrs["text_config"]
+    assert tc["layer_types"] == [
+        "linear_attention",
+        "linear_attention",
+        "linear_attention",
+        "full_attention",
+    ]
+    assert tc["full_attention_interval"] == 4
+    assert tc["attn_output_gate"] is True
+    assert tc["partial_rotary_factor"] == 0.25
+    assert tc["head_dim"] == 256
+    assert tc["linear_num_key_heads"] == 16
+    assert tc["linear_num_value_heads"] == 32
+    assert tc["shared_expert_intermediate_size"] == 512
+    # The hybrid split the forward pass will consume: 3 linear + 1 full.
+    assert sum(1 for t in tc["layer_types"] if t == "full_attention") == 1
+    assert sum(1 for t in tc["layer_types"] if t == "linear_attention") == 3
+
+
+def test_parse_config_offload_flag_is_not_a_ckpt_field():
+    assert parse_config(_hf_config()).use_offload_moe is False
+    assert parse_config(_hf_config(), use_offload_moe=True).use_offload_moe is True
+
+
+def test_parse_config_flat_config_falls_back_to_top_level():
+    # A config that is already the flat text object (no text_config nesting, e.g.
+    # a hand-built one) must parse using its own top-level fields.
+    flat = RawConfigShim(
+        {
+            "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+            "hidden_size": 64,
+            "num_hidden_layers": 2,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_intermediate_size": 16,
+            "vocab_size": 32,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+        }
+    )
+    cfg = parse_config(flat)
+    assert cfg.hidden_size == 64
+    assert cfg.num_layers == 2
+    assert cfg.num_experts == 4
+    assert cfg.is_moe is True
+    assert cfg.num_moe_layers == 2
+
+
+def test_parse_config_expert_count_spelling():
+    # The real Qwen3.5/3.6 config stores the count under num_experts; a
+    # transformers-style config may store it under num_local_experts. Both must
+    # resolve to the same place (num_local_experts takes precedence if present).
+    assert parse_config(_hf_config({"num_experts": 256})).num_experts == 256
+    cfg = parse_config(_hf_config({"num_experts": 7, "num_local_experts": 13}))
+    assert cfg.num_experts == 13
+
+
+# (Instantiating the model class needs torch -- the constructor rebinds the
+# instance to an nn.Module -- so that lives in the torch-gated loader tests,
+# not here. This file must stay importable and runnable on the torch-free CPU
+# box.)

--- a/tests/test_models_qwen35_loader.py
+++ b/tests/test_models_qwen35_loader.py
@@ -1,0 +1,196 @@
+"""Tests for the Qwen3.5/3.6 (``qwen3_5_moe``) weight path -- torch-gated.
+
+``iter_weights`` (and the ``load_model`` path built on it) need torch to move
+tensors to their destination devices, so this module is torch-gated: it
+``importorskip("torch")``s at the top and is deselected on a torch-free box (the
+CPU ``.venv``). It runs under the XPU venv / nightly.
+
+These tests drive the real loader contract against a fabricated *multimodal*
+checkpoint whose language tower sits under ``model.language_model.*`` (the Qwen3.6
+layout) and ships a ``model.visual.*`` vision tower:
+
+* ``iter_weights`` drops the vision tower and remaps ``model.language_model.*``
+  to ``model.*`` so the loader's MoE-bank plumbing resolves the keys.
+* routed experts go to host; everything else (including the always-on shared
+  expert and the linear-attention weights) goes to the dense device.
+* ``load_moe_expert_sources`` builds the per-layer banks from the remapped keys.
+* ``load_model`` runs end-to-end: it places the dense weights, builds the banks,
+  and returns the (still-stub) model -- whose ``forward`` fails loud until the
+  real hybrid forward lands in a later issue.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.loader import load_model
+from freetoken.models.qwen3_5_moe import iter_weights
+from freetoken.models.weight import load_moe_expert_sources
+
+H, I, E, V, L = 32, 16, 4, 64, 2
+
+# A small hybrid text tower: 2 layers (1 linear-attention + 1 full-attention),
+# a 4-way router top-2 + an always-on shared expert, and a vision tower to prove
+# it is dropped. The text tower sits under model.language_model.* (the real
+# Qwen3.6 layout).
+def _qwen35_text_config() -> dict:
+    return {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": 8,
+        "attn_output_gate": True,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 2,
+        "layer_types": ["linear_attention", "full_attention"],
+        "linear_num_key_heads": 2,
+        "linear_num_value_heads": 2,
+        "linear_key_head_dim": 8,
+        "linear_value_head_dim": 8,
+        "linear_conv_kernel_dim": 4,
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+
+
+def _qwen35_weights() -> dict:
+    """The full hybrid text-tower weight set (every layer), plus a vision tower.
+
+    Layer 0 is linear-attention (linear_attn.* + conv1d), layer 1 is full-
+    attention (self_attn.*); both carry a MoE mlp (experts.* + shared_expert.*).
+    """
+    w = {
+        "model.visual.blocks.0.attn.q.weight": torch.randn(8, 8),
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+    }
+    for layer in range(L):
+        if layer % 2 == 0:  # linear-attention (Gated DeltaNet) layer
+            w[f"model.language_model.layers.{layer}.linear_attn.in_proj_qkv.weight"] = torch.randn(2 * H, H)
+            w[f"model.language_model.layers.{layer}.linear_attn.in_proj_z.weight"] = torch.randn(H, H)
+            w[f"model.language_model.layers.{layer}.linear_attn.conv1d.weight"] = torch.randn(4, H)
+            w[f"model.language_model.layers.{layer}.linear_attn.out_proj.weight"] = torch.randn(H, H)
+        else:  # full-GQA layer
+            w[f"model.language_model.layers.{layer}.self_attn.q_proj.weight"] = torch.randn(H, H)
+            w[f"model.language_model.layers.{layer}.self_attn.o_proj.weight"] = torch.randn(H, H)
+        # Every layer has a MoE block: 4 routed experts (packed) + a shared expert.
+        w[f"model.language_model.layers.{layer}.mlp.gate.weight"] = torch.randn(E, H)
+        w[f"model.language_model.layers.{layer}.mlp.experts.gate_up_proj"] = torch.randn(E, 2 * I, H)
+        w[f"model.language_model.layers.{layer}.mlp.experts.down_proj"] = torch.randn(E, H, I)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert.gate_proj.weight"] = torch.randn(I, H)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert.up_proj.weight"] = torch.randn(I, H)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert.down_proj.weight"] = torch.randn(H, I)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert_gate.weight"] = torch.randn(1, H)
+    return w
+
+
+@pytest.fixture(scope="module")
+def qwen35_ckpt(tmp_path_factory):
+    """A fabricated multimodal Qwen3.5/3.6 checkpoint (config.json + one
+    safetensors shard + index)."""
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35")
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "vision_config": {"hidden_size": 8, "num_chunks": 2},
+        "text_config": _qwen35_text_config(),
+    }
+    weights = _qwen35_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+# --- iter_weights: vision drop + language_model remap + device routing --------
+
+
+def test_iter_weights_drops_visual_and_remaps_language_model(qwen35_ckpt):
+    names = [n for n, _ in iter_weights(qwen35_ckpt, torch.device("cpu"))]
+    # No vision tower leaks through.
+    assert not any(n.startswith("model.visual") for n in names)
+    # The language prefix is remapped to the FreeToken name space.
+    assert "model.embed_tokens.weight" in names
+    assert "model.layers.0.linear_attn.in_proj_qkv.weight" in names
+    assert "model.layers.1.self_attn.q_proj.weight" in names
+    assert "model.layers.0.mlp.experts.gate_up_proj" in names
+    assert "model.layers.0.mlp.shared_expert.gate_proj.weight" in names
+    assert "lm_head.weight" in names
+    # The raw checkpoint keys are never yielded un-remapped.
+    assert not any(n.startswith("model.language_model") for n in names)
+
+
+def test_iter_weights_dense_goes_to_device_experts_go_to_host(qwen35_ckpt):
+    got = {n: t for n, t in iter_weights(qwen35_ckpt, torch.device("cpu"))}
+    # Dense weights (incl. the shared expert + linear-attention) -> the device.
+    assert got["model.layers.0.mlp.shared_expert.gate_proj.weight"].device.type == "cpu"
+    assert got["model.layers.0.linear_attn.in_proj_qkv.weight"].device.type == "cpu"
+    # Routed experts -> host offload banks (cpu here).
+    assert got["model.layers.0.mlp.experts.gate_up_proj"].device.type == "cpu"
+
+
+def test_iter_weights_include_flags_route_experts_only(qwen35_ckpt):
+    # include_moe_experts=False: the routed experts are dropped, the shared expert
+    # (dense) is kept. This is the loader's dense path.
+    no_experts = [n for n, _ in iter_weights(qwen35_ckpt, torch.device("cpu"), include_moe_experts=False)]
+    assert not any(".experts." in n for n in no_experts)
+    assert "model.layers.0.mlp.shared_expert.gate_proj.weight" in no_experts
+    assert "model.embed_tokens.weight" in no_experts
+    # include_non_moe=False: only the routed experts remain (the loader's bank path).
+    experts_only = [n for n, _ in iter_weights(qwen35_ckpt, torch.device("cpu"), include_non_moe=False)]
+    assert all(".experts." in n for n in experts_only)
+    assert len(experts_only) == 2 * L  # gate_up_proj + down_proj per layer
+
+
+# --- the MoE bank path (remapped keys must satisfy the loader) -----------------
+
+
+def test_load_moe_expert_sources_builds_banks_from_remapped_keys(qwen35_ckpt):
+    gate_up, down = load_moe_expert_sources(qwen35_ckpt, dtype=torch.bfloat16)
+    assert len(gate_up) == L and len(down) == L
+    assert gate_up[0].shape == (E, 2 * I, H)
+    assert down[0].shape == (E, H, I)
+    assert gate_up[0].device.type == "cpu"
+    assert down[0].device.type == "cpu"
+
+
+# --- the top-level loader path -------------------------------------------------
+
+
+def test_load_model_end_to_end_on_multimodal_ckpt(qwen35_ckpt):
+    model, expert_sources = load_model(qwen35_ckpt, torch.device("cpu"))
+    # The loader resolves the multimodal config, builds the model (which the
+    # stub's __init__ rebinds to a plain nn.Module instance), and attaches the
+    # per-layer host banks for the routed experts. (isinstance(model,
+    # Qwen3_5MoEForCausalLM) is False by design -- the instance's class is
+    # nn.Module so the loader's named_parameters() resolves; that is what the
+    # loader actually consumes.)
+    assert isinstance(model, torch.nn.Module)
+    assert model.config.architectures == ["Qwen3_5MoeForConditionalGeneration"]
+    assert len(expert_sources[0]) == L
+    assert expert_sources[0][0].shape == (E, 2 * I, H)
+    assert expert_sources[0][0].device.type == "cpu"
+
+
+def test_load_model_stub_forward_fails_loud(qwen35_ckpt):
+    model, _ = load_model(qwen35_ckpt, torch.device("cpu"))
+    # Phase 1: the hybrid forward is not implemented yet -- the loaded model must
+    # fail loud (NotImplementedError) rather than silently run a wrong forward.
+    with pytest.raises(NotImplementedError):
+        model.forward()


### PR DESCRIPTION
### **User description**
## What

Phase 1 of the hero model ([#18]): wire the two **checkpoint adapters** for
`Qwen3.6-35B-A3B` / Qwen3.5 so `ft serve --model ...` gets a real
`parse_config` + `iter_weights` instead of the bare stub. The hybrid
**forward pass** (Gated-DeltaNet linear attention + gated full attention +
256-way shared-expert MoE + the engine's recurrent-state decode path) is a
separate follow-up PR — until then the loaded model fails loud
(`NotImplementedError`) rather than silently running a wrong forward.

## Adapters

- **`parse_config`** (torch-free): reads the *nested* `text_config` off the
  multimodal `config.json` (the language tower), with a flat-config fallback.
  Sets the first-class MoE plumbing the bank fabricator reads
  (`is_moe`, `num_experts`, `moe_intermediate_size`, `num_moe_layers`,
  `rope_theta`) and stows the full raw `text_config`
  (`layer_types`, `partial_rotary_factor`, `attn_output_gate`, the
  linear-attention head dims) in `config.attrs` for the forward pass.
- **`iter_weights`** (torch-gated, lazy import so the module stays
  importable on the torch-free CPU box): drops `model.visual.*` (the vision
  tower is out of scope for text serving), remaps `model.language_model.*`
  to `model.*` so the loader's MoE-bank plumbing resolves the keys, and routes
  the routed experts to host (offload banks) with everything else — including
  the always-on **shared expert** and the linear-attention weights — to the
  dense device. Honors the loader's `include_moe_experts` / `include_non_moe`
  contract.

## The stub

`Qwen3_5MoEForCausalLM` is a plain class whose `__init__` rebinds the
*instance* to a real `nn.Module` (so the loader's `named_parameters()` runs)
while the class object stays plain — so the module imports without torch and
only instantiation (the torch loader/engine path) needs it.

## Tests

- `tests/test_models_qwen35_config.py` — torch-free: runs on the CPU `.venv`.
  Covers the multimodal nested-text_config parse, the MoE plumbing fields, the
  `attrs["text_config"]` stash, the flat-config fallback, and the
  `num_experts`/`num_local_experts` spelling.
- `tests/test_models_qwen35_loader.py` — torch-gated
  (`importorskip("torch")`; deselected on the torch-free box, runs under the
  XPU venv/nightly): drives the real loader contract against a fabricated
  multimodal checkpoint (vision drop, language-model remap, expert routing,
  bank shapes, end-to-end `load_model`, and the forward-fails-loud guarantee).

## Verification

- `bash tools/validate.sh` → OK (5 passed, 3 skipped, 0 failed); CPU suite
  green (54 passed, no regressions), `ci:venv-contract` holds (torch not
  importable in `.venv`).
- torch-gated loader tests: 6/6 pass under `.venv-xpu`.

Closes phase 1 of #18. The hybrid forward pass is the follow-up.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add Qwen3.5/3.6 `parse_config` torch-free config adapter

- Add `iter_weights` weight adapter remapping multimodal checkpoint

- Implement forward-only stub failing with `NotImplementedError`

- Add config and loader tests; update docs status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["Multimodal HF config"] --> Parse["parse_config"]
  Parse --> ModelCfg["ModelConfig: MoE fields + attrs"]
  Weights["Checkpoint weights"] --> Iter["iter_weights"]
  Iter --> Remap["Drop visual, remap language_model"]
  Remap --> Route["Route experts to host, dense to device"]
  Stub["Forward stub"] --> Fail["NotImplementedError"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add Qwen3.5/3.6 config and weight adapters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li>Implement <code>parse_config</code> to read nested <code>text_config</code>, derive MoE fields, <br>stash attrs.<br> <li> Implement <code>iter_weights</code> to drop <code>model.visual.*</code>, remap <br><code>model.language_model.*</code> to <code>model.*</code>, route experts to host.<br> <li> Add forward-only stub class that rebinds instance to <code>torch.nn.Module</code> <br>and raises <code>NotYetImplemented</code>.<br> <li> Add helper functions <code>_expert_source_names</code>, <code>_first</code>, <code>_rope_theta</code>, <br><code>_cfg_for_path</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/89/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+294/-12</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_qwen35_config.py</strong><dd><code>Add torch-free config adapter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_qwen35_config.py

<ul><li>Test multimodal <code>text_config</code> parsing and flat-config fallback.<br> <li> Verify MoE plumbing fields and <code>attrs["text_config"]</code> stash.<br> <li> Cover <code>num_experts</code> / <code>num_local_experts</code> spelling precedence.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/89/files#diff-d31e0b31ffdf949b8a1d93b828ee2dbab0245bfac453b3195e4ce73fbc2bedc9">+167/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_models_qwen35_loader.py</strong><dd><code>Add torch-gated loader/weight adapter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_qwen35_loader.py

<ul><li>Fabricate multimodal checkpoint with vision tower and nested language <br>model.<br> <li> Verify vision drop, language-model remap, and device routing for <br>experts.<br> <li> Test <code>load_moe_expert_sources</code> bank shapes and <code>load_model</code> end-to-end.<br> <li> Assert stub forward raises <code>NotImplementedError</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/89/files#diff-a6033b042354d3944a84d9a2e3636f7ba9b2641d0fadd5df6447456feeb1e2b5">+196/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.md</strong><dd><code>Update Qwen3.5 model status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/models.md

- Change Qwen3.5/3.6 status from stub to config + weights.


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/89/files#diff-4a20043f76a669ac926c5fe98226490f44635620f8f20e27f2703b7eb46a4b2e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___