### PR TITLE
fix(ci): stop gh pr edit from silently swallowing the PR-Agent score banner

### DIFF
--- a/.github/workflows/pr-review-reusable.yml
+++ b/.github/workflows/pr-review-reusable.yml
@@ -322,7 +322,13 @@ jobs:
               gh label create "$HS_LABEL" --color '5319e7' \
                 --description 'High-stakes review-rigor (see project pr-review config)' \
                 --repo "$REPO" 2>/dev/null || true
-                gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$HS_LABEL" 2>/dev/null || true
+                # `gh issue edit --add-label`, not `gh pr edit --add-label`: on this
+                # repo's self-hosted runner (jupiter-b70) `gh pr edit` reliably fails
+                # (confirmed via job logs across every PR-Agent run) while `gh issue
+                # edit` against the same PR number succeeds — PRs are issues under
+                # the hood, so the label lands identically. See the "Inject score
+                # banner" step below for the same swap and the root-cause writeup.
+                gh issue edit "$PR_NUM" --repo "$REPO" --add-label "$HS_LABEL" 2>/dev/null || true
                 exit 0
             fi
           done
@@ -743,8 +749,35 @@ jobs:
           } > /tmp/pr-body-banner.md
 
           cat /tmp/pr-body-banner.md /tmp/pr-body-current.md > /tmp/pr-body-new.md
-          gh pr edit "$PR_NUM" --body-file /tmp/pr-body-new.md --repo "${REPO}" 2>/dev/null || { echo "::warning::could not write banner to PR body (gh unavailable or API error) — the label/status still run."; }
-          echo "Banner injected (score $SCORE)"
+
+          # `gh api PATCH .../pulls/$PR_NUM -f body=...`, not `gh pr edit --body-file`:
+          # on this repo's self-hosted runner (jupiter-b70), `gh pr edit --body-file`
+          # failed on EVERY PR-Agent run so far, with no visible error — the old
+          # `2>/dev/null || { warn }` swallowed the real error, and the unconditional
+          # `echo "Banner injected"` right after printed success regardless, so every
+          # run "passed" in the log while the PR body was never actually touched. The
+          # score-bracket label step directly above it (`gh issue edit --add-label`)
+          # succeeded on every one of those same runs, which is why only the banner
+          # went missing. Testing `gh pr edit` against this org outside CI reproduces
+          # a hard failure (a GraphQL query it issues needs org/team read access no
+          # repo-scoped token — including the Actions GITHUB_TOKEN — can ever have),
+          # while both `gh issue edit --add-label` and this `gh api` PATCH complete
+          # normally with the same credentials — consistent with, though not provably
+          # identical to, whatever `gh pr edit` was hitting in CI. If banners still
+          # don't land after this change, the real error is no longer swallowed —
+          # read it from the `::warning::` this step prints instead of guessing again.
+          # `gh api -f body=@file` does NOT read the file (it sends the literal string
+          # "@path") on the gh version installed here — read the file into a shell
+          # variable and pass that instead. The `if` form keeps this compatible with
+          # the job's `bash -e`: a failed command substitution used directly as an
+          # `if` condition does not abort the step, so the real error can be reported
+          # instead of silently discarded.
+          NEW_BODY="$(cat /tmp/pr-body-new.md)"
+          if BANNER_ERR=$(gh api -X PATCH "repos/${REPO}/pulls/${PR_NUM}" -f body="$NEW_BODY" --silent 2>&1); then
+            echo "Banner injected (score $SCORE)"
+          else
+            echo "::warning::could not write banner to PR body via gh api PATCH: ${BANNER_ERR}"
+          fi
 
       # ── Commit status check ──────────────────────────────────────────────────
       # Green = PR-Agent ran and returned a score, OR the PR diff is entirely


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit c3124a3](https://github.com/Performant-Labs/FreeToken-Intel/commit/c3124a3f5357de79c49cf712e1d287955074c935) · run [#33327325429](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33327325429) · 2026-08-30 12:16 MDT / 2026-08-30 18:16 UTC
<!-- argos-status:end -->

### **User description**

### **User description**
## Why

The PR-Agent score banner (the `🟢 PR-Agent Score: NN` block that's supposed
to get prepended to every PR body) has never actually landed on any PR in
this repo, despite every CI run logging `Banner injected (score N)` as if it
had succeeded.

## Root cause

This repo's PR-Agent workflow (`.github/workflows/pr-review-reusable.yml`) is
a **local vendored copy** of playbook's canonical reusable workflow — required
because FreeToken-Intel is public and playbook is private, and a public repo
cannot call a reusable workflow hosted in a private one. When this copy was
hardened against gaps observed on the self-hosted GPU runner (`jupiter-b70`,
`vars.CI_RUNNER`), several `gh` calls got a `2>/dev/null || { echo ::warning }`
safety net so a flaky `gh` couldn't abort the whole job (see the file's own
`#433` comments).

That safety net had a side effect on the banner-injection step specifically:
`gh pr edit --body-file` has been failing on **every single PR-Agent run**
checked (verified across 4 separate job logs — PRs #84, #88, #89, #90), the
real error was swallowed by `2>/dev/null`, and the unconditional
`echo "Banner injected (score $SCORE)"` right after it printed a false
success line regardless. The score-bracket label step directly above it
(`gh issue edit --add-label`) succeeded on every one of those same runs
(labels like `score-90+` are correctly present on PRs today) — which is
exactly why labels worked but the banner never did.

Re-running `gh pr edit` against this same org outside CI reproduces a hard
failure: it issues a GraphQL query that needs org/team read access no
repo-scoped token can grant (not even the Actions `GITHUB_TOKEN`), while both
`gh issue edit --add-label` and a plain `gh api PATCH` on the same PR complete
normally with identical credentials. This is consistent with, though not
provably identical to, whatever `gh pr edit` has been hitting in CI — the fix
below sidesteps it either way, and if it's ever wrong, the real error is no
longer swallowed.

## Fix

Swap both `gh pr edit` call sites in the vendored workflow for the equivalents
already proven to work against this repo:

- **High-stakes label sync** (`gh pr edit --add-label`) → `gh issue edit --add-label`
- **Banner body write** (`gh pr edit --body-file`) → `gh api -X PATCH repos/OWNER/REPO/pulls/$PR_NUM -f body=...`,
  reading the rendered body into a shell variable first (`gh api -f body=@file`
  does **not** read the file on the gh version installed here — it sends the
  literal string `@path` — confirmed by testing it directly against this repo).

The banner-write `if`/`else` now reports the real `gh api` error via
`::warning::` instead of printing a false "Banner injected" success line if it
ever fails again.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — the workflow YAML still parses.
- `bash -n` on each of the three edited `run:` step bodies (Sync high-stakes
  label, Apply score-bracket label, Inject score banner) — no syntax errors.
- Manually reproduced the `gh pr edit` failure and the `gh issue edit` /
  `gh api PATCH` success against this org outside CI (see investigation
  notes — not included in this PR, available on request).
- Not run through this repo's own CI yet — that requires actually opening/
  updating a PR in this repo, which is what merging this will let happen
  naturally on its own PR-Agent run.

## Scope note (fleet-wide impact)

This appears specific to repos whose PR-Agent job runs on a self-hosted
runner (`vars.CI_RUNNER`) with a `gh` CLI that hits this `gh pr edit` failure
mode — currently only this repo (`CI_RUNNER=jupiter-b70`) among the repos
checked. `performantlabs.com` carries the same *kind* of vendored copy (same
public/private mismatch) but has no `CI_RUNNER` variable set and its banner
works fine; Flotilla calls playbook's reusable workflow directly and also
works fine. Worth flagging to whoever owns `playbook/pipelines/pr-reviewer/`
in case other repos get pointed at self-hosted runners in the future — the
`gh issue edit` / `gh api PATCH` swap is a strictly more robust default
regardless of runner.

🤖 Investigated and fixed with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace failing `gh pr edit` calls in workflow

- Use `gh issue edit` for high-stakes label sync

- Use `gh api PATCH` to write PR banner body

- Surface real errors via `::warning::`, not false success


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR-Agent workflow"] --> B["Replace failing gh pr edit calls"]
  B --> C["High-stakes label: gh issue edit --add-label"]
  B --> D["Banner body: gh api PATCH pulls/<num>"]
  D --> E["Report real error via ::warning::"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-review-reusable.yml</strong><dd><code>Replace failing gh pr edit banner and label calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-review-reusable.yml

<ul><li>Replaced <code>gh pr edit --add-label</code> with <code>gh issue edit --add-label</code> for <br>high-stakes label sync.<br> <li> Replaced <code>gh pr edit --body-file</code> with <code>gh api -X PATCH </code><br><code>repos/OWNER/REPO/pulls/$PR_NUM</code> for banner injection.<br> <li> Reads rendered body into a shell variable before PATCH because <code>gh api </code><br><code>-f body=@file</code> does not read the file.<br> <li> Changed failure handling to surface the real <code>gh api</code> error via <br><code>::warning::</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/92/files#diff-20d1ba61ec95b7f1ef8bb8a0ffa3ecc775e82704710bb4fc9cb5997614cf4c2f">+36/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix


___

### **Description**
- Swap failing `gh pr edit` label sync to `gh issue edit`.

- Patch PR body via `gh api` and shell variable.

- Emit `::warning::` with real API error on failure.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR-Agent workflow"] --> B["Replace gh pr edit --add-label"]
  A --> C["Replace gh pr edit --body-file"]
  B --> D["gh issue edit --add-label"]
  C --> E["gh api PATCH pulls/PR_NUM body"]
  E --> F["Report real error via ::warning::"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-review-reusable.yml</strong><dd><code>Swap `gh pr edit` calls for reliable label and banner updates</code></dd></summary>
<hr>

.github/workflows/pr-review-reusable.yml

<ul><li>Replace <code>gh pr edit --add-label</code> with <code>gh issue edit --add-label</code><br> <li> Replace <code>gh pr edit --body-file</code> with <code>gh api -X PATCH</code> on pulls endpoint<br> <li> Read <code>NEW_BODY</code> from file into shell variable before PATCH<br> <li> Report real <code>gh api</code> errors through <code>::warning::</code> instead of false success</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/92/files#diff-20d1ba61ec95b7f1ef8bb8a0ffa3ecc775e82704710bb4fc9cb5997614cf4c2f">+36/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___