### PR TITLE
fix(server): wire real Engine into ft serve (#93)

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -87,8 +87,15 @@ class Engine:
 
         # Size the paged KV pool. The pool is indexed by token slot
         # (page_size==1 in the reference path), one row per (request, position).
+        # The override is a *floor*, not a cap: it raises the pool for small
+        # test models (which otherwise get a 1-row pool for a 1-row page table
+        # and overrun the gather on decode) but never shrinks a large model's
+        # ``max_running_req * max_seq_len`` pool below what its context needs.
         max_seq_len = config.max_seq_len
-        num_pages = config.num_page_override or (config.max_running_req * max_seq_len)
+        default_num_pages = config.max_running_req * max_seq_len
+        num_pages = (
+            max(config.num_page_override, default_num_pages) if config.num_page_override else default_num_pages
+        )
         self.page_size = config.page_size
         self.max_seq_len = max_seq_len
         self.max_running_req = config.max_running_req

--- a/python/freetoken/server/generation.py
+++ b/python/freetoken/server/generation.py
@@ -3,23 +3,42 @@
 Upstream NVIDIA path: python/freetoken/server/generation.py
 
 This is the seam between the HTTP surface and the engine. The OpenAI routes
-call :func:`stream_chat`; it renders the messages to a prompt, streams decoded
-tokens from the engine, and splits reasoning from content via the configured
-reasoning parser.
+call :func:`stream_chat`; it encodes the messages to prompt token ids, admits
+them to the loaded engine, and streams the generated token ids back, splitting
+reasoning from content via the configured reasoning parser.
 
-Boundary: the engine loop (``#14``) is not implemented yet, so a call into it
-raises :class:`EngineNotReady` (a ``NotYetImplemented``). The routes map that
-to a clean 503 — the server stays up and ``/v1/models`` keeps answering —
-which is exactly what the ``ft serve`` spine relies on to report
-``blocked: engine-loop (#14)`` once the loader and model land.
+Boundary: the engine loop (``#14``) is real, so :func:`_stream_tokens` drives
+the real ``Engine`` (``add_request`` + ``generate``). The only remaining not-ready
+signal is a genuinely unloaded engine (no ``generate`` / no ``add_request``, e.g.
+the ``ft serve`` spine's pre-load holder), which raises
+:class:`EngineNotReady` (a ``NotYetImplemented``) that the routes map to a clean
+503 — the server stays up and ``/v1/models`` keeps answering.
+
+Token-id <-> text: the message frontend (chat-template encode / decode) is still
+a stub (``server-openai`` tokenizer seam), so :func:`_prompt_token_ids` falls
+back to a deterministic hash mapping and :func:`_decode_token` falls back to a
+readable placeholder until the real tokenizer path lands.
 """
 from __future__ import annotations
 
+import hashlib
 import time
 import uuid
 from collections.abc import Iterator
 
 from freetoken._stub import NotYetImplemented
+
+# The reference engine's sampler stops on eos_token_id=-1, so a request never
+# hits an end-of-sequence id; the decode budget comes from max_tokens (or the
+# engine's per-request cap when max_tokens is None). This cap bounds a
+# tokenizer-less smoke test so a mis-set request cannot spin the decode loop.
+_FALLBACK_MAX_TOKENS = 64
+# The prompt encoder's fallback hashes the prompt into the model's *own* vocab
+# (see _prompt_token_ids), not a fixed id space: a fixed 4096 would mint ids far
+# past a small model's vocab, and the embedding layer would gather out of bounds
+# (the engine's KV / embedding math only stays well-formed when every prompt id
+# is < vocab_size).
+_FALLBACK_ID_SPACE_MAX = 4096
 
 
 class EngineNotReady(NotYetImplemented):
@@ -31,7 +50,7 @@ def _chat_completion_id() -> str:
 
 
 def _prompt_from_messages(messages: list[dict]) -> str:
-    """Flatten chat messages into the single prompt string the engine stub takes.
+    """Flatten chat messages into the single prompt string the engine takes.
 
     The real message frontend / chat-template rendering (tokenizer process)
     replaces this once the tokenizer path exists; today it is a
@@ -47,24 +66,101 @@ def _prompt_from_messages(messages: list[dict]) -> str:
     return "\n".join(parts)
 
 
-def _stream_tokens(engine, prompt: str, *, model: str, max_tokens: int | None) -> Iterator[str]:
-    """Yield raw decoded token strings from the engine.
+def _fallback_id_space(engine) -> int:
+    """The id space the fallback prompt encoder hashes into.
 
-    The real implementation (issue #14) submits the prompt via
-    ``engine.add_request`` and drains ``engine.step`` outputs. Until the
-    engine loop lands, an engine without a ``generate`` method is the
-    not-ready signal: it raises ``EngineNotReady`` (a ``NotYetImplemented``),
-    which the routes map to a clean 503. A loaded engine exposes ``generate``
-    and is streamed token by token.
+    Bounded by the model's own vocab size (read from the loaded engine's
+    ``config.model_config.vocab_size``) so the hash-derived id is always a valid
+    embedding-row index: ``embed_tokens`` gathers ``k_buffer[input_ids]``, so an
+    id >= vocab_size reads past the embedding table (an out-of-bounds gather that
+    the XPU runtime aborts on). A fixed 4096 was wrong for small models. When the
+    vocab is unknown (not yet parsed) we fall back to a conservative ceiling.
+    """
+    vocab = getattr(getattr(getattr(engine, "config", None), "model_config", None), "vocab_size", None)
+    if vocab is None:
+        return _FALLBACK_ID_SPACE_MAX
+    return max(2, min(int(vocab), _FALLBACK_ID_SPACE_MAX))
+
+
+def _prompt_token_ids(engine, prompt: str) -> list[int]:
+    """Encode ``prompt`` to the token ids the engine consumes.
+
+    Uses the model's real tokenizer / chat template when the engine exposes one
+    (``tokenizer`` with ``encode``/``apply_chat_template``); until the message
+    frontend (``server-openai`` tokenizer seam) lands, it falls back to a
+    deterministic hash of the prompt bound to the model's own vocab, so the
+    request stays well-formed (a single in-vocab id) and the engine's prefill +
+    embedding / KV math is exercised end to end without a tokenizer on the seam.
+    """
+    tokenizer = getattr(engine, "tokenizer", None)
+    if tokenizer is not None and hasattr(tokenizer, "encode"):
+        return list(tokenizer.encode(prompt))
+    digest = hashlib.sha256(prompt.encode("utf-8")).digest()
+    return [int.from_bytes(digest[:4], "big") % _fallback_id_space(engine)]
+
+
+def _decode_token(engine, token_id: int) -> str:
+    """Decode one generated token id to text (or a readable placeholder).
+
+    Mirrors :func:`_prompt_token_ids`: a real ``tokenizer.decode`` when one is
+    attached, else a stable ``<tok-<id>>`` placeholder so the stream is
+    non-empty and the HTTP seam is exercisable before the tokenizer lands.
+    """
+    tokenizer = getattr(engine, "tokenizer", None)
+    if tokenizer is not None and hasattr(tokenizer, "decode"):
+        return tokenizer.decode([token_id])
+    return f"<tok-{token_id}>"
+
+
+def _stream_tokens(engine, prompt: str, *, model: str, max_tokens: int | None) -> Iterator[str]:
+    """Admit ``prompt`` to the engine and yield each generated token's text.
+
+    Two engine shapes are supported, selected by what the engine exposes:
+
+    * A real :class:`~freetoken.engine.engine.Engine` (``#14`` / ``#93``)
+      exposes ``add_request`` + a no-arg ``generate``. It is driven by the id
+      path: encode the prompt to ids, admit it with the requested decode budget,
+      run ``generate``, and decode each emitted id.
+
+    * A lighter engine (the CPU route-test stub) exposes only
+      ``generate(prompt, *, model, max_tokens)`` and yields token *text*. It is
+      driven by the text path — the original ``#14``-era contract — so the HTTP
+      seam is testable without torch / a real checkpoint.
+
+    An engine with no ``generate`` at all is the not-loaded signal: raise
+    :class:`EngineNotReady` so the routes map it to a clean 503.
     """
     generate = getattr(engine, "generate", None)
     if generate is None:
         raise EngineNotReady(
-            "engine loop is not implemented — generation is blocked on "
+            "engine loop is not loaded — generation is blocked on "
             "engine-loop (#14); see docs/architecture.md"
         )
-    for token in generate(prompt, model=model, max_tokens=max_tokens):
-        yield token
+    add_request = getattr(engine, "add_request", None)
+
+    if add_request is None:
+        # Lightweight engine: generate() takes the prompt and yields token text.
+        for token in generate(prompt, model=model, max_tokens=max_tokens):
+            yield token
+        return
+
+    from freetoken.core import Req, SamplingParams
+
+    budget = max_tokens if max_tokens and max_tokens > 0 else _FALLBACK_MAX_TOKENS
+    engine.add_request(
+        Req(
+            input_ids=_prompt_token_ids(engine, prompt),
+            table_idx=0,  # add_request reassigns the real slot index
+            cached_len=0,
+            output_len=budget,
+            uid=0,
+            sampling_params=SamplingParams(max_tokens=budget),
+            cache_handle=None,
+        )
+    )
+    token_lists = generate()
+    for token_id in token_lists[0] if token_lists else []:
+        yield _decode_token(engine, token_id)
 
 
 def stream_chat(

--- a/python/freetoken/server/launch.py
+++ b/python/freetoken/server/launch.py
@@ -173,11 +173,13 @@ def _check_server(_args: argparse.Namespace) -> None:
     # feed the full argv back through parse_args.
     server_args = parse_args(_SERVE_ARGV, prog="ft serve")
 
-    def _engine_holder():
-        raise NotYetImplemented("engine loop is a stub — implement under `engine-loop` (#14)")
-
+    # Real wiring (serve-live-engine #93): the server layer must build the app
+    # against the *same* engine holder the live path uses, so a wiring break in
+    # holder -> create_app -> routes is caught here, not at request time.
+    # The holder is lazy (engine_holder() is only called per request), so
+    # create_app stays cheap and network-free.
     try:
-        create_app(server_args, _engine_holder)
+        create_app(server_args, _build_engine_holder(server_args))
     except NotYetImplemented as exc:
         raise NotYetImplemented(f"server: {exc}") from exc
 
@@ -261,16 +263,52 @@ def launch_server(argv: list[str] | None = None, prog: str = "ft serve", out: Te
     from freetoken.server.api_server import run_api_server
 
     server_args = parse_args(_SERVE_ARGV, prog=prog)
+    return run_api_server(server_args, _build_engine_holder(server_args))
 
-    def _engine_holder():
-        # Real wiring: load the model onto the XPU host banks and wrap it in
-        # the engine loop. Both land under #17/#14; until then the spine
-        # never reaches this line.
-        from freetoken.engine.engine import Engine
-        from freetoken.models import create_model
-        from freetoken.models.config import ModelConfig
 
-        create_model(ModelConfig())
-        Engine()
+def _build_engine_holder(server_args):
+    """Zero-arg callable returning the live ``Engine`` the server routes drive.
 
-    return run_api_server(server_args, _engine_holder)
+    Real wiring since serve-live-engine (#93): the holder is *lazy* — it is only
+    invoked per request by the routes, never at app-build time — so ``create_app``
+    stays cheap and the spine's wiring check never loads a checkpoint. On first
+    invocation it builds an :class:`EngineConfig` from the serve args (the model
+    path, the XPU device, and a conservative single-request KV budget) and lets
+    ``Engine`` load the weights + build the KV pool / sampler. For a MoE on a B70
+    ``moe_backend="auto"`` resolves to host-RAM offload (ADR 0002), so a 35B
+    hero is served without OOM-ing the 32 GB. A genuinely unloaded / not-ready
+    engine still raises :class:`NotYetImplemented`, which the routes map to a
+    clean 503.
+    """
+    from freetoken.distributed import DistributedInfo
+    from freetoken.engine.config import EngineConfig
+    from freetoken.engine.engine import Engine
+    from freetoken.utils.arch import is_xpu_available
+
+    def engine_holder():
+        import torch
+
+        engine_config = EngineConfig(
+            model_path=server_args.model,
+            tp_info=DistributedInfo(0, 1),
+            # The engine defaults to XPU when present; pin it explicitly so the
+            # serve path never silently runs on CPU on a B70 box.
+            device="xpu" if is_xpu_available() else "cpu",
+            dtype=torch.float32,
+            moe_backend="auto",
+            # A single in-flight request per server: keeps the paged KV pool
+            # small and the serve path trivially correct. (Batching is #13.)
+            max_running_req=1,
+            # The pool defaults to ``max_running_req * max_seq_len`` rows and the
+            # page table maps slot ``pos`` -> pool row ``pos``, so ``read_kv``
+            # gathers ``k_buffer[0..max_seq_len-1]`` — zero headroom, so a
+            # request decoding to the very last position overruns the pool by one
+            # row (an out-of-bounds gather the XPU runtime aborts on). The
+            # override is a *floor* (the engine takes max(override, default)), so
+            # 2048 gives small test models a safe margin while a large hero model
+            # keeps its full-context pool.
+            num_page_override=2048,
+        )
+        return Engine(engine_config)
+
+    return engine_holder

--- a/tests/test_serve_live_engine_xpu.py
+++ b/tests/test_serve_live_engine_xpu.py
@@ -1,0 +1,181 @@
+"""Live serve seam on the B70 (issue ``serve-live-engine``, #93).
+
+Closes the gap between the three already-merged pieces — ``server-openai``
+(#25, the HTTP surface), ``models-loader`` (#17, weights on XPU / host banks)
+and ``engine-loop`` (#14, the real prefill/decode ``Engine``) — and the final
+wiring step: the server's generation seam driving the *real* engine, not a
+mock, so ``ft serve`` actually streams generated tokens instead of failing
+loud at a stub.
+
+XPU-only: skipped cleanly where there is no XPU. Runs in ``.venv-xpu`` on the
+B70 (Intel Arc Pro B70, Battlemage). The model is the same tiny
+Qwen3.5/3.6 that the offload suite proves correct (host-RAM expert banks +
+XPU LRU), so this exercises the real 35B-shape architecture end to end.
+
+Thread note: the offload MoE path does a device->host sync per token (the
+host-side routing plan in the forward) and the XPU runtime faults on that sync
+when it is issued from a non-main thread (FastAPI's ``TestClient`` runs the
+route on an anyio portal thread — see the comment at
+``qwen3_5_moe/__init__.py``). So these tests drive the real engine on the
+*main* thread through the same ``stream_chat`` seam the route uses; that keeps
+the XPU stream bound to the thread that built the engine. A real ``uvicorn``
+serve is covered separately by the ``--smoke`` integration test.
+"""
+from __future__ import annotations
+
+import json
+import re
+import pytest
+
+import tests.test_qwen35_offload_xpu as _offload
+
+from tests.test_qwen35_offload_xpu import XPU
+
+# The offload suite defines `qwen35_xpu_ckpt` as a *module*-scoped fixture. This
+# suite builds a fresh engine per test (each installs its own global context +
+# offload cache), so a module-scoped checkpoint shared across tests would let
+# two engines collide on the global ctx. Re-expose it at the default (function)
+# scope so every test gets an isolated checkpoint dir.
+qwen35_xpu_ckpt = pytest.fixture(_offload.qwen35_xpu_ckpt.__wrapped__)
+
+from freetoken.core import reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.server.api_server import create_app
+from freetoken.server.args import parse_args
+from freetoken.server.generation import stream_chat
+
+# The generation fallback encoder emits exactly one prompt token (the tokenizer
+# seam is still a stub), so the request never overflows a small pool. The
+# decode budget stays tiny so the test is fast and the offload LRU is exercised
+# without heavy churn.
+_PROMPT_TOKENS = 1
+_DECODE_TOKENS = 4
+# KV pool sizing. Must be large enough that the identity-mapped page table
+# (slots 0..max_seq_len-1) gathers stay in-bounds across the *whole* prompt +
+# decode: the pool has ``num_pages`` rows and read_kv gathers
+# page_table[table_idx, pos] with pos up to max_seq_len-1. The offload suite's
+# proven-correct sizing is num_pages=64 / max_seq_len=32 (a 2x margin over the
+# 5-token prompt + 4-token decode), so the serve test reuses it. A pool pinned
+# to just the prompt token (the #93 spine's original 1-row pool) overruns the
+# gather the moment the request decodes past position 0.
+_NUM_PAGES = 64
+_MAX_SEQ_LEN = 32
+
+_MESSAGES = [{"role": "user", "content": "Count from one."}]
+
+
+def qwen35_xpu_ckpt_vocab(ckpt_path: str) -> int:
+    """The vocab size the serve path must keep generated ids inside."""
+    config = json.load(open(f"{ckpt_path}/config.json"))
+    return config["text_config"]["vocab_size"]
+
+
+def _serve_engine(ckpt_path: str, dev):
+    """The real engine the server seam drives: same as the offload suite, with
+    the KV pool sized for the serve path's single prompt token."""
+    import torch
+
+    return Engine(
+        EngineConfig(
+            model_path=ckpt_path,
+            tp_info=DistributedInfo(0, 1),
+            dtype=torch.float32,
+            device=dev,
+            attention_backend="auto",
+            moe_backend="offload",
+            max_running_req=1,
+            page_size=1,
+            max_seq_len_override=_MAX_SEQ_LEN,
+            num_page_override=_NUM_PAGES,
+        )
+    )
+
+
+@XPU
+def test_serve_chat_completions_streams_real_engine_tokens(qwen35_xpu_ckpt):
+    """Accept (#93): the OpenAI seam streams real (non-503) tokens from the engine.
+
+    A tiny Qwen3.5/3.6 is loaded host-offload through the real ``Engine`` and
+    driven by the exact seam the ``/v1/chat/completions`` route uses
+    (``stream_chat`` -> ``_stream_tokens`` -> ``engine.add_request`` +
+    ``engine.generate``). The pre-fix seam called ``engine.generate(prompt,
+    model=, max_tokens=)`` — a signature the real ``Engine`` does not have — so
+    the route raised ``EngineNotReady`` and the HTTP layer answered 503. After
+    the fix the same seam yields real generated token ids (here as the
+    tokenizer's placeholder, since the tokenizer seam is still a stub).
+
+    The engine is built and driven on the *main* thread (see module docstring):
+    the offload path's per-token D2H sync faults off-thread on the XPU, and
+    ``TestClient`` would otherwise run this on a worker thread. The app is still
+    built exactly as the route sees it, so the seam under test is the real one.
+    """
+    import torch
+
+    dev = torch.device("xpu")
+    vocab = qwen35_xpu_ckpt_vocab(qwen35_xpu_ckpt)
+    engine = _serve_engine(qwen35_xpu_ckpt, dev)
+    server_args = parse_args([qwen35_xpu_ckpt])
+
+    # The seam the /v1/chat/completions route calls, driven on the main thread.
+    deltas = list(stream_chat(engine, _MESSAGES, model=server_args.resolved_model_name, max_tokens=_DECODE_TOKENS))
+    content = "".join(content_delta for _reasoning, content_delta in deltas)
+
+    # A real (non-503) token stream came back.
+    assert content, "the stream must be non-empty — the engine generated tokens"
+    # The tokenizer seam is still a stub, so each token decodes to a
+    # "<tok-<id>>" placeholder with no separating whitespace — the stream is one
+    # concatenated run of them. Pull the ids back out with a pattern match and
+    # confirm every one is a valid embedding-row index (the whole point of the
+    # in-vocab prompt-encoder fix: an out-of-vocab id would have aborted the
+    # XPU gather).
+    ids = [int(match) for match in re.findall(r"<tok-(\d+)>", content)]
+    assert ids, content
+    for token_id in ids:
+        assert 0 <= token_id < vocab, f"token id outside vocab: {token_id} (content={content!r})"
+
+
+@XPU
+def test_serve_app_built_against_real_engine_holder(qwen35_xpu_ckpt):
+    """Accept (#93, wiring): create_app wires the real engine holder into the
+    routes without error, so the live server's route graph is the real one."""
+    import torch
+
+    dev = torch.device("xpu")
+    engine = _serve_engine(qwen35_xpu_ckpt, dev)
+    # The app must build against the real holder that returns the real engine (the
+    # launch.server layer's contract). A stub holder would build too, so assert
+    # the app is the OpenAI app and its engine is the real Engine.
+    app = create_app(parse_args([qwen35_xpu_ckpt]), lambda: engine)
+    assert app.state.engine_holder is not None
+    assert app.state.engine_holder() is engine
+    routes = {getattr(r, "path", None) for r in app.routes}
+    assert "/v1/chat/completions" in routes
+    assert "/health" in routes
+
+
+@XPU
+def test_serve_503_only_when_engine_not_loaded():
+    """Accept (#93, negative control): a genuinely not-loaded engine is a 503.
+
+    The 503 path is preserved for the case the pre-fix code *falsely* hit — an
+    engine with no generation method (e.g. the spine's pre-load holder). This
+    pins that the fix did not delete the not-ready path, only the stub that
+    raised it unconditionally. This test needs no XPU work, but keeps the XPU
+    marker so it runs in the same XPU suite as the rest of the seam.
+    """
+    from freetoken._stub import NotYetImplemented
+
+    from fastapi.testclient import TestClient
+
+    def not_loaded_holder():
+        raise NotYetImplemented("engine loop is a stub — implement under `engine-loop` (#14)")
+
+    app = create_app(parse_args(["m"]), not_loaded_holder)
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={"model": "m", "messages": [{"role": "user", "content": "x"}]})
+    assert response.status_code == 503
+    assert "detail" in response.json()
+    # /v1/models stays live even while the engine is not loaded.
+    assert client.get("/v1/models").status_code == 200


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟠 **PR-Agent Score: 75** `score-70-79` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/94#issuecomment-5470666267) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit be1fc60](https://github.com/Performant-Labs/FreeToken-Intel/commit/be1fc60db0a8a01945f8d8d46275659b06107bd2) · run [#33329938209](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33329938209) · 2026-08-30 13:17 MDT / 2026-08-30 19:17 UTC
<!-- argos-status:end -->

### **User description**

### **User description**
## What

Closes #93. `ft serve` previously drove a stub engine holder, so `/v1/chat/completions` always returned 503. This wires the real `Engine` into the server so it streams actual tokens over HTTP on the B70.

## The three real bugs

**1. Out-of-vocab prompt ids aborted the XPU (the crash)**
The generation seam's fallback prompt encoder hashed the prompt into a fixed 4096-id space. For the tiny B70 test model (vocab_size=64) that minted ids far past the vocab, and `embed_tokens` gathers `k_buffer[input_ids]` — an out-of-vocab id read past the embedding table, and the XPU runtime aborted on an out-of-bounds gather ("vectorized gather kernel index out of bounds"). The fallback now bounds its ids to the loaded model's own vocab (`engine.config.model_config.vocab_size`).

**2. The seam required `add_request`, breaking the CPU route tests**
The prior rewrite drove the engine via `add_request` + a no-arg `generate`, and the not-ready guard required *both*. The CPU route-test `_StubEngine` exposes only a yielding `generate(prompt, *, model, max_tokens)` (the original #14-era contract), so it 503'd. The seam now detects the engine's shape: real `Engine` → id path; lightweight stub → text path. Only a missing `generate` raises `EngineNotReady` (→ 503).

**3. The KV pool override was a hard cap**
`num_page_override` replaced the default `max_running_req * max_seq_len` pool outright. The serve path's 2048-row margin would have *shrunk* a large hero model's full-context pool. It's now a floor: `max(override, default)`.

## Verification

- `tests/test_serve_live_engine_xpu.py` (new, XPU): 3 passed — drives the real engine on the main thread (the XPU runtime faults off-main-thread), asserts the stream is non-empty and every token id is in-vocab, plus the app-wiring and 503-not-ready controls.
- Full CPU suite: 60 passed, 12 skipped (no regressions).
- The 7 SYCL/toolchain XPU failures are pre-existing (confirmed by stashing the changes).

## Notes

- The tokenizer/chat-template seam is still a stub (separate issue), so the smoke test asserts on the `<tok-<id>>` placeholder stream and in-vocab ids rather than decoded text.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Wire real `Engine` into `ft serve` streaming
  - Dual-shape seam supports real and stub engine paths
  - Lazy holder builds `Engine` per request

- Bound fallback prompt ids to model vocab size

- Make `num_page_override` a floor, not hard cap

- Add XPU live serve and 503 control tests


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["HTTP /v1/chat/completions"] -- "stream_chat" --> B["_stream_tokens"]
  B -- "detect engine shape" --> C{"Has add_request?"}
  C -- "real Engine" --> D["_prompt_token_ids == vocab bound"]
  D --> E["add_request + generate"]
  E --> F["_decode_token"]
  C -- "stub generate" --> G["yield text"]
  H["launch._build_engine_holder"] -- "lazy build" --> K["Real Engine"]
  K --> B
  I["EngineConfig num_page_override"] -- "max(override, default)" --> J["KV pool floor"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.py</strong><dd><code>Make KV pool override a floor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/engine/engine.py

<ul><li>Replace <code>num_page_override</code> hard override with floor <code>max(override, </code><br><code>default)</code><br> <li> Preserve default <code>max_running_req * max_seq_len</code> pool for large models</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-ac01fc4935708ecb318c53b01021cb308dbea3f1d1d356d68b796fc860dda54c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generation.py</strong><dd><code>Wire real engine and dual-shape token streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/server/generation.py

<ul><li>Add <code>_prompt_token_ids</code> hash fallback bounded to <code>model_config.vocab_size</code><br> <li> Support real <code>Engine</code> path via <code>add_request</code> and no-arg <code>generate</code><br> <li> Keep text path for lightweight <code>generate(prompt, model, max_tokens)</code> <br>stubs<br> <li> Add <code>_decode_token</code> placeholder and fallback max tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-6cc9eb8ffc1a3a954156d11ed41130092731f48a4b524eaa3f40c2fc8194d4e8">+117/-21</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.py</strong><dd><code>Build real lazy engine holder for server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/server/launch.py

<ul><li>Replace stub engine holder with lazy <code>_build_engine_holder</code><br> <li> Build <code>EngineConfig</code> from serve args with XPU device and page override<br> <li> Use real holder in <code>_check_server</code> wiring check and server launch</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-1bfcdb5a34b441e2901f238435ed2584530ddc6db3b9bfe3b35459b9d56e7e6e">+54/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_serve_live_engine_xpu.py</strong><dd><code>Add XPU live engine serve tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_serve_live_engine_xpu.py

<ul><li>Add live XPU tests streaming real engine tokens via <code>stream_chat</code><br> <li> Assert generated token ids are within model vocab<br> <li> Verify app wiring with real holder and 503 not-loaded control</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-5abae54fdf874d5ab33c5ace836e26d73abe6172e670fc0d02e7f16af1374625">+181/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Wire real `Engine` into `ft serve` streaming
  - Lazy holder builds `Engine` per request
  - Dual-shape seam supports real and stub engines

- Bound fallback prompt ids to model vocab size

- Make `num_page_override` a floor, not hard cap

- Add XPU live serve and 503 control tests


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["HTTP /v1/chat/completions"] -- "stream_chat" --> B["_stream_tokens"]
  B --> C{"Has add_request?"}
  C -- "real Engine" --> D["_prompt_token_ids bound to vocab"]
  D --> E["add_request + generate"]
  E --> F["_decode_token"]
  C -- "stub generate" --> G["yield text"]
  H["launch._build_engine_holder"] -- "lazy build" --> K["Real Engine"]
  K --> B
  I["EngineConfig num_page_override"] -- "max(override, default)" --> J["KV pool floor"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.py</strong><dd><code>Make KV pool override a floor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/engine/engine.py

<ul><li>Replace hard override <code>num_page_override</code> with floor <code>max(override, </code><br><code>default_num_pages)</code><br> <li> Ensure small test models get extra KV pool rows without shrinking <br>large models</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-ac01fc4935708ecb318c53b01021cb308dbea3f1d1d356d68b796fc860dda54c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generation.py</strong><dd><code>Wire real Engine streaming and vocabulary-safe prompt encoding</code></dd></summary>
<hr>

python/freetoken/server/generation.py

<ul><li>Add fallback prompt token id encoder bound to model vocab size<br> <li> Add token id decoder returning real tokenizer or <code><tok-<id>></code> placeholder<br> <li> Support dual engine shapes: real <code>add_request</code>+<code>generate</code> id path and stub <br><code>generate(prompt, ...)</code> text path<br> <li> Keep only missing <code>generate</code> as <code>EngineNotReady</code> 503</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-6cc9eb8ffc1a3a954156d11ed41130092731f48a4b524eaa3f40c2fc8194d4e8">+117/-21</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.py</strong><dd><code>Build real lazy engine holder for serve</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/server/launch.py

<ul><li>Add <code>_build_engine_holder</code> that lazily builds real <code>Engine</code> from serve <br>args<br> <li> Pass real holder into <code>create_app</code> and <code>run_api_server</code><br> <li> Configure single request, XPU/CPU device, floor KV override 2048</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-1bfcdb5a34b441e2901f238435ed2584530ddc6db3b9bfe3b35459b9d56e7e6e">+54/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_serve_live_engine_xpu.py</strong><dd><code>Add XPU live serve and 503 control tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_serve_live_engine_xpu.py

<ul><li>Add XPU tests driving real engine via <code>stream_chat</code> on main thread<br> <li> Assert non-empty in-vocab token stream and app wiring<br> <li> Add negative 503 test for not-loaded engine holder</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/94/files#diff-5abae54fdf874d5ab33c5ace836e26d73abe6172e670fc0d02e7f16af1374625">+181/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___