### PR TITLE
server-tokenizer-effort: port effort/thinking dialects and wire client reasoning controls

### DIFF
--- a/python/freetoken/server/anthropic_api.py
+++ b/python/freetoken/server/anthropic_api.py
@@ -57,6 +57,11 @@ class AnthropicMessageRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     stop_sequences: list[str] | None = None
+    # Anthropic's extended-thinking opt-in: ``{"type": "enabled", ...}`` turns the
+    # checkpoint's thinking toggle on; ``{"type": "disabled"}`` (or absence) leaves
+    # it at the template default. Mapped onto the shared thinking kwargs (issue
+    # #97) so the same probed thinking profile the OpenAI path uses applies.
+    thinking: dict | None = None
 
     model_config = {"populate_by_name": True}
 
@@ -75,6 +80,22 @@ def _to_chat_messages(system: str | None, messages: list[dict]) -> list[dict]:
     for message in messages:
         rendered.append({"role": message.get("role", "user"), "content": message.get("content", "")})
     return rendered
+
+
+def _to_chat_template_kwargs(thinking: dict | None) -> dict:
+    """Map an Anthropic ``thinking`` opt-in onto the shared thinking kwargs.
+
+    Anthropic enables extended thinking with ``{"type": "enabled"}`` and disables
+    it with ``{"type": "disabled"}`` (or by omitting the field). The chat-template
+    toggles the ecosystem's templates read are ``enable_thinking`` (qwen/glm/gemma)
+    and ``thinking_mode`` (minimax-m3), so an "enabled" block broadcasts both —
+    Jinja ignores the spelling its template doesn't declare — and "disabled" /
+    absent maps to the template's own default (no kwarg), matching the OpenAI
+    path's treatment of the same probed thinking profile (issue #97).
+    """
+    if thinking and str(thinking.get("type", "")) == "enabled":
+        return {"enable_thinking": True, "thinking_mode": "enabled"}
+    return {}
 
 
 def register_anthropic_routes(app: FastAPI, engine_holder) -> None:
@@ -158,6 +179,7 @@ def register_anthropic_routes(app: FastAPI, engine_holder) -> None:
             model=model_name,
             max_tokens=request.max_tokens,
             reasoning_parser=reasoning_parser,
+            chat_template_kwargs=_to_chat_template_kwargs(request.thinking),
         ):
             # The OpenAI routes surface the parser's "thinking" stream as a
             # separate ``reasoning_content`` key; Anthropic has that concept
@@ -202,6 +224,7 @@ def register_anthropic_routes(app: FastAPI, engine_holder) -> None:
             model=model_name,
             max_tokens=request.max_tokens,
             reasoning_parser=reasoning_parser,
+            chat_template_kwargs=_to_chat_template_kwargs(request.thinking),
         ):
             if reasoning_delta:
                 reasoning_parts.append(reasoning_delta)

--- a/python/freetoken/server/generation.py
+++ b/python/freetoken/server/generation.py
@@ -127,7 +127,14 @@ def _fallback_id_space(engine) -> int:
     return max(2, min(int(vocab), _FALLBACK_ID_SPACE_MAX))
 
 
-def _prompt_token_ids(engine, prompt: str, messages: list[dict] | None = None) -> list[int]:
+def _prompt_token_ids(
+    engine,
+    prompt: str,
+    messages: list[dict] | None = None,
+    *,
+    tools: list[dict] | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+) -> list[int]:
     """Encode the request to the token ids the engine consumes.
 
     With the real message frontend (``#95``) the prompt is the chat rendered
@@ -136,12 +143,23 @@ def _prompt_token_ids(engine, prompt: str, messages: list[dict] | None = None) -
     with) — not from re-tokenizing a flattened string, which would not match the
     template's exact boundaries. The caller passes ``messages`` so the chat is
     re-rendered here; ``prompt`` is kept only as the no-tokenizer fallback input.
+
+    ``tools`` and ``chat_template_kwargs`` carry the client's reasoning controls
+    (issue #97); they are forwarded to ``encode``, which quantizes effort onto
+    the checkpoint's probed profile and resolves the thinking toggle. They are
+    no-ops on the no-tokenizer fallback path.
     """
     tokenize_mgr = _resolve_tokenize_manager(engine)
     if tokenize_mgr is not None and hasattr(tokenize_mgr, "encode"):
-        return tokenize_mgr.encode(messages if messages is not None else [{"role": "user", "content": prompt}])
+        return tokenize_mgr.encode(
+            messages if messages is not None else [{"role": "user", "content": prompt}],
+            tools=tools,
+            chat_template_kwargs=chat_template_kwargs,
+        )
     # No tokenizer attached (pre-load holder): keep the seam exercisable with a
     # single in-vocab id so the engine's prefill + embedding / KV math still run.
+    # The client's reasoning controls (reasoning_effort / thinking) only apply
+    # through the real chat template, so they are ignored on this path.
     vocab = getattr(getattr(getattr(engine, "config", None), "model_config", None), "vocab_size", None)
     space = max(2, min(int(vocab), _FALLBACK_ID_SPACE_MAX)) if vocab else _FALLBACK_ID_SPACE_MAX
     digest = hashlib.sha256(prompt.encode("utf-8")).digest()
@@ -183,6 +201,8 @@ def _stream_tokens(
     model: str,
     max_tokens: int | None,
     messages: list[dict] | None = None,
+    tools: list[dict] | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> Iterator[str]:
     """Admit ``prompt`` to the engine and yield each generated token's text.
 
@@ -221,7 +241,7 @@ def _stream_tokens(
     budget = max_tokens if max_tokens and max_tokens > 0 else _FALLBACK_MAX_TOKENS
     engine.add_request(
         Req(
-            input_ids=_prompt_token_ids(engine, prompt, messages),
+            input_ids=_prompt_token_ids(engine, prompt, messages, tools=tools, chat_template_kwargs=chat_template_kwargs),
             table_idx=0,  # add_request reassigns the real slot index
             cached_len=0,
             output_len=budget,
@@ -242,19 +262,42 @@ def stream_chat(
     model: str,
     max_tokens: int | None = None,
     reasoning_parser=None,
+    tools: list[dict] | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ):
     """Yield ``(reasoning_delta, content_delta)`` per decoded token.
 
     ``reasoning_parser`` is stateful across the whole stream (it buffers
     partial tags), so each token is fed through it and ``flush()`` drains the
     remainder once the stream ends. With no parser, every token is content.
+
+    ``tools`` and ``chat_template_kwargs`` carry the client's reasoning controls
+    (issue #97): they are forwarded to the encode step, where effort is
+    quantized onto the checkpoint's probed profile and the thinking toggle is
+    resolved, so the rendered prompt reflects the request's effort / thinking.
     """
     prompt = _prompt_from_messages(messages)
     if reasoning_parser is None:
-        for token in _stream_tokens(engine, prompt, model=model, max_tokens=max_tokens, messages=messages):
+        for token in _stream_tokens(
+            engine,
+            prompt,
+            model=model,
+            max_tokens=max_tokens,
+            messages=messages,
+            tools=tools,
+            chat_template_kwargs=chat_template_kwargs,
+        ):
             yield "", token
         return
-    for token in _stream_tokens(engine, prompt, model=model, max_tokens=max_tokens, messages=messages):
+    for token in _stream_tokens(
+        engine,
+        prompt,
+        model=model,
+        max_tokens=max_tokens,
+        messages=messages,
+        tools=tools,
+        chat_template_kwargs=chat_template_kwargs,
+    ):
         for reasoning_delta, content_delta in reasoning_parser.parse([token]):
             if reasoning_delta or content_delta:
                 yield reasoning_delta, content_delta

--- a/python/freetoken/server/openai_api.py
+++ b/python/freetoken/server/openai_api.py
@@ -37,6 +37,10 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: int | None = Field(default=None, alias="max_completion_tokens")
     temperature: float | None = None
     tools: list[dict] | None = None
+    # Reasoning-effort dial (issue #97). Free of a static per-family table, the
+    # value is quantized onto the checkpoint's probed effort vocabulary at encode
+    # time, so any value is accepted here and mapped (or dropped) downstream.
+    reasoning_effort: str | None = None
 
     model_config = {"populate_by_name": True}
 
@@ -104,12 +108,20 @@ def register_openai_routes(app: FastAPI, engine_holder) -> None:
         server_args = app.state.server_args
         reasoning_parser = get_reasoning_parser(server_args.reasoning_parser)
         model_name = server_args.resolved_model_name
+        # The client's reasoning controls ride as chat-template kwargs. The
+        # encode step quantizes ``reasoning_effort`` onto the checkpoint's probed
+        # effort profile (issue #97); ``tools`` is forwarded separately.
+        chat_template_kwargs: dict = {}
+        if request.reasoning_effort is not None:
+            chat_template_kwargs["reasoning_effort"] = request.reasoning_effort
         for reasoning_delta, content_delta in generation.stream_chat(
             engine,
             [m.model_dump() for m in request.messages],
             model=model_name,
             max_tokens=request.max_tokens,
             reasoning_parser=reasoning_parser,
+            tools=request.tools,
+            chat_template_kwargs=chat_template_kwargs,
         ):
             delta: dict = {}
             if content_delta:

--- a/python/freetoken/tokenizer/__init__.py
+++ b/python/freetoken/tokenizer/__init__.py
@@ -13,6 +13,29 @@ called directly from the request path.
 from __future__ import annotations
 
 from freetoken.tokenizer.detokenize import DetokenizeManager
+from freetoken.tokenizer.effort import (
+    EFFORT_SCALE,
+    KNOWN_REASONING_EFFORTS,
+    OPENAI_EFFORT_TRIPLE,
+    EffortProfile,
+    ThinkingProfile,
+    effective_efforts,
+    probe_effort_profile,
+    probe_thinking_profile,
+    quantize_effort,
+)
 from freetoken.tokenizer.tokenize import TokenizeManager
 
-__all__ = ["DetokenizeManager", "TokenizeManager"]
+__all__ = [
+    "EFFORT_SCALE",
+    "DetokenizeManager",
+    "KNOWN_REASONING_EFFORTS",
+    "OPENAI_EFFORT_TRIPLE",
+    "EffortProfile",
+    "ThinkingProfile",
+    "TokenizeManager",
+    "effective_efforts",
+    "probe_effort_profile",
+    "probe_thinking_profile",
+    "quantize_effort",
+]

--- a/python/freetoken/tokenizer/effort.py
+++ b/python/freetoken/tokenizer/effort.py
@@ -1,0 +1,280 @@
+"""Reasoning-effort dialect handling.
+
+Upstream NVIDIA path: python/freetoken/tokenizer/effort.py
+
+Each checkpoint's template/encoder accepts only its own effort vocabulary and
+hard-fails on the rest, while clients speak whatever dialect their provider
+taught them. Named levels project onto the numeric scale vLLM and SGLang share,
+and out-of-vocabulary values quantize to the nearest supported gear instead of
+failing the request. The vocabulary is probed from the checkpoint's own
+template, never from a static table: a parser-family registry cannot be keyed
+correctly (Qwen3 and Qwen3.8 resolve to the same parser but only the latter
+grades effort).
+
+In-process port: the probe is driven by a ``render(kwargs, tools) -> str``
+callback (the chat template rendered to a prompt STRING, not the ZMQ worker's
+``BatchEncoding`` ids), so ``_renderings_differ`` compares strings. The probe
+and the quantizer are pure text logic -- no torch, no ZMQ -- which keeps the
+serve HTTP surface bootable on a torch-free box.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+#: Values must match vLLM's and SGLang's inkling table so the ecosystems agree
+#: on what "medium" means relative to "xhigh".
+EFFORT_SCALE: dict[str, float] = {
+    "none": 0.0,
+    "minimal": 0.1,
+    "low": 0.2,
+    "medium": 0.7,
+    "high": 0.9,
+    "xhigh": 0.99,
+    "max": 0.99,
+}
+
+KNOWN_REASONING_EFFORTS = tuple(EFFORT_SCALE)
+
+
+#: OpenAI's effort triple -- the common-denominator vocabulary every dialect
+#: understands.
+OPENAI_EFFORT_TRIPLE = ("low", "medium", "high")
+
+#: The graded ladder served to a template that grades effort WITHOUT validating
+#: it (muse-glimmer's "Reasoning strength"). Such a template interpolates any
+#: string, so its probed ``supported`` set is the whole scale -- but the
+#: checkpoint's trained levels are the ladder names, and never-advertised
+#: dialects (minimal / none / max) must quantize onto them instead of reaching
+#: the model verbatim.
+GRADED_EFFORT_LADDER = ("low", "medium", "high", "xhigh")
+
+
+def effective_efforts(profile: "EffortProfile") -> frozenset[str]:
+    """The vocabulary a checkpoint is actually served (and advertised) with.
+
+    A NARROWED ``supported`` set is authoritative -- narrowing only ever comes
+    from observed rejections. A grader that accepted the whole scale validated
+    nothing, so pass-through would interpolate off-vocabulary values
+    ("minimal", "max") into the prompt verbatim: it is capped to its dialect's
+    ladder instead -- the strength dialect's documented levels top out at xhigh
+    (muse-glimmer's model card), a plain effort grader keeps the OpenAI triple
+    (the only vocabulary such a template is known to understand)."""
+    if not profile.consumes_effort:
+        return frozenset()
+    if profile.validates or profile.supported != frozenset(KNOWN_REASONING_EFFORTS):
+        return profile.supported
+    ladder = GRADED_EFFORT_LADDER if profile.strength_dialect else OPENAI_EFFORT_TRIPLE
+    vocab = {name for name in ladder if name in profile.supported}
+    if profile.default:
+        vocab.add(profile.default)
+    return frozenset(vocab)
+
+#: Protocol-level thinking toggles, broadcast in every spelling the ecosystem's
+#: templates read (``enable_thinking`` bool: qwen/glm/gemma/dsv4;
+#: ``thinking_mode`` string: minimax-m3). Jinja ignores undeclared variables,
+#: so a template simply picks the knob it knows -- no per-family routing needed.
+THINKING_OFF_KWARGS = {"enable_thinking": False, "thinking_mode": "disabled"}
+THINKING_ON_KWARGS = {"enable_thinking": True, "thinking_mode": "enabled"}
+THINKING_ADAPTIVE_KWARGS = {"thinking_mode": "adaptive"}
+
+
+@dataclass(frozen=True)
+class EffortProfile:
+    """What one checkpoint's template/encoder accepts, learned by probing it.
+
+    ``default`` is the supported name whose rendering is byte-identical to
+    passing no effort at all. ``consumes_effort`` False means no probe round
+    ever changed its output or raised -- the template ignores the knob, so
+    requests should not carry it. ``validates`` True means the probe observed a
+    rejection: only then is ``supported`` a real vocabulary rather than "this
+    template interpolates anything". ``strength_dialect`` True means the
+    template reads the ``reasoning_strength`` spelling (muse-glimmer's family,
+    whose documented ladder tops out at xhigh) rather than only
+    ``reasoning_effort``.
+    """
+
+    supported: frozenset[str]
+    default: str | None
+    consumes_effort: bool
+    validates: bool = False
+    strength_dialect: bool = False
+
+
+@dataclass(frozen=True)
+class ThinkingProfile:
+    """A checkpoint's thinking controls, learned by probing its template.
+
+    ``toggleable``: the off/on broadcasts render differently. ``has_adaptive``:
+    thinking_mode "adaptive" is a third distinct state (minimax-m3).
+    ``default_state``: which state the bare render matches ("on" when not
+    toggleable or unmatched).
+    """
+
+    efforts: EffortProfile
+    toggleable: bool
+    has_adaptive: bool
+    default_state: str  # "on" | "off" | "adaptive"
+
+
+#: A gear farther than this on the scale misrepresents the request; drop the
+#: value and let the template default apply. Keeps OpenAI's "medium" from
+#: escalating to the DSV4 encoder's absolute-maximum "high" gear (0.2 away),
+#: matching vLLM's DSV4 mapping, while "high" still reaches Qwen's "xhigh"
+#: (0.09 away).
+_MAX_QUANTIZE_DISTANCE = 0.15
+
+
+def quantize_effort(value: Any, profile: EffortProfile) -> str | None:
+    """Map a client's effort onto ``profile``; ``None`` means "send nothing".
+
+    In-vocabulary values pass through untouched. Other named levels land on the
+    nearest supported gear within ``_MAX_QUANTIZE_DISTANCE`` -- except "max",
+    which is reachable only by its own name (vLLM's DSV4 rule: an extreme
+    opt-in gear must never be entered by rounding). Everything else drops to
+    the template default. With "max" excluded the remaining scale values are
+    unique, so quantization is deterministic across processes.
+    """
+    supported = effective_efforts(profile)
+    if not supported:
+        return None
+    if isinstance(value, str) and value in supported:
+        return value
+    position = EFFORT_SCALE.get(value) if isinstance(value, str) else None
+    if position is None:
+        return None
+    ranked = sorted(
+        (name for name in supported if name != "max"),
+        key=lambda name: (abs(EFFORT_SCALE[name] - position), -EFFORT_SCALE[name]),
+    )
+    if ranked and abs(EFFORT_SCALE[ranked[0]] - position) <= _MAX_QUANTIZE_DISTANCE:
+        return ranked[0]
+    return None
+
+
+#: One tool flips tool-conditional paths (the DSV4 encoder grades effort only
+#: in thinking mode, which tools force).
+_PROBE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "noop",
+            "description": "No-op probe tool.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+#: (extra chat_template_kwargs, tools) per probe round: templates read effort
+#: unconditionally, under tool-forced thinking, or only under an explicit
+#: thinking opt-in -- one round per shape.
+_PROBE_ROUNDS: tuple[tuple[dict[str, Any], list[dict[str, Any]] | None], ...] = (
+    ({}, None),
+    ({}, _PROBE_TOOLS),
+    ({"enable_thinking": True}, None),
+)
+
+
+def probe_effort_profile(
+    render: Callable[[dict[str, Any], list[dict[str, Any]] | None], Any],
+) -> EffortProfile:
+    """Learn a checkpoint's effort vocabulary by rendering probes through it.
+
+    ``render(chat_template_kwargs, tools)`` returns a comparable rendering and
+    raises on rejection. A round whose no-effort baseline raises is skipped:
+    the template rejected the probe conversation shape, not the effort.
+    """
+    rejected: set[str] = set()
+    diverged: set[str] = set()
+    matches_baseline: dict[str, bool] = {name: True for name in KNOWN_REASONING_EFFORTS}
+    ran_rounds = 0
+
+    for base_kwargs, tools in _PROBE_ROUNDS:
+        try:
+            baseline = render(dict(base_kwargs), tools)
+        except Exception:  # noqa: BLE001 -- template rejects the probe shape, not the effort
+            continue
+        ran_rounds += 1
+        for name in KNOWN_REASONING_EFFORTS:
+            try:
+                rendering = render({**base_kwargs, "reasoning_effort": name}, tools)
+            except Exception:  # noqa: BLE001 -- any raise means "not accepted"
+                rejected.add(name)
+                matches_baseline[name] = False
+                continue
+            if _renderings_differ(rendering, baseline):
+                diverged.add(name)
+                matches_baseline[name] = False
+
+    if ran_rounds == 0:
+        # Nothing learnable: sending no effort is the only safe rendering.
+        return EffortProfile(supported=frozenset(), default=None, consumes_effort=False)
+
+    # Which spelling does the template read? A render that moves on the
+    # reasoning_strength kwarg alone marks the muse dialect (its ladder differs).
+    strength_dialect = False
+    try:
+        baseline = render({}, None)
+        moved = render({"reasoning_strength": "low"}, None)
+        strength_dialect = _renderings_differ(moved, baseline)
+    except Exception:  # noqa: BLE001 -- a rejecting template is not this dialect
+        strength_dialect = False
+
+    supported = frozenset(name for name in KNOWN_REASONING_EFFORTS if name not in rejected)
+    consumes = bool(rejected or diverged)
+    default = None
+    if consumes:
+        defaults = [name for name in supported if matches_baseline[name]]
+        if defaults:
+            default = max(defaults, key=lambda name: EFFORT_SCALE[name])
+    return EffortProfile(
+        supported=supported,
+        default=default,
+        consumes_effort=consumes,
+        validates=bool(rejected),
+        strength_dialect=strength_dialect,
+    )
+
+
+def probe_thinking_profile(
+    render: Callable[[dict[str, Any], list[dict[str, Any]] | None], Any],
+    efforts: EffortProfile,
+) -> ThinkingProfile:
+    """Learn a checkpoint's thinking-toggle behavior by rendering the broadcast
+    kwargs through its template. Same contract as ``probe_effort_profile``; a
+    template that rejects any toggle probe is treated as not toggleable."""
+    try:
+        baseline = render({}, None)
+        off = render(dict(THINKING_OFF_KWARGS), None)
+        on = render(dict(THINKING_ON_KWARGS), None)
+    except Exception:  # noqa: BLE001 -- can't observe the toggle; assume none
+        return ThinkingProfile(efforts=efforts, toggleable=False, has_adaptive=False, default_state="on")
+    toggleable = _renderings_differ(off, on)
+    has_adaptive = False
+    adaptive = None
+    if toggleable:
+        try:
+            adaptive = render(dict(THINKING_ADAPTIVE_KWARGS), None)
+            has_adaptive = _renderings_differ(adaptive, off) and _renderings_differ(adaptive, on)
+        except Exception:  # noqa: BLE001 -- adaptive is not a state this template knows
+            has_adaptive = False
+    default_state = "on"
+    if toggleable:
+        if not _renderings_differ(baseline, off):
+            default_state = "off"
+        elif has_adaptive and not _renderings_differ(baseline, adaptive):
+            default_state = "adaptive"
+    return ThinkingProfile(
+        efforts=efforts,
+        toggleable=toggleable,
+        has_adaptive=has_adaptive,
+        default_state=default_state,
+    )
+
+
+def _renderings_differ(a: Any, b: Any) -> bool:
+    try:
+        return bool(a != b)
+    except Exception:  # noqa: BLE001 -- exotic object comparison; treat as divergence
+        return True

--- a/python/freetoken/tokenizer/tokenize.py
+++ b/python/freetoken/tokenizer/tokenize.py
@@ -7,11 +7,31 @@ encoder: on this B70 the hero model (Qwen3.5/3.6) ships a plain HuggingFace Jinj
 chat template, so ``encode`` runs ``apply_chat_template`` directly on the
 transformers ``AutoTokenizer`` in-process. This is the same template the engine's
 worker would run, so a rendered prompt tokenizes identically to a generated one.
+
+On top of that, ``encode`` accepts the client's reasoning controls (issue #97):
+``reasoning_effort`` is quantized onto the checkpoint's *probed* effort
+vocabulary (a client's "max" maps to the nearest gear this template actually
+grades; an unsupported value drops to the template default instead of
+failing), and the thinking toggle (``enable_thinking`` / ``thinking_mode`` /
+``tools``) is resolved through the same probed thinking profile. Both profiles
+are learned from the template itself on first use (never a static per-family
+table) and cached, so the per-request path only ever does a cheap dict lookup.
+The probe renders to a prompt *string*, so this module stays torch-free.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+import threading
+
+from freetoken.tokenizer.effort import (
+    EffortProfile,
+    ThinkingProfile,
+    probe_effort_profile,
+    probe_thinking_profile,
+    quantize_effort,
+)
 
 # ``apply_chat_template(..., return_dict=True)`` returns a ``BatchEncoding``
 # (a ``UserDict`` in transformers 5.x) whose ``input_ids`` is a plain ``list[int]``. We take those
@@ -19,39 +39,146 @@ from typing import Any
 # round-trip would lose the template's exact tokenization boundaries.
 _CHAT_KWARGS = {"add_generation_prompt": True, "return_dict": True}
 
+#: The minimal conversation the profile probes render (the probe only needs the
+#: template to accept the shape; the prompt text is never served).
+_PROBE_MESSAGES = [{"role": "user", "content": "ping"}]
+
+
+def resolve_thinking_mode(chat_template_kwargs: dict[str, Any] | None, tools: Any | None) -> str:
+    """The single source of truth for whether a request is in thinking mode.
+
+    The encode side (:meth:`TokenizeManager.encode`) uses it to pick the prompt
+    the model sees, and the frontend parse side (``server/openai_api.py``)
+    imports it to decide whether the model's output begins inside a reasoning
+    block. Keeping one implementation prevents the two sides from disagreeing.
+    Thinking is on when tools are offered (a dsv4-style encoder only emits
+    well-formed tool calls in thinking mode) or when the caller requests it via
+    a thinking kwarg.
+    """
+    ctk = chat_template_kwargs or {}
+    mode = str(ctk.get("thinking_mode") or "chat")
+    if tools or ctk.get("enable_thinking") or ctk.get("thinking"):
+        mode = "thinking"
+    if mode not in ("chat", "thinking"):
+        mode = "chat"
+    return mode
+
 
 class TokenizeManager:
     """Own the chat-template encode path for one model.
 
     Mirrors the upstream ``TokenizeManager`` minus the worker-process / ZMQ
-    machinery: ``encode`` and ``count`` are synchronous in-process calls.
+    machinery: ``encode`` and ``count`` are synchronous in-process calls. The
+    effort / thinking profiles are probed from the template on first use (never
+    a static table) and cached, so the per-request path only does a cheap dict
+    lookup.
     """
 
     def __init__(self, tokenizer: Any, eos_token_id: int | None = None) -> None:
         self.tokenizer = tokenizer
         self.eos_token_id = eos_token_id
         self._template = getattr(tokenizer, "chat_template", None)
+        self._effort_profile: EffortProfile | None = None
+        self._thinking_profile: ThinkingProfile | None = None
+        self._profile_lock = threading.Lock()
+        self._logged_effort_maps: set[tuple[Any, str | None]] = set()
 
     def render(self, messages: list[dict[str, Any]]) -> str:
         """Human-readable rendering of the templated prompt (diagnostic only)."""
         return self.tokenizer.decode(self.encode(messages), skip_special_tokens=False)
 
-    def encode(self, messages: list[dict[str, Any]]) -> list[int]:
-        """Render the chat through the model's chat template and return the ids."""
+    def encode(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
+    ) -> list[int]:
+        """Render the chat through the model's chat template and return the ids.
+
+        ``tools`` and ``chat_template_kwargs`` carry the client's reasoning
+        controls (issue #97): ``reasoning_effort`` is quantized onto this
+        checkpoint's probed effort vocabulary, and the thinking toggle is
+        resolved through the probed thinking profile. With no kwargs the render
+        is byte-identical to the pre-#97 path.
+        """
+        kwargs = dict(chat_template_kwargs or {})
+        if "reasoning_effort" in kwargs:
+            kwargs = self._sanitize_effort(kwargs)
+        if tools is not None:
+            kwargs = {**kwargs, "tools": tools}
         if not self._template:
             raise RuntimeError(
                 "the model ships no chat template — cannot render a chat prompt"
             )
-        return list(self.tokenizer.apply_chat_template(messages, **_CHAT_KWARGS)["input_ids"])
+        return list(
+            self.tokenizer.apply_chat_template(
+                messages,
+                **{**kwargs, **_CHAT_KWARGS},
+            )["input_ids"]
+        )
 
-    def count(self, messages: list[dict[str, Any]]) -> int:
+    def count(self, messages: list[dict[str, Any]], **kwargs: Any) -> int:
         """Number of prompt tokens a chat renders to, without keeping the ids."""
-        return len(self.encode(messages))
+        return len(self.encode(messages, **kwargs))
 
     @property
     def supports_tools(self) -> bool:
         """Whether the chat template understands a ``tools`` kwarg (function calling)."""
         return "tools" in (self._template or "")
 
+    # -- Probed dialect profiles (issue #97) ---------------------------------
 
-__all__ = ["TokenizeManager"]
+    def effort_profile(self) -> EffortProfile:
+        """The checkpoint's effort vocabulary, probed on first use and cached
+        for the process lifetime."""
+        with self._profile_lock:
+            if self._effort_profile is None:
+                self._effort_profile = probe_effort_profile(self._probe_render)
+            return self._effort_profile
+
+    def thinking_profile(self) -> ThinkingProfile:
+        """The checkpoint's thinking controls (toggle behavior + effort
+        vocabulary), probed on first use and cached for the process lifetime."""
+        efforts = self.effort_profile()
+        with self._profile_lock:
+            if self._thinking_profile is None:
+                self._thinking_profile = probe_thinking_profile(self._probe_render, efforts)
+            return self._thinking_profile
+
+    def _probe_render(self, kwargs: dict[str, Any], tools: list[dict[str, Any]] | None) -> str:
+        """Render the probe conversation to a *string* (not a BatchEncoding),
+        since ``_renderings_differ`` compares the probe round-trips by string.
+        Jinja ignores undeclared template variables, so the raw probe kwargs
+        (including unsupported effort / thinking values) are safe to pass."""
+        if tools is not None:
+            kwargs = {**kwargs, "tools": tools}
+        rendered = self.tokenizer.apply_chat_template(_PROBE_MESSAGES, tokenize=False, **kwargs)
+        return rendered if isinstance(rendered, str) else str(rendered)
+
+    def _sanitize_effort(self, chat_template_kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Quantize a client's ``reasoning_effort`` onto the probed vocabulary.
+
+        Every render path (``encode``, the count proxy, the frontend) must
+        quantize identically, so the value reaching the template is the one the
+        checkpoint actually grades. Unsupported values map to the nearest
+        supported gear (or are dropped to the template default)."""
+        if "reasoning_effort" not in chat_template_kwargs:
+            return chat_template_kwargs
+        raw = chat_template_kwargs.get("reasoning_effort")
+        mapped = quantize_effort(raw, self.effort_profile())
+        if mapped == raw:
+            return chat_template_kwargs
+        # raw is client-controlled and may be unhashable (a JSON list/dict).
+        key = (raw if isinstance(raw, str) else repr(raw), mapped)
+        if key not in self._logged_effort_maps:
+            self._logged_effort_maps.add(key)
+        sanitized = dict(chat_template_kwargs)
+        if mapped is None:
+            del sanitized["reasoning_effort"]
+        else:
+            sanitized["reasoning_effort"] = mapped
+        return sanitized
+
+
+__all__ = ["TokenizeManager", "resolve_thinking_mode"]

--- a/tests/test_serve_live_engine_xpu.py
+++ b/tests/test_serve_live_engine_xpu.py
@@ -139,6 +139,94 @@ def test_serve_chat_completions_streams_real_engine_tokens(qwen35_xpu_ckpt):
 
 
 @XPU
+def test_serve_chat_completions_accepts_reasoning_controls(qwen35_xpu_ckpt):
+    """Accept (#97): the OpenAI seam accepts ``reasoning_effort`` +
+    ``enable_thinking`` + ``tools`` and still streams readable tokens.
+
+    The live request path runs the client's reasoning controls through the
+    probed effort/thinking profiles: ``encode`` quantizes ``reasoning_effort``
+    onto the checkpoint's probed effort vocabulary and resolves the thinking
+    toggle, so a request carrying any combination of these controls renders
+    through the same chat template the model was trained with and the engine
+    still streams non-placeholder text. The fabricated Qwen-style template
+    interpolates the controls rather than gating generation on them, so the
+    assertion is *acceptance* — the request is honored (no 500) and the
+    stream is readable — not effort-specific output text.
+    """
+    import torch
+
+    dev = torch.device("xpu")
+    engine = _serve_engine(qwen35_xpu_ckpt, dev)
+    engine.frontend_tokenizer = _frontend_tokenizer(parse_args([qwen35_xpu_ckpt]))
+    server_args = parse_args([qwen35_xpu_ckpt])
+    # A tool definition the template can be offered (the thinking resolver
+    # treats "tools offered" as a thinking signal); the value is irrelevant —
+    # the assertion is that the request is accepted.
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    # The full #97 control surface: an effort the template may or may not grade
+    # (quantized to the nearest gear or dropped), the thinking toggle, and tools.
+    # Every combination must render without a 500 and stream readable text.
+    for reasoning_effort in ("high", "max", "unbounded"):
+        for enable_thinking in (None, True, False):
+            for use_tools in (None, tools):
+                chat_template_kwargs = {}
+                if reasoning_effort is not None:
+                    chat_template_kwargs["reasoning_effort"] = reasoning_effort
+                if enable_thinking is not None:
+                    chat_template_kwargs["enable_thinking"] = enable_thinking
+                deltas = list(
+                    stream_chat(
+                        engine,
+                        _MESSAGES,
+                        model=server_args.resolved_model_name,
+                        max_tokens=_DECODE_TOKENS,
+                        tools=use_tools,
+                        chat_template_kwargs=chat_template_kwargs,
+                    )
+                )
+                content = "".join(content_delta for _reasoning, content_delta in deltas)
+                assert content, (
+                    f"the #97 control set (effort={reasoning_effort!r}, "
+                    f"thinking={enable_thinking!r}, tools={bool(use_tools)}) "
+                    f"must not 500 and must stream tokens"
+                )
+                assert "<tok-" not in content, (
+                    f"decoder still emits placeholders under the #97 control set: {content!r}"
+                )
+
+
+@XPU
+def test_serve_chat_completions_resolves_effort_profile(qwen35_xpu_ckpt):
+    """Accept (#97, wiring): the seam's profile probe resolves a real
+    ``EffortProfile`` + ``ThinkingProfile`` from the checkpoint's own chat
+    template (never a static per-family table)."""
+    import torch
+
+    dev = torch.device("xpu")
+    _engine = _serve_engine(qwen35_xpu_ckpt, dev)
+    mgr = _frontend_tokenizer(parse_args([qwen35_xpu_ckpt]))
+    # The probe runs in-process against the template on first use and caches.
+    effort = mgr.effort_profile()
+    thinking = mgr.thinking_profile()
+    assert effort is not None, "the effort probe must resolve a profile"
+    assert thinking is not None, "the thinking probe must resolve a profile"
+    # Second access is the cached profile (the per-request path is a lookup,
+    # not a re-probe).
+    assert mgr.effort_profile() is effort
+    assert mgr.thinking_profile() is thinking
+    assert isinstance(effort, object)
+
+
+@XPU
 def test_serve_app_built_against_real_engine_holder(qwen35_xpu_ckpt):
     """Accept (#93, wiring): create_app wires the real engine holder into the
     routes without error, so the live server's route graph is the real one."""

--- a/tests/test_server_anthropic.py
+++ b/tests/test_server_anthropic.py
@@ -54,6 +54,30 @@ def _messages_payload(**overrides):
     return payload
 
 
+def test_messages_accepts_thinking_opt_in():
+    """Accept (#97): the Anthropic route accepts the ``thinking`` opt-in and
+    maps it onto the shared thinking kwargs without a 500. The stub engine has
+    no tokenizer, so the encode path is the no-tokenizer fallback; the point is
+    acceptance at the HTTP boundary plus the mapping the seam applies."""
+    from freetoken.server.anthropic_api import _to_chat_template_kwargs
+
+    app = _make_app(["Hello", " world"])
+    response = _client(app).post(
+        "/v1/messages", json=_messages_payload(thinking={"type": "enabled"})
+    )
+    assert response.status_code == 200
+    assert response.json()["content"][0]["text"] == "Hello world"
+    # The mapping is the seam's single source of truth: "enabled" turns the
+    # thinking toggle on (broadcast across the dialect spellings); "disabled" or
+    # absent leaves the template default (no kwarg).
+    assert _to_chat_template_kwargs({"type": "enabled"}) == {
+        "enable_thinking": True,
+        "thinking_mode": "enabled",
+    }
+    assert _to_chat_template_kwargs({"type": "disabled"}) == {}
+    assert _to_chat_template_kwargs(None) == {}
+
+
 def test_messages_non_streaming_envelope():
     app = _make_app(["Hello", " world"])
     response = _client(app).post("/v1/messages", json=_messages_payload())

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -99,6 +99,32 @@ def test_chat_completions_non_streaming():
     assert body["choices"][0]["finish_reason"] == "stop"
 
 
+def test_chat_completions_accepts_reasoning_controls():
+    """Accept (#97): the OpenAI route accepts the client's reasoning controls
+    (``reasoning_effort`` / ``enable_thinking`` / ``tools``) without a 500 — the
+    request model parses them and the seam quantizes effort onto the probed
+    profile. The stub engine has no tokenizer, so the encode path is the
+    no-tokenizer fallback; the point here is acceptance at the HTTP boundary."""
+    app = _make_app(["Hello", " world"])
+    response = _client(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "Qwen3-30B-A3B",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "reasoning_effort": "high",
+            "enable_thinking": True,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {"type": "object"}},
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "Hello world"
+
+
 def test_chat_completions_streaming_sse():
     app = _make_app(["Hello", " world"])
     with _client(app).stream(

--- a/tests/test_template_probe_cpu.py
+++ b/tests/test_template_probe_cpu.py
@@ -1,0 +1,220 @@
+"""CPU unit tests for the reasoning-effort / thinking probe (issue #97).
+
+Faithful port of upstream's ``tests/tokenizer/test_effort.py`` to the in-process
+seam: the probe is driven by a ``render(kwargs, tools) -> str`` callback and the
+quantizer by the static ``EFFORT_SCALE`` table. Pure text -- no AutoTokenizer,
+no Jinja, no torch -- so these run in the lean CPU venv and the dual-venv
+"torch must not import" contract is unaffected. A real-tokenizer probe
+round-trip is exercised on the XPU live suite (``test_serve_live_engine_xpu``).
+"""
+from __future__ import annotations
+
+from freetoken.tokenizer.effort import (
+    EFFORT_SCALE,
+    EffortProfile,
+    KNOWN_REASONING_EFFORTS,
+    OPENAI_EFFORT_TRIPLE,
+    probe_effort_profile,
+    probe_thinking_profile,
+    quantize_effort,
+)
+
+
+# --- Representative profiles (mirrors upstream test fixtures) ---------------
+QWEN38 = EffortProfile(supported=frozenset({"xhigh", "medium", "low"}), default="xhigh", consumes_effort=True)
+DSV4_OFFICIAL = EffortProfile(supported=frozenset({"low", "high", "max"}), default="low", consumes_effort=True)
+IGNORES = EffortProfile(supported=frozenset(KNOWN_REASONING_EFFORTS), default=None, consumes_effort=False)
+
+
+# --------------------------------------------------------------------------- #
+# quantize_effort
+# --------------------------------------------------------------------------- #
+def test_in_vocabulary_values_pass_through():
+    for name in ("xhigh", "medium", "low"):
+        assert quantize_effort(name, QWEN38) == name
+    for name in ("low", "high", "max"):
+        assert quantize_effort(name, DSV4_OFFICIAL) == name
+
+
+def test_deepseek_dialect_high_lands_on_qwen_xhigh():
+    # high (0.9) is nearer xhigh (0.99) than medium (0.7)
+    assert quantize_effort("high", QWEN38) == "xhigh"
+
+
+def test_openai_dialect_medium_drops_to_the_dsv4_default():
+    # medium (0.7) is 0.2 from the nearest gear -- beyond the quantize
+    # threshold, so nothing is sent and the encoder default (low) applies;
+    # anything else would silently escalate OpenAI-default traffic to the
+    # encoder's absolute-maximum "high" prompt. Matches vLLM's DSV4 mapping.
+    assert quantize_effort("medium", DSV4_OFFICIAL) is None
+
+
+def test_xhigh_lands_on_dsv4_high_never_max():
+    # "max" is an extreme opt-in gear, reachable only by its own name
+    # (vLLM's DSV4 rule) -- rounding must not enter it.
+    assert quantize_effort("xhigh", DSV4_OFFICIAL) == "high"
+
+
+def test_max_lands_on_qwen_xhigh():
+    # "max" is a removable default gear (xhigh==max on the scale): it rounds to
+    # the nearest non-"max" gear, never to itself.
+    assert quantize_effort("max", QWEN38) == "xhigh"
+
+
+def test_far_values_drop_instead_of_rounding():
+    profile = EffortProfile(supported=frozenset({"low", "xhigh"}), default=None, consumes_effort=True)
+    assert quantize_effort("minimal", profile) == "low"  # 0.1 away
+    assert quantize_effort("medium", profile) is None  # 0.29 to the nearest gear
+
+
+def test_unknown_and_non_string_values_drop_to_template_default():
+    assert quantize_effort("banana", QWEN38) is None
+    assert quantize_effort(3, QWEN38) is None
+    assert quantize_effort(None, QWEN38) is None
+
+
+def test_effort_ignoring_template_sends_nothing():
+    assert quantize_effort("high", IGNORES) is None
+    assert quantize_effort("xhigh", IGNORES) is None
+
+
+# --------------------------------------------------------------------------- #
+# probe_effort_profile: fake render callables standing in for real templates
+# --------------------------------------------------------------------------- #
+def _qwen38_render(kwargs, tools):
+    # Validates unconditionally (enable_thinking undefined counts as on) and
+    # renders a distinct effort preamble per gear, default xhigh.
+    effort = kwargs.get("reasoning_effort", "xhigh")
+    if effort not in ("xhigh", "medium", "low"):
+        raise ValueError(f"Unexpected reasoning effort {effort}")
+    preamble = {"xhigh": "think hard", "medium": "", "low": "think briefly"}[effort]
+    return f"{preamble}|tools={bool(tools)}"
+
+
+def test_probe_learns_the_qwen38_vocabulary():
+    profile = probe_effort_profile(_qwen38_render)
+    assert profile.supported == frozenset({"xhigh", "medium", "low"})
+    assert profile.default == "xhigh"
+    assert profile.consumes_effort
+    assert profile.validates  # rejections observed -> the vocabulary is real
+
+
+def _dsv4_render(kwargs, tools):
+    # Grades effort only in thinking mode (tools force it); asserts on unknown
+    # values there; "low" renders the empty preamble, matching the default.
+    effort = kwargs.get("reasoning_effort") or "low"
+    if not tools:
+        return "chat prompt"
+    assert effort in ("low", "high", "max"), f"Invalid reasoning effort: {effort}"
+    preamble = {"low": "", "high": "absolute maximum", "max": "beyond maximum"}[effort]
+    return f"{preamble}|thinking"
+
+
+def test_probe_learns_the_dsv4_vocabulary_through_the_tools_round():
+    profile = probe_effort_profile(_dsv4_render)
+    assert profile.supported == frozenset({"low", "high", "max"})
+    assert profile.default == "low"
+    assert profile.consumes_effort
+    assert profile.validates
+
+
+def test_probe_marks_an_ignoring_template_as_not_consuming():
+    profile = probe_effort_profile(lambda kwargs, tools: f"same|tools={bool(tools)}")
+    assert not profile.consumes_effort
+    assert not profile.validates
+    assert profile.default is None
+
+
+def test_probe_marks_an_interpolating_template_as_not_validating():
+    # Grades effort (renders differ) but rejects nothing: consumes without a
+    # trustworthy vocabulary.
+    profile = probe_effort_profile(lambda kwargs, tools: f"p|{kwargs.get('reasoning_effort')}")
+    assert profile.consumes_effort
+    assert not profile.validates
+    # A non-validating grader that accepted the whole scale is capped to its
+    # dialect's ladder -- the OpenAI triple for a plain effort grader.
+    from freetoken.tokenizer.effort import effective_efforts  # noqa: E402
+
+    assert effective_efforts(profile) == frozenset(OPENAI_EFFORT_TRIPLE)
+
+
+def test_probe_skips_rounds_whose_baseline_fails():
+    def render(kwargs, tools):
+        if tools:  # template rejects tools outright -- round is uninformative
+            raise RuntimeError("no tools supported")
+        return _qwen38_render(kwargs, tools)
+
+    profile = probe_effort_profile(render)
+    assert profile.supported == frozenset({"xhigh", "medium", "low"})
+    assert profile.consumes_effort
+
+
+# --------------------------------------------------------------------------- #
+# probe_thinking_profile: toggle behavior + default state
+# --------------------------------------------------------------------------- #
+def _thinking_render(baseline_state, kwargs, tools, adaptive=False):
+    """A toggleable Qwen-style template: the off/on broadcasts render
+    differently, and the no-kwarg baseline matches ``baseline_state``. When
+    ``adaptive`` is False (the default) the template has no adaptive knob, so
+    the adaptive probe is rejected -- only a minimax-style template admits it."""
+    if "enable_thinking" in kwargs or "thinking_mode" in kwargs:
+        if kwargs.get("thinking_mode") == "adaptive":
+            if not adaptive:
+                raise ValueError("template has no adaptive thinking mode")
+            return "ADAPTIVE"
+        if kwargs.get("enable_thinking") is False or kwargs.get("thinking_mode") == "disabled":
+            return "OFF"
+        if kwargs.get("enable_thinking") is True or kwargs.get("thinking_mode") == "enabled":
+            return "ON"
+    return baseline_state
+
+
+def test_thinking_profile_toggleable_default_on():
+    profile = probe_thinking_profile(lambda kw, t: _thinking_render("ON", kw, t), QWEN38)
+    assert profile.toggleable is True
+    assert profile.default_state == "on"
+    assert profile.has_adaptive is False
+    assert profile.efforts is QWEN38
+
+
+def test_thinking_profile_default_off():
+    profile = probe_thinking_profile(lambda kw, t: _thinking_render("OFF", kw, t), QWEN38)
+    assert profile.toggleable is True
+    assert profile.default_state == "off"
+
+
+def test_thinking_profile_not_toggleable_when_broadcast_identical():
+    # off and on render the same -> not a toggle.
+    profile = probe_thinking_profile(lambda kw, t: "SAME", QWEN38)
+    assert profile.toggleable is False
+    assert profile.default_state == "on"
+    assert profile.has_adaptive is False
+
+
+def test_thinking_profile_rejecting_template_not_toggleable():
+    def reject(kwargs, tools):
+        raise RuntimeError("no thinking knobs here")
+
+    profile = probe_thinking_profile(reject, QWEN38)
+    assert profile.toggleable is False
+    assert profile.has_adaptive is False
+    assert profile.default_state == "on"
+
+
+def test_thinking_profile_adaptive_third_state():
+    # A minimax-m3-style template admits a third "adaptive" state distinct from
+    # on/off; the no-kwarg baseline still matches "on".
+    profile = probe_thinking_profile(lambda kw, t: _thinking_render("ON", kw, t, adaptive=True), QWEN38)
+    assert profile.toggleable is True
+    assert profile.has_adaptive is True
+    assert profile.default_state == "on"
+
+
+# --- scale table sanity ------------------------------------------------------
+def test_scale_covers_the_probed_vocabulary():
+    assert set(EFFORT_SCALE) == set(KNOWN_REASONING_EFFORTS)
+    # xhigh and max intentionally share the top of the scale (0.99): max is an
+    # opt-in alias, and quantization excludes "max" from rounding, so the tie
+    # never makes nearest-gear selection ambiguous.
+    assert EFFORT_SCALE["xhigh"] == EFFORT_SCALE["max"]
+    assert OPENAI_EFFORT_TRIPLE == ("low", "medium", "high")


### PR DESCRIPTION
<!-- argos-status:start -->
> 🔴 **PR-Agent Score: 68** `score-below-70` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/98#issuecomment-5471623961) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 18d085d](https://github.com/Performant-Labs/FreeToken-Intel/commit/18d085dc5590d60cb9eda446571c671d04bb4cda) · run [#33338791183](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33338791183) · 2026-08-30 16:23 MDT / 2026-08-30 22:23 UTC
<!-- argos-status:end -->

### **User description**
## What

Ports the deferred `tokenizer/effort.py` from upstream FlashML FreeToken and wires the client's `reasoning_effort` / `enable_thinking` / `tools` through the in-process tokenizer seam, so `ft serve` speaks each model family's real effort and thinking vocabulary — **probed from the checkpoint's own chat template, never a static per-family table**.

Closes #97.

## How

**Phase 1 — `python/freetoken/tokenizer/effort.py` (new).** Faithful in-process port of the upstream effort dialect logic:
- `EffortProfile`, `ThinkingProfile`, `EFFORT_SCALE` (`none/minimal/low/medium/high/xhigh/max`), `KNOWN_REASONING_EFFORTS`, `OPENAI_EFFORT_TRIPLE`, `GRADED_EFFORT_LADDER`, `quantize_effort`, `effective_efforts`, `probe_effort_profile`, `probe_thinking_profile`, `THINKING_{OFF,ON,ADAPTIVE}_KWARGS`.
- The probe renders prompt **strings** via `apply_chat_template` (no `return_dict`) because `BatchEncoding.__eq__` always raises and would make `_renderings_differ` mark everything divergent.
- The ZMQ worker and the DSV4/GGUF custom encoder are dropped (the Intel port is in-process).
- `__init__.py` exports the new symbols; the module stays torch-free.

**Phase 2 — `tests/test_template_probe_cpu.py` (new, torch-free).** CPU unit tests driving the probe/quantize logic with deterministic fake renderers:
- template ignores the knob → `consumes_effort=False`, quantize → `None`
- template rejects unknown efforts → `validates=True`, narrowed `supported`
- template diverges but never rejects → `supported=full scale`, `effective_efforts` caps to the OpenAI triple / graded ladder
- `quantize_effort`: in-vocab passthrough; nearest gear within 0.15; `max` only by name; out-of-band → `None`
- `probe_thinking_profile`: toggleable vs not, `has_adaptive`, `default_state`

Gate: all pass in `.venv`; `import torch` still fails there (the CPU venv contract).

**Phase 3 — wire client kwargs into the seam.**
- `tokenize.py`: `resolve_thinking_mode()` is the single source of truth for whether a request is in thinking mode (used by both the encode side and the frontend parse side). `TokenizeManager` lazily probes + caches `EffortProfile` / `ThinkingProfile` (lock-guarded, on first use — no eager probe at startup). `encode(messages, *, tools=None, chat_template_kwargs=None)` quantizes `reasoning_effort` onto the probed profile (a client value outside the family's vocabulary maps to the nearest supported gear, or drops to the template default) and resolves the thinking toggle + `tools`.
- `server/launch.py`: `_frontend_tokenizer` builds the `TokenizeManager` (profiles now probe lazily).
- `server/openai_api.py`: `ChatCompletionRequest` accepts `reasoning_effort` + `enable_thinking` + `tools`; the routes pass them into `generation.stream_chat`.
- `server/anthropic_api.py`: `AnthropicMessageRequest` accepts `thinking`; `_to_chat_template_kwargs` maps it onto the shared thinking kwargs.
- `server/generation.py`: `_prompt_token_ids` / `_stream_tokens` / `stream_chat` forward `tools` + `chat_template_kwargs` to `TokenizeManager.encode`; the `EngineNotReady` and no-tokenizer fallback paths are preserved.
- CPU route tests (`test_server_api.py`, `test_server_anthropic.py`) pin acceptance (no 500) for the new client fields on both surfaces.

**Phase 4 — XPU live assertions (`test_serve_live_engine_xpu.py`).** The live request path accepts `reasoning_effort` + `enable_thinking` + `tools` (no 500, readable stream) and the seam's probe resolves + caches a real `EffortProfile` / `ThinkingProfile` from the fabricated GPT-2 checkpoint's Qwen-style template. XPU-gated (runs in `.venv-xpu` on the B70, not the CPU merge gate).

## Why

#95 landed the lean in-process tokenizer seam (chat-template encode + incremental decode + stop-string holdback) and deliberately deferred the upstream effort/thinking handling. This issue is that follow-up. The whole point is that a client's `reasoning_effort` outside a family's vocabulary quantizes to the nearest supported gear (or drops to the template default) instead of failing the request, and the thinking toggle + `tools` flow through `apply_chat_template` on the in-process seam.

## Accept
- [x] `ft serve --model <family>` resolves each family's effort/thinking vocabulary from its own chat template (probe), never a static table
- [x] A client `reasoning_effort` outside the family's vocabulary quantizes to the nearest supported gear (or drops to the template default) instead of failing the request
- [x] `enable_thinking` / `thinking` toggle and `tools` flow through `apply_chat_template` on the in-process seam
- [x] CPU-safe: the probe is transformers-only (no torch); the torch-free app contract holds
- [x] A prompt-id ↔ decoded-text round-trip still matches a single greedy decode

## Related
- #95 (server-tokenizer, closed via #96) — the lean seam this issue completes
- #25 (server-openai, closed) / #26 (server-anthropic) — the HTTP seams that share it
- #19 / #20 (model families) — each family's effort/thinking dialect is probed per-checkpoint

Upstream reference (local clone): `../FreeToken/python/freetoken/tokenizer/{effort,tokenize,detokenize,server}.py`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add probed reasoning effort and thinking profiles from chat template
  - New `effort.py` ports `EffortProfile`, `ThinkingProfile`, and quantizers
  - `TokenizeManager` lazily probes and caches profiles per checkpoint

- Wire OpenAI and Anthropic reasoning controls to tokenizer seam
  - Accept `reasoning_effort`, `enable_thinking`, `thinking`, and `tools`
  - `generation.stream_chat` forwards controls through `encode`

- Add CPU unit tests and XPU live acceptance assertions
  - Cover quantization, probing, and HTTP boundary behavior
  - Verify live request path streams readable tokens without 500


___

### Diagram Walkthrough


```mermaid
flowchart TD
  Client["Client request: reasoning_effort / enable_thinking / thinking / tools"] --> APIs["OpenAI + Anthropic routes"]
  APIs --> Stream["generation.stream_chat"]
  Stream --> Encode["TokenizeManager.encode"]
  Encode --> Probe["lazy EffortProfile / ThinkingProfile probe"]
  Probe --> Quant["quantize_effort + resolve_thinking_mode"]
  Quant --> Template["apply_chat_template"]
  Tests["CPU/XPU tests"] --> Probe
  Tests --> APIs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>effort.py</strong><dd><code>Port reasoning effort and thinking probe logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-466f3aa7dc18b0fee70a36e554f11d5c72fc9404383ec9eb418e020a0516697e">+280/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tokenize.py</strong><dd><code>Integrate probed profiles into tokenizer encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-e8cec3e2731d4966e1a13fc7cc6f8a8f6134b0d6d31bef539954b1814fc24221">+134/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>generation.py</strong><dd><code>Forward tools and chat template kwargs downstream</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-6cc9eb8ffc1a3a954156d11ed41130092731f48a4b524eaa3f40c2fc8194d4e8">+48/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openai_api.py</strong><dd><code>Accept OpenAI reasoning controls on requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-3d5e5b76705f6c34212eddb8fc62a32ae9cad2db9b648d5aed996d32eac66c1a">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>anthropic_api.py</strong><dd><code>Accept Anthropic thinking opt-in mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-0ba54594c85f13f15e6bed9fe9b1325f952b702e5dd3133303458a678da94041">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Export effort and thinking profile symbols</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-6770134d5d2696273aca9df8ac28180bdcdaad6882ede4a2a3a0b6c655e4e95a">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_template_probe_cpu.py</strong><dd><code>Add CPU probe and quantization tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-80dad81ccc0100408b9f3cb4d98a7f3680165d05668c6c1ea2ef13626f7e3f2b">+220/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_server_api.py</strong><dd><code>Test OpenAI reasoning controls acceptance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-f8fe62042b932fe6b2ac78805307ae2e7accb40e2ba8531155a57fffd216af57">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_server_anthropic.py</strong><dd><code>Test Anthropic thinking opt-in mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-c61d22b2b96d21a30e57fcc01a8ed6e05eb539c1c92bb783955c7d916d316714">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_serve_live_engine_xpu.py</strong><dd><code>Add XPU live reasoning control assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/98/files#diff-5abae54fdf874d5ab33c5ace836e26d73abe6172e670fc0d02e7f16af1374625">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___