### PR TITLE
feat(scheduler): chunked-prefill admission + bsz-invariant attention (issue #13)

### DIFF
--- a/python/freetoken/attention/triton.py
+++ b/python/freetoken/attention/triton.py
@@ -106,12 +106,32 @@ class TritonAttentionBackend(BaseAttnBackend):
         if table_idx is not None:
             req = next((r for r in batch.reqs if r.table_idx == table_idx), batch.reqs[0])
             ext = q.shape[1]
-            # Per-request phase (NOT the batch-level flag -- a batch can mix
-            # phases): a request is decoding once a token has been generated.
-            is_decode = req.device_len != len(req.input_ids)
-            written = req.device_len if is_decode else ext
+            # Phase comes from the scheduler's per-step flag ``batch.phase``
+            # ("prefill" for any step that extends the prompt -- first chunk or a
+            # chunked continuation -- "decode" otherwise), which is uniform within
+            # a step: the scheduler emits a prefill step or a decode step, never a
+            # mix, so one flag sizes every request's slice this step. This matches
+            # the engine, which appends/samples and keys its token bookkeeping off
+            # batch.phase. (NOT req.can_decode -- that is a per-request token-BUDGET
+            # flag (remain_len > 0): it is False for a finished decode req, and it
+            # is the chunked-prefill "do not sample this chunk" signal, NOT the
+            # attention phase. The old shape checks (device_len != / > len(input_ids))
+            # misfire under chunked prefill, where a continuation has device_len >
+            # len(input_ids) and a full prefill has device_len == len(input_ids).)
+            is_decode = batch.phase == "decode"
+            # Decode steps read the full KV history (prompt + every generated
+            # token). A prefill step reads the prompt prefix already resident
+            # in the pool plus the tokens this chunk carries: for the first
+            # chunk (cached_len 0) that is the whole prompt; for a
+            # continuation the pool holds [0, device_len) and ext == the
+            # chunk, so cached_len + ext == device_len == the full attended
+            # prefix. The old "written = device_len" under-counted a
+            # continuation (device_len was the pre-bump), so the kernel read pool slots that
+            # had not been written yet (torch.empty garbage, which differs per
+            # process -- the original nondeterminism).
+            written = req.device_len if is_decode else req.cached_len + ext
             q_pos = self._request_positions(batch, table_idx, ext)
-            out[:] = self._attend_one(req, q, q_pos, written, repeat, scale, window)
+            out[:] = self._attend_one(req, q, q_pos, written, repeat, scale, window, layer_id)
             return out
 
         # Whole-batch call (table_idx is None): q/k/v span all requests, so walk
@@ -119,21 +139,31 @@ class TritonAttentionBackend(BaseAttnBackend):
         # Each request's phase is decided per-request (a batch can mix phases).
         token_idx = 0
         for req in batch.reqs:
-            is_decode = req.device_len != len(req.input_ids)
+            # Uniform phase from the scheduler's per-step flag (see the
+            # per-request call above): one flag sizes every request's slice.
+            is_decode = batch.phase == "decode"
+            # A decode step always contributes exactly one new token per request,
+            # independent of req.extend_len (which is device_len - cached_len and
+            # can be larger when a request was framed/overridden with a stale
+            # cached_len -- e.g. a test that overrides device_len but leaves
+            # cached_len at 0). Pref pattern of upstream: decode -> 1 new token,
+            # prefill -> the whole chunk (req.extend_len).
             ext = 1 if is_decode else req.extend_len
-            written = req.device_len if is_decode else req.extend_len
+            # Decode reads the full history; prefill reads the resident prompt
+            # prefix + this chunk (see the per-request path above).
+            written = req.device_len if is_decode else req.cached_len + ext
             qh = q[:, token_idx : token_idx + ext, :]
             q_pos = batch.positions[token_idx : token_idx + ext]
-            out[:, token_idx : token_idx + ext, :] = self._attend_one(req, qh, q_pos, written, repeat, scale, window)
+            out[:, token_idx : token_idx + ext, :] = self._attend_one(req, qh, q_pos, written, repeat, scale, window, layer_id)
             token_idx += ext
         return out
 
-    def _attend_one(self, req, qh, q_pos, written, repeat, scale, window: int = 0) -> torch.Tensor:
+    def _attend_one(self, req, qh, q_pos, written, repeat, scale, window: int = 0, layer_id: int = 0) -> torch.Tensor:
         """Attend a block of query rows against one request's KV history."""
         ctx = _get_ctx()
         kv_cache = ctx.kv_cache
         dev = qh.device
-        k_tok, v_tok = kv_cache.read_kv(req.table_idx, torch.arange(written, device=dev))
+        k_tok, v_tok = kv_cache.read_kv(req.table_idx, torch.arange(written, device=dev), layer_id)
         k_all = k_tok.transpose(0, 1).contiguous()  # [kv, written, D]
         v_all = v_tok.transpose(0, 1).contiguous()  # [kv, written, D]
         if repeat != 1:
@@ -171,9 +201,12 @@ class TritonAttentionBackend(BaseAttnBackend):
         for r in batch.reqs:
             if r.table_idx == table_idx:
                 break
-            # Per-request phase: a request that has generated a token is in
-            # decode (one new token this step); otherwise it is prefilling.
-            offset += 1 if (r.device_len != len(r.input_ids)) else r.extend_len
+            # A decoding request contributes one new token this step; a
+            # prefilling one (first chunk or chunked continuation) contributes
+            # its extend length. The phase is the scheduler's uniform per-step
+            # flag (not a per-request device_len shape test, which misfires for
+            # a full prefill / chunked continuation).
+            offset += 1 if batch.phase == "decode" else r.extend_len
         return batch.positions[offset : offset + ext]
 
 

--- a/python/freetoken/engine/__init__.py
+++ b/python/freetoken/engine/__init__.py
@@ -1,5 +1,31 @@
+"""The engine package.
+
+``EngineConfig`` is import-safe without torch (it only pulls ``DistributedInfo``
+from ``freetoken.distributed``), so it is imported eagerly -- the scheduler
+subclasses it and must be importable on the torch-free CPU venv (the dual-venv
+contract). ``Engine`` / ``ForwardOutput`` / ``BatchSamplingArgs`` live in modules
+that import torch, so they are exposed *lazily* via :func:`__getattr__` (PEP
+562): importing ``freetoken.engine`` -- which ``freetoken.scheduler.config`` does
+just to reach ``EngineConfig`` -- must NOT trigger ``import torch``.
+"""
 from .config import EngineConfig
-from .engine import Engine, ForwardOutput
-from .sample import BatchSamplingArgs
 
 __all__ = ["Engine", "EngineConfig", "ForwardOutput", "BatchSamplingArgs"]
+__all_lazy__ = {"Engine", "ForwardOutput", "BatchSamplingArgs"}
+
+
+def __getattr__(name):
+    # PEP 562: lazy re-exports so the package stays torch-free at import time.
+    if name == "Engine" or name == "ForwardOutput":
+        from . import engine
+
+        return getattr(engine, name)
+    if name == "BatchSamplingArgs":
+        from . import sample
+
+        return getattr(sample, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals()) + list(__all__))

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -8,30 +8,45 @@ that are already real -- the model's forward, the paged KV pool, the reference
 attention backend, and the sampler -- into a prefill/decode loop:
 
     Engine(config)
-        .add_request(Req)      -> assign a slot / table index
-        .generate()             -> prefill the prompt, then decode until every
-                                   request hits its stop condition (eos or
-                                   max_tokens) and return the generated ids
+        .add_request(Req)      -> admit into the scheduler (assigns a slot)
+        .generate()             -> prefill the prompt (chunked to the token
+                                   budget), then decode until every request
+                                   hits its stop condition (eos or max_tokens)
+                                   and return the generated ids
 
-Each :meth:`step` builds the batch's device tensors (``input_ids`` /
+Since issue ``scheduler`` the engine no longer picks the batch by hand. Each
+:meth:`step` asks the :class:`~freetoken.scheduler.Scheduler` which batch to run
+(a prefill batch, chunked to the per-step token budget, or a decode batch), runs
+that one batch through the model + sampler, and then hands the result back to
+the scheduler via :meth:`~freetoken.scheduler.Scheduler.complete` so it can move
+finished prefills into the decode set and free the rows of requests that hit
+their stop condition. The engine keeps ownership of the token pool (it is the
+one that actually materializes and frees ``table_idx`` rows) and of the device
+tensors; the scheduler owns the scheduling decision (which requests, which
+phase, which chunk) and the uid / free-slot bookkeeping.
+
+Each step still builds the batch's device tensors (``input_ids`` /
 ``positions`` / ``out_loc``) from the request state, sets them on the global
-context, runs ``model(...)`` once, samples a next token per request, and
-advances each request's history length. Prefill and decode differ only in how
-the tensors are assembled (a request's whole extend during prefill; one new
-token during decode), which the model's forward already branches on.
+context, runs ``model(...)`` once, and samples a next token per request.
+Prefill and decode differ only in how the tensors are assembled (a request's
+whole extend during prefill; one new token during decode), which the model's
+forward already branches on.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import math
+from dataclasses import dataclass, fields
 from typing import List
 
 import torch
 
 from freetoken.attention import create_attention_backend
-from freetoken.core import Batch, Context, Req, get_global_ctx, set_global_ctx
+from freetoken.core import Batch, Context, Req, set_global_ctx
+from freetoken.engine.config import EngineConfig
 from freetoken.kvcache import create_kv_pool
-from freetoken.models import create_model
 from freetoken.models.loader import load_model
+from freetoken.scheduler import Scheduler, SchedulerConfig, make_pending_req
+from freetoken.scheduler.prefill import ChunkedReq
 from freetoken.utils.arch import is_xpu_available
 
 
@@ -43,6 +58,8 @@ class ForwardOutput:
     next_token_ids: torch.Tensor
     # Which requests finished this step (hit eos / max_tokens).
     finished: List[Req]
+    # The batch this step ran (reqs in batch order, aligned to next_token_ids).
+    reqs: List[Req]
 
 
 class Engine:
@@ -53,7 +70,9 @@ class Engine:
     checkpoint, or fabricating dummy expert banks when ``use_dummy_weight`` is
     set), creates the paged KV pool + page table + attention backend + sampler,
     and installs them on the global context so the model's ``forward`` can read
-    them.
+    them. It also builds the :class:`~freetoken.scheduler.Scheduler`, which owns
+    per-step batch selection; the engine drives it from :meth:`add_request` /
+    :meth:`step` / :meth:`generate`.
     """
 
     def __init__(self, config) -> None:
@@ -74,8 +93,8 @@ class Engine:
         self.device = device
 
         # Build the model and place its weights (dense on `device`; MoE experts
-        # on host offload banks). use_dummy_weight fabricates the expert banks
-        # offline so the engine is testable without a checkpoint on disk.
+        # on host offload banks). use_dummy_weight fabricates the expert banks offline so
+        # the engine is testable without a checkpoint on disk.
         dtype = config.dtype if isinstance(config.dtype, torch.dtype) else None
         self.model, _expert_sources = load_model(
             config.model_path,
@@ -139,9 +158,27 @@ class Engine:
             self.ctx.moe_offload_cache = self.model.moe_cache
         set_global_ctx(self.ctx)
 
-        # Request bookkeeping.
-        self._reqs: List[Req] = []
-        self._next_table_idx = 0
+        # Scheduler: owns uid assignment, page-slot (table_idx) bookkeeping, and
+        # per-step batch selection (chunked prefill + decode batching). It is
+        # built over the same pool the engine owns: max_pages rows (the page
+        # table) and the pool's token budget. A plain EngineConfig is wrapped in
+        # a SchedulerConfig view (a SchedulerConfig is itself an EngineConfig, so
+        # passing one through works unchanged).
+        self._pool_num_pages = num_pages
+        self._pool_budget = num_pages * self.page_size
+        if not isinstance(config, SchedulerConfig):
+            # Build the SchedulerConfig view from the *declared* EngineConfig
+            # fields only. config.__dict__ also carries the resolved
+            # cached_property instances (hf_config, model_config) once they have
+            # been accessed above, and those are not dataclass fields -- splatting
+            # them would raise TypeError and would defeat the lazy (torch-gated)
+            # load. Constructing the subclass directly (not dataclasses.replace,
+            # which re-instantiates type(config) and would drop the subclass
+            # fields like max_extend_tokens) is what actually yields a
+            # SchedulerConfig.
+            field_values = {f.name: getattr(config, f.name) for f in fields(EngineConfig)}
+            config = SchedulerConfig(**field_values)
+        self.scheduler = Scheduler(config, max_pages=num_pages, cache_budget=self._pool_budget)
 
     def _build_sampler(self, model_config, device) -> "object":
         from freetoken.engine.sample import Sampler
@@ -152,47 +189,76 @@ class Engine:
     # -- request admission ---------------------------------------------------
 
     def add_request(self, req: Req) -> Req:
-        """Admit a request: assign it a KV slot (table index) and queue it."""
-        if self._next_table_idx >= self.max_running_req:
-            raise RuntimeError(
-                f"cannot admit request: max_running_req={self.max_running_req} reached"
-            )
-        req.table_idx = self._next_table_idx
-        self._next_table_idx += 1
-        req.cached_len = 0
-        self._reqs.append(req)
+        """Admit a request: hand the scheduler a page slot and queue it.
+
+        The caller sets ``req.uid`` (the server path assigns it at the API
+        boundary); the scheduler assigns the page-table row (freeing it when the
+        request later completes) and returns the uid. The raw
+        :class:`~freetoken.core.Req` is wrapped in the scheduler's
+        :class:`~freetoken.scheduler.prefill.PendingReq` -- the caller's uid is
+        preserved -- and the assigned row is stored back on ``req``. Raises
+        :class:`RuntimeError` when the request cap is reached so a caller can
+        reject the request cleanly.
+        """
+        pending = make_pending_req(req.uid, req.input_ids, req.sampling_params, req.cache_handle)
+        uid = self.scheduler.add(pending)
+        req.uid = uid
+        req.table_idx = pending._table_idx  # noqa: SLF001
         return req
+
+    def abort_request(self, uid: int) -> bool:
+        """Free a request's page slot and drop it from the scheduler (any phase)."""
+        return self.scheduler.abort(uid)
+
+    def _free_slot(self, table_idx: int) -> None:
+        # Restore the identity slot map for a freed row (no-op on the reference
+        # pool, which re-derives the slot from the position; kept for symmetry
+        # with a paged pool that may need to clear a row on release).
+        pass
 
     # -- the loop -------------------------------------------------------------
 
     def step(self) -> ForwardOutput:
-        """Run one engine step (one model forward + one sample) over all reqs.
+        """Run one engine step (one model forward + one sample) over the batch
+        the :class:`~freetoken.scheduler.Scheduler` selected.
 
-        The first step for a request is its *prefill*: every prompt token must be
-        run through the model and written into the KV pool (one row per position),
-        so the backend can attend over the full history. A request is in prefill
-        while ``device_len == len(input_ids)`` -- i.e. no token has been generated
-        yet (``device_len`` grows by one after each step, so this is true exactly
-        once, on the first step). Every later step is a decode: one new token.
+        The scheduler picks the batch (a chunked-prefill batch if a prompt is
+        waiting, else a decode batch). Each request in the batch extends by its
+        own count: a whole-prompt or chunk extend during prefill, one new token
+        during decode. After the forward + sample the result is handed back to
+        the scheduler (:meth:`~freetoken.scheduler.Scheduler.complete`) so it can
+        promote finished prefills into the decode set and free completed rows.
+
+        Returns a :class:`ForwardOutput` with no batch (empty tensor) when the
+        scheduler has nothing to run this step (no pending prefill, no live
+        decode) -- the :meth:`generate` loop treats that as "idle" and stops.
         """
-        reqs = self._reqs
-        if not reqs:
-            return ForwardOutput(next_token_ids=torch.empty((0,), device=self.device), finished=[])
-        # A single step mixes prefill (prompt not yet processed) and decode
-        # (already processed) requests; batch the phase per request. The
-        # reference model slices per-request by ``extend_len`` (prefill) or 1
-        # (decode), so the batch just carries the request list.
-        phase = "prefill" if any(r.device_len == len(r.input_ids) for r in reqs) else "decode"
-        batch = Batch(reqs=reqs, phase=phase)
+        batch = self.scheduler.schedule()
+        if batch is None:
+            return ForwardOutput(
+                next_token_ids=torch.empty((0,), device=self.device), finished=[], reqs=[]
+            )
 
         input_ids: List[int] = []
         positions: List[int] = []
         out_locs: List[int] = []
         extend_lens: List[int] = []
-        for req in reqs:
-            # Per-request phase: prefill while no token has been generated yet
-            # (the whole prompt is new), decode afterwards (one new token).
-            if req.device_len == len(req.input_ids):
+        # The scheduler emits a uniform per-step phase (a prefill batch or a
+        # decode batch, never a mix -- see Scheduler.schedule), so batch.phase is
+        # the authoritative phase for every request in this batch. The old
+        # per-request shape test (device_len < len(input_ids)) misfired for a
+        # FRESH prefill: at prefill time the scheduler has already bumped
+        # device_len up to the prompt length, so device_len == len(input_ids) and
+        # the strict "<" is False -- every whole-prompt (and final-chunk) prefill
+        # was misrouted into the decode branch and ran as a 1-token step,
+        # truncating the prompt's attention context.
+        is_prefill_batch = batch.phase == "prefill"
+        for req in batch.reqs:
+            if is_prefill_batch:
+                # Prefill: extend by this request's own extend_len (the whole
+                # prompt for a non-chunked one, or the chunk's slice for a
+                # continuation), reading the not-yet-extended prompt slice
+                # [cached_len, cached_len + ext).
                 ext = req.extend_len
                 start = req.cached_len
                 ids = req.input_ids
@@ -203,6 +269,22 @@ class Engine:
                     out_locs.append(pos)
             else:  # decode: one new token per request
                 ext = 1
+                # The token being positioned is the one just sampled, whose
+                # absolute position is ``device_len - 1``: the prefill step that
+                # ran already did ``device_len += 1`` to include it, so
+                # ``device_len`` is the history length (position + 1) and the
+                # new token sits at ``device_len - 1`` (prompt len 5 -> decode
+                # positions 5,6,7,...).
+                #
+                # Do NOT use ``len(req.input_ids) - 1``: the decode branch of the
+                # post-step bookkeeping *replaces* ``input_ids`` with just the
+                # new token (``[tok]``) rather than appending, so from the second
+                # decode step on ``len(input_ids)`` is 1 and that formula pins
+                # every decode position to 0 -- leaving pool slots unwritten and
+                # exploding attention. ``device_len`` is chunk-size-independent
+                # (the prefill's single ``+= 1`` is the same whether the prompt
+                # was one 5-token chunk or five 1-token chunks), so this is what
+                # keeps chunked and non-chunked runs bit-identical.
                 pos = req.device_len - 1
                 last = req.input_ids
                 input_ids.append(int(last[-1]))
@@ -226,18 +308,43 @@ class Engine:
 
         from freetoken.engine.sample import BatchSamplingArgs
 
-        sampling_args = BatchSamplingArgs([req.sampling_params for req in reqs])
+        sampling_args = BatchSamplingArgs([req.sampling_params for req in batch.reqs])
         next_ids = self.sampler.sample(logits, sampling_args)
 
         finished: List[Req] = []
-        for i, req in enumerate(reqs):
+        for i, req in enumerate(batch.reqs):
+            if isinstance(req, ChunkedReq):
+                # An intermediate prefill chunk is not sampled: only the chunk
+                # that fully extends the prompt (a plain Req) emits the first
+                # generated token. The chunk is not appended a token and is not
+                # marked finished here; it stays queued (the scheduler re-queues
+                # its PendingReq) and is continued next step. Mirrors upstream
+                # _process_last_data, which skips ChunkedReq entirely.
+                continue
             tok = int(next_ids[i])
             # This step's token is the one that may trip the stop condition, so
             # append it *before* marking the request finished (see generate()).
-            req.input_ids = (
-                [tok] if phase == "decode" else list(req.input_ids) + [tok]
-            )
+            # The batch phase is uniform, so the append rule is uniform too.
+            req.input_ids = [tok] if batch.phase == "decode" else list(req.input_ids) + [tok]
             req.device_len += 1
+            # The FINAL chunk of a chunked prefill -- the one that just
+            # completed the prompt -- is a plain Req (promoted out of the
+            # ChunkedReq chain) whose cached_len is > 0 (it resumed from a
+            # prior ChunkedReq via the adder). A full, non-chunked prefill is
+            # also a plain Req in a prefill batch, but its cached_len is 0, so
+            # the "cached_len > 0" test is exactly "this is the final chunk of a
+            # chunked prompt". Snap its cached prefix to the prompt boundary so
+            # the post-prefill state is coherent: the attention backend keys its
+            # phase off batch.phase and reads device_len as the attended length;
+            # with cached_len == prompt_len the decode step's extend_len
+            # (device_len - cached_len) is 1 (just the sampled token) and
+            # positions [cached_len, cached_len+1) align with that token. A full
+            # prefill must NOT be snapped (cached_len 0 -> the decode step reads
+            # the whole history via device_len). Intermediate chunks never reach
+            # here (step() skips ChunkedReq sampling above), so their
+            # cached_len keeps tracking raw prefix progress.
+            if batch.phase == "prefill" and not isinstance(req, ChunkedReq) and req.cached_len > 0:
+                req.cached_len = len(req.input_ids) - 1
             sp = req.sampling_params
             done = tok == self.sampler.eos_token_id
             if not sp.ignore_eos and done:
@@ -246,44 +353,73 @@ class Engine:
                 req.aborted = True
             if req.aborted:
                 finished.append(req)
-        return ForwardOutput(next_token_ids=next_ids, finished=finished)
+
+        # Record the step in the scheduler: promote finished prefills into the
+        # decode set, refresh the decode set, and free the rows of requests that
+        # completed (hit max_tokens / eos).
+        self.scheduler.complete(batch)
+        return ForwardOutput(next_token_ids=next_ids, finished=finished, reqs=list(batch.reqs))
 
     def generate(self, max_steps: int | None = None) -> List[List[int]]:
         """Run admitted requests to completion; return generated ids per request.
 
-        The first step prefills every request's prompt (which yields each one's
-        first generated token); subsequent steps decode one token per request
-        until each request hits its stop condition (eos or max_tokens) or
-        ``max_steps`` is reached. Returns a list, aligned to the admission
-        order, of the *generated* token ids (prompt tokens excluded).
+        Each :meth:`step` runs the batch the scheduler selected (a chunked
+        prefill, then decodes) until the scheduler is idle -- no prompt waiting
+        and no request still decoding -- or ``max_steps`` is reached. Returns a
+        list, aligned to the admission order, of the *generated* token ids
+        (prompt tokens excluded).
 
         With no admitted requests this is a no-op returning an empty list (the
         spine's ``Engine.generate(None)`` wiring probe relies on that).
         """
-        reqs = getattr(self, "_reqs", None)
-        if not reqs:
+        if self.scheduler is None or not self.scheduler.prefill_manager.pending_list:
+            # No admitted requests: the wiring probe (launch.py) calls
+            # generate() on a freshly-constructed engine and expects [].
             return []
-        budget = max_steps if max_steps is not None else max(req.max_device_len for req in reqs)
-        # ``tokens[i]`` accumulates request i's generated tokens. A request may
-        # emit exactly one *final* token that trips its stop condition; that
-        # token is appended in the same step that aborts it, so nothing is lost
-        # (the old "skip aborted" check dropped the last token).
-        tokens: List[List[int]] = [[] for _ in reqs]
-        done: List[bool] = [False] * len(reqs)
+        # Each admitted request needs ceil(prompt_len / max_extend_tokens)
+        # prefill steps plus one decode step per output token. Use that as the
+        # default step budget when the caller does not pin one.
+        budget = max_steps if max_steps is not None else sum(
+            (
+                math.ceil(len(pr.input_ids) / max(1, self.scheduler.config.max_extend_tokens))
+                + pr.output_len
+                for pr in self.scheduler.prefill_manager.pending_list
+            )
+        ) + len(self.scheduler.decode_manager.running_reqs)
+        # Snapshot the admitted uids in admission order *before* the loop: as the
+        # loop runs, each request leaves pending_list the moment its prompt is
+        # fully prefilled (it is promoted into the decode set, then freed on
+        # completion), so pending_list is empty by the time the loop ends.
+        # Rebuilding the result from the live list would then drop every
+        # completed request. The admission order is the contract the server relies
+        # on to map results back to API calls.
+        admitted_uids = [pr.uid for pr in self.scheduler.prefill_manager.pending_list]
+        # ``tokens[uid]`` accumulates a request's generated tokens, in emission
+        # order. Each step samples exactly one token per request in the batch
+        # (the last-position logit). We capture it for every request that
+        # participates in the step -- not just the one that trips the stop
+        # condition -- because every step produces a real generated token.
+        # Keys are uids (unique, scheduler-assigned) because batch order changes
+        # across steps (prefill batches are uid-sorted, continuations first).
+        tokens: dict[int, list[int]] = {}
+        for pr in self.scheduler.prefill_manager.pending_list:
+            tokens[pr.uid] = []
         steps = 0
-        while any(not d for d in done) and steps < budget:
+        while steps < budget:
             step = self.step()
+            if step.next_token_ids is None or len(step.next_token_ids) == 0:
+                break  # scheduler idle: nothing pending, nothing decoding
             steps += 1
-            for i, req in enumerate(reqs):
-                if done[i]:
+            # next_token_ids is aligned to batch.reqs order (one per request).
+            # Record each request's token in its per-request accumulator. An
+            # intermediate prefill chunk is skipped (step() does not append it a
+            # token), so only the chunk that fully extends the prompt contributes
+            # a generated token here -- the same final-chunk-only rule as above.
+            for i, req in enumerate(step.reqs):
+                if isinstance(req, ChunkedReq):
                     continue
-                tokens[i].append(int(step.next_token_ids[i]))
-                if req.aborted:
-                    done[i] = True
-            # Retire finished requests (frees their KV slot) so the loop does
-            # not keep stepping an already-complete request.
-            self._reqs = [r for i, r in enumerate(self._reqs) if not done[i]]
-        return [tokens[i] for i in range(len(reqs))]
+                tokens.setdefault(req.uid, []).append(int(step.next_token_ids[i]))
+        return [tokens[uid] for uid in admitted_uids]
 
     def rebuild_cache(self) -> None:
         # No radix / hybrid cache in the reference engine; nothing to rebuild.

--- a/python/freetoken/kvcache/base.py
+++ b/python/freetoken/kvcache/base.py
@@ -21,14 +21,18 @@ class BaseCacheHandle:
 
 
 class BaseKVCachePool:
-    """A flat paged K/V store.
+    """A flat paged K/V store, segregated per decoder layer.
 
-    Layout: ``k_buffer`` / ``v_buffer`` are each ``[num_pages * page_size,
-    num_kv_heads, head_dim]`` -- one row per token slot. ``page_table`` is
-    ``[num_requests, max_seq_len]`` of int32 slot indices, filled in by the
-    engine (an identity map suffices: slot ``pos`` holds token at position
-    ``pos``). Attention reads the keys/values for positions ``[0, len)`` via
-    ``page_table[req, pos]``.
+    Layout: ``k_buffer`` / ``v_buffer`` are each ``[num_layers, num_pages *
+    page_size, num_kv_heads, head_dim]`` -- one row per (layer, token slot).
+    The leading layer dim is essential: every decoder layer projects its own
+    K/V and attends against its *own* history, so the layers must not share one
+    flat buffer (a shared buffer makes each layer's attention read the previous
+    layer's -- or a stale cross-step -- K/V, which corrupts the output and,
+    under chunked prefill, diverges from the non-chunked run because the
+    per-step write order differs). ``page_table`` is ``[num_requests,
+    max_seq_len]`` of int32 slot indices (an identity map suffices: slot
+    ``pos`` holds token at position ``pos``).
     """
 
     def __init__(self, model_config, page_size: int, num_pages: int, device, dtype):
@@ -42,44 +46,69 @@ class BaseKVCachePool:
         self.num_pages = num_pages
         self.num_slots = num_pages * page_size
         self.num_kv_heads = model_config.num_key_value_heads
-        # Some models (Qwen3.5/3.6) set an explicit head_dim that differs from
-        # hidden // num_heads; honor it when present, else derive.
+        # Number of decoder layers, each with its own K/V slice. The parsed
+        # ModelConfig exposes ``num_layers``; accept ``num_hidden_layers`` as a
+        # fallback for config objects that use the HF spelling.
+        self.num_layers = getattr(model_config, "num_layers", None) or getattr(
+            model_config, "num_hidden_layers", 0
+        )
+        # Some models (Qwen3.5/3.6) set an explicit head_dim that differs from HF; the TINY/Qwen3-MoE path derives it.
         self.head_dim = getattr(model_config, "head_dim", None) or (
             model_config.hidden_size // model_config.num_attention_heads
         )
-        self.k_buffer = torch.empty(
-            (self.num_slots, self.num_kv_heads, self.head_dim), device=device, dtype=dtype
+        # torch.zeros (NOT torch.empty): a request's slots are written one at a
+        # time, so an attention step that (erroneously or defensively) gathers a
+        # position the pool has not written yet must see a benign zero, never a
+        # stale `inf`/NaN left in the allocator's free list -- that is exactly
+        # the process-dependent garbage that made reads nondeterministic.
+        # The leading dim is the layer index (see class docstring).
+        self.k_buffer = torch.zeros(
+            (self.num_layers, self.num_slots, self.num_kv_heads, self.head_dim),
+            device=device,
+            dtype=dtype,
         )
-        self.v_buffer = torch.empty(
-            (self.num_slots, self.num_kv_heads, self.head_dim), device=device, dtype=dtype
+        self.v_buffer = torch.zeros(
+            (self.num_layers, self.num_slots, self.num_kv_heads, self.head_dim),
+            device=device,
+            dtype=dtype,
         )
 
     def attach_page_table(self, page_table: torch.Tensor) -> None:
         """Bind the engine's page table (slot indices) to this pool."""
         self.page_table = page_table
 
-    def write_kv(self, k: torch.Tensor, v: torch.Tensor, out_loc: torch.Tensor) -> None:
-        """Write per-token keys/values into the pool at slots ``out_loc``.
+    def write_kv(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out_loc: torch.Tensor,
+        layer_id: int = 0,
+    ) -> None:
+        """Write per-token keys/values into layer ``layer_id``'s pool slice at
+        slots ``out_loc``.
 
         ``out_loc`` is ``[num_tokens]`` int64 slot indices. The attention block
         hands ``k`` / ``v`` in **head-major** ``[num_kv_heads, num_tokens,
         head_dim]`` (the order its own projections use), so we transpose them
         back to token-major ``[num_tokens, num_kv_heads, head_dim]`` before the
-        slot scatter (out_loc is ordered by token).
+        slot scatter (out_loc is ordered by token). ``layer_id`` selects which
+        decoder layer's slice to write -- each layer owns its own K/V.
         """
         k_tok = k.transpose(0, 1).contiguous()
         v_tok = v.transpose(0, 1).contiguous()
-        self.k_buffer[out_loc.long()] = k_tok.reshape(out_loc.numel(), *k_tok.shape[1:])
-        self.v_buffer[out_loc.long()] = v_tok.reshape(out_loc.numel(), *v_tok.shape[1:])
+        self.k_buffer[layer_id][out_loc.long()] = k_tok.reshape(out_loc.numel(), *k_tok.shape[1:])
+        self.v_buffer[layer_id][out_loc.long()] = v_tok.reshape(out_loc.numel(), *v_tok.shape[1:])
 
-    def read_kv(self, table_idx: int, pos: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def read_kv(
+        self, table_idx: int, pos: torch.Tensor, layer_id: int = 0
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Read keys/values for request ``table_idx`` at token positions ``pos``
-        (``[num_tokens]``). The page table row maps position -> pool slot, so
-        this is a per-request gather. Returns ``[num_tokens, num_kv_heads,
-        head_dim]`` for K and V.
+        (``[num_tokens]``) from layer ``layer_id``'s slice. The page table row
+        maps position -> pool slot, so this is a per-request gather. Returns
+        ``[num_tokens, num_kv_heads, head_dim]`` for K and V.
         """
         slots = self.page_table[table_idx, pos.long()]
-        return self.k_buffer[slots], self.v_buffer[slots]
+        return self.k_buffer[layer_id][slots], self.v_buffer[layer_id][slots]
 
     def allocate(self, *args, **kwargs):
         # Page bookkeeping for the minimal pool is the identity map the engine

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -839,7 +839,7 @@ class _Qwen35Attention:
         v = v.transpose(1, 2)[0]
         # Append this request's K/V to the pool at its positions (identity table:
         # out_loc == position under the identity page table, as in qwen3_moe).
-        ctx.kv_cache.write_kv(k, v, positions)
+        ctx.kv_cache.write_kv(k, v, positions, self.layer_id)
         out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, table_idx=table_idx)
         # Gated output: sigmoid(gate) elementwise over the attention output.
         # out is head-major [heads, T, head_dim]; make the gate head-major to match.
@@ -949,11 +949,25 @@ class _Qwen35MoE:
         model = ctx.model
         layer_id = model.moe_layer_id[self.layer_id]
         cache = model.moe_cache
-        is_prefill = (batch is not None and batch.is_prefill) or flat.shape[0] > 1
+        # is_prefill must come from the batch's *phase flag*, not from flat.shape[0]:
+        # in a mixed step (decode reqs with 1 token each, or a decode req alongside a
+        # prefill req) flat.shape[0] > 1 even though every token is a 1-token decode.
+        # The offload path then calls materialize_layer (whole layer) instead of
+        # ensure_experts (routed experts only). Routing itself is host-side and
+        # phase-independent: we snapshot the routed *expert* ids and map them to
+        # slots from the cache's slot_for_id, so the phase only decides *which*
+        # experts to make resident (the whole layer, or just the routed ones).
+        is_prefill = bool(batch is not None and batch.is_prefill)
         is_xpu = bool(getattr(cache, "is_xpu", False))
         B, k = top_idx.shape
-        # 1) Snapshot the routed *expert* ids on the host (the topk output is a
-        #    fresh tensor; reading it back here is a clean D2H of its final value).
+        # 1) Snapshot the routed *expert* ids on the host BEFORE the LRU call.
+        #    top_idx holds *expert* ids (the topk output) and the cache never
+        #    rewrites it (issue #7): the old code rewrote top_idx in place to
+        #    *slot* ids, so a repeat routing that skipped the rewrite left the
+        #    previous step's slot ids in place and the next step read them as if
+        #    they were expert ids -> out-of-bounds (XPU IndexError) / a wrong
+        #    expert gather on CPU. Routing is fully determined by this snapshot +
+        #    the cache's slot map, so top_idx may keep holding expert ids.
         expert_ids = top_idx.to("cpu")
         # 2) Let the LRU pool decide residency (prefill: whole layer; decode:
         #    only the routed experts), staging the host->XPU copy plan.
@@ -1005,9 +1019,8 @@ class _Qwen35MoE:
                 if bool(valid_cpu[i, j]):
                     by_slot.setdefault(int(routed_cpu[i, j]), []).append(i)
             groups.extend((j, s_i, rows) for s_i, rows in by_slot.items())
-        # 5) Push the routing to the XPU (one op). Validity is already encoded in
-        #    which rows appear in `groups`, so no separate valid tensor is pushed.
-        routed_dev = routed_cpu.to(dev)
+        # 5) (No device-side push needed: validity is encoded in which rows appear
+        #    in `groups`, and the gather below uses host-built index tensors.)
         # 6) Gather per slot on the XPU using host-computed INTEGER indices:
         #    static shapes, no nonzero(), no implicit D2H anywhere in the loop.
         #    index_add_ accumulates exactly as `out[sub] += ...` did (and handles
@@ -1021,9 +1034,17 @@ class _Qwen35MoE:
                 flat.index_select(0, idx),
             )
             out.index_add_(0, idx, y)
-        # 7) Leave top_idx in the slot-id contract (harmless; nothing downstream
-        #    reads it, but keeps the "top_idx holds slot ids" invariant true).
-        top_idx.copy_(routed_dev)
+        # NB: we do NOT write the slot ids back into top_idx here (the old code did
+        # `top_idx.copy_(routed_dev)`). top_idx is a *fresh* topk tensor each call,
+        # and routing is done host-side from the `expert_ids` snapshot + the cache's
+        # slot map, so nothing downstream reads top_idx after we return. On the XPU
+        # the in-place write raced the next step's fresh topk: the host snapshot of
+        # top_idx then read *stale slot ids* (0..S-1, e.g. 5 >= num_experts 4)
+        # instead of the just-computed expert ids -- an out-of-bounds slots[] read
+        # (XPU IndexError / kernel abort) and, on CPU, a wrong expert gather that
+        # silently corrupts the logits (offload no longer matches the in-VRAM
+        # reference). The routing is fully determined by the host snapshot, so the
+        # device-side top_idx may keep holding expert ids; leave it untouched.
         return out
 
 

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -178,9 +178,18 @@ class _Qwen3Attention(nn.Module):
         # token slice is the *middle* dim) and it returns the output the same
         # way, letting us fold the heads back into the hidden dim with an
         # identity transpose(1, 2).
-        q = self.q_proj(hidden_states).view(self.num_heads, bsz, self.head_dim)
-        k = self.k_proj(hidden_states).view(self.num_kv_heads, bsz, self.head_dim)
-        v = self.v_proj(hidden_states).view(self.num_kv_heads, bsz, self.head_dim)
+        # The projection output is token-major [bsz, heads*head_dim] (each row
+        # is one token whose columns are the per-head slices concatenated). A
+        # flat ``.view(heads, bsz, head_dim)`` reinterprets memory linearly and
+        # therefore scrambles which token lands in which head -- it is
+        # *bsz-dependent* (only accidentally correct when bsz == num_heads),
+        # which is exactly what made chunked-prefill (bsz>1) diverge from
+        # decode (bsz=1). Lay it out token-major first, then transpose to the
+        # head-major [heads, bsz, head_dim] the rest of the pipeline (RoPE,
+        # write_kv's token-major round-trip) expects.
+        q = self.q_proj(hidden_states).view(bsz, self.num_heads, self.head_dim).transpose(0, 1)
+        k = self.k_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        v = self.v_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
         q = self._rope(self.q_norm(q), positions)
         k = self._rope(self.k_norm(k), positions)
         # Append this request's K/V to the pool. ``positions`` here is this
@@ -188,7 +197,7 @@ class _Qwen3Attention(nn.Module):
         # positions[token_slice]); the new token's out_loc slot equals its
         # absolute position under the identity page table, so index out_loc by
         # this request's positions rather than the whole-batch out_loc.
-        ctx.kv_cache.write_kv(k, v, positions)
+        ctx.kv_cache.write_kv(k, v, positions, self.layer_id)
         # ``table_idx`` identifies *this* request (the decoder layer runs each
         # request's layers on its own hidden slice, so q/k/v hold only this
         # request's new tokens, not the whole batch's). The backend uses it to
@@ -196,7 +205,22 @@ class _Qwen3Attention(nn.Module):
         # per-request q/k/v; without it a backend cannot tell which request is
         # 'current' when a step mixes multiple requests.
         out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, table_idx=table_idx)
-        return self.o_proj(out.transpose(1, 2).reshape(bsz, -1))
+        # ``out`` is head-major [heads, bsz, head_dim]: dim 0 is the head axis,
+        # dim 1 is this request's new-token axis, dim 2 the head_dim. To feed
+        # o_proj we need the *token-major* [bsz, heads, head_dim] token vector
+        # (row t = concatenation over heads of head h's head_dim slice at token
+        # t). That is achieved by moving the token axis (1) to the front, i.e.
+        # swapping axes 0 and 1: transpose(0, 1) -> [bsz, heads, head_dim].
+        # (The old transpose(1, 2) moved the *head_dim* axis to the front,
+        # yielding [heads, head_dim, bsz]; on a non-contiguous view .reshape
+        # then copied in raw head-first memory order, so for bsz > 1 each row
+        # interleaved the wrong heads' tokens -- the o_proj input was silently
+        # scrambled. bsz == 1 hid it (single token row, memory order coincides
+        # with the token vector), which is exactly why chunked prefill (bsz==1
+        # per step) matched while a whole-prompt prefill (bsz>1) diverged.)
+        # .contiguous() after the swap materializes the [bsz, heads, head_dim]
+        # layout so the flatten to [bsz, heads*head_dim] is the intended vector.
+        return self.o_proj(out.transpose(0, 1).contiguous().reshape(bsz, -1))
 
 
 def _expert_compute(gate_w: torch.Tensor, up_w: torch.Tensor, down_w: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
@@ -306,67 +330,84 @@ class _Qwen3MoE(nn.Module):
         (ADR 0002): a prefill materializes the *whole* layer into the pool
         (evicting the LRU-resident experts of other layers), and a decode step
         streams in only the *missed* routed experts, each into an evicted slot.
-        After :meth:`ensure_experts` / :meth:`materialize_layer` the ``top_idx``
-        tensor holds *slot* ids, so each routed token runs the expert the slot
-        currently holds -- which, after ``copy_missing``, is exactly the routed
-        expert (the forward indexes the slot cache, not the layer bank).
+
+        Routing is done **on the host** from a snapshot of the routed *expert*
+        ids (``top_idx``), mapped through the cache's ``slot_for_id``. The cache
+        does NOT rewrite ``top_idx`` in place: it stays the ``torch.topk``
+        expert-id tensor across steps, so a repeat routing never leaves a stale
+        slot id for the next step to misread (issue #7). Nothing downstream
+        reads ``top_idx`` as slot ids after this method returns.
         """
         layer_id = model.moe_layer_id[self.layer_id]
         cache = model.moe_cache
-        # A prefill must materialize the *whole* MoE layer into the LRU pool
-        # (evicting other layers' resident experts); a decode streams in only the
-        # missed routed experts, one at a time. The engine tags the prompt step
-        # ``phase="prefill"`` and later steps ``phase="decode"`` (engine.step),
-        # so ``batch.is_prefill`` is the phase signal; the ``flat.shape[0] > 1``
-        # check is a phase-independent fallback (prefill >1 token, decode == 1).
-        is_prefill = (batch is not None and batch.is_prefill) or flat.shape[0] > 1
+        # The phase flag (not token count) decides prefill vs decode: in a mixed
+        # step (decode reqs with 1 token each, or a decode req alongside a
+        # prefill req) flat.shape[0] > 1 even though every token is a 1-token
+        # decode. Deriving the phase from the token count then calls
+        # materialize_layer (whole layer) instead of ensure_experts (routed
+        # experts only): the LRU pool is shared across layers, so materializing
+        # a layer evicts the other layer's just-resident decode experts and the
+        # next decode step routes them through the wrong slot (or a slot the
+        # pool has re-used) -- a silent logit divergence from the in-VRAM path.
+        is_prefill = bool(batch is not None and batch.is_prefill)
         is_xpu = bool(getattr(cache, "is_xpu", False))
+        B, k = top_idx.shape
+        # 1) Snapshot the routed *expert* ids on the host before the LRU call.
+        expert_ids = top_idx.to("cpu")
+        # 2) Let the LRU pool decide residency and stage the host->device copies.
         if is_prefill:
-            # materialize_layer rewrites top_idx to slot ids in place (same
-            # contract as ensure_experts), so prefill and decode index the
-            # slot pool identically.
-            cache.materialize_layer(layer_id, top_idx)
+            cache.materialize_layer(layer_id)
         else:
-            cache.ensure_experts(layer_id, top_idx)
+            cache.ensure_experts(layer_id, expert_ids)
         cache.copy_missing()
 
-        # bank_views() returns a tuple indexed by bank registration order
-        # ("gate_up" first, "down" second); index the pool (S slots) and pick
-        # the per-slot row by slot id.
+        # 3) Map expert -> slot on the host from the cache's own (Python) map.
+        #    An expert the pool evicted maps to -1 -> clamped to 0, valid=False.
+        slots = cache.slot_for_id[layer_id].to("cpu").tolist()
+        S = cache.cache_size
         gu, dn = cache.bank_views()  # ([S, 2I, H], [S, H, I])
-        S = gu.shape[0]
         intermediate = int(model.config.moe_intermediate_size)
-
+        dev = flat.device
         out = torch.zeros_like(flat)
-        k = top_idx.shape[1]
-        for slot_pos in range(k):
-            routed = top_idx[:, slot_pos]  # [B] slot ids (after ensure_experts)
-            # Mask out-of-range slot ids too (>= S): a stale/recycled id from
-            # ensure_experts/copy_missing would index gu/dn out of bounds and
-            # abort the (shared) XPU kernel, so clamp it out of the gather.
-            valid = (routed >= 0) & (routed < S)
-            if not valid.any():
-                continue
-            if is_xpu:
-                if (routed >= S).any() and (routed >= 0).any():
-                    raise IndexError(
-                        f"layer {self.layer_id}: offload routed slot id "
-                        f"{int(routed.max())} >= cache_size {S}: stale slot id "
-                        "(ensure_experts/copy_missing desync)"
-                    )
-            s = routed[valid]  # the slot each token's expert landed in
-            # Dedup on the host (the routed set per step is tiny): the XPU's
-            # torch.unique runs an async sort-scatter that aborts (Indexing.h
-            # "index out of bounds") when a slot id races the pool; a CPU
-            # unique + CPU->XPU gather is deterministic and identical in math.
-            for s_i in torch.unique(s.cpu()).tolist():
-                sub = valid & (routed == s_i)
-                out[sub] += top_w[sub, slot_pos, None] * _expert_compute(
-                    gu[s_i, 0:intermediate],
-                    gu[s_i, intermediate : 2 * intermediate],
-                    dn[s_i],
-                    flat[sub],
+        routed_cpu = torch.empty(B, k, dtype=torch.int64)
+        valid_cpu = torch.zeros(B, k, dtype=torch.bool)
+        for i in range(B):
+            for j in range(k):
+                slot = slots[int(expert_ids[i, j])]
+                ok = 0 <= slot < S
+                routed_cpu[i, j] = slot if ok else 0
+                valid_cpu[i, j] = ok
+        # Belt-and-suspenders tripwire: an out-of-range slot means a stale map
+        # entry; fail loudly in Python rather than aborting the (shared) XPU.
+        if is_xpu and (~valid_cpu).any():
+            stale = int(routed_cpu[~valid_cpu].max()) if (~valid_cpu).any() else -1
+            if stale >= S:
+                raise IndexError(
+                    f"layer {self.layer_id}: offload routed slot id {stale} >= "
+                    f"cache_size {S}: stale slot map (ensure_experts desync)"
                 )
+        # 4) Host-side (column j, slot s_i) -> row indices routing to it, built
+        #    from the CPU tensors only: the gather below never asks the device
+        #    "which rows matched?" (a boolean-mask index would call nonzero(),
+        #    whose data-dependent shape forces an implicit D2H sync mid-loop).
+        groups: list[tuple[int, int, list[int]]] = []
+        for j in range(k):
+            by_slot: dict[int, list[int]] = {}
+            for i in range(B):
+                if bool(valid_cpu[i, j]):
+                    by_slot.setdefault(int(routed_cpu[i, j]), []).append(i)
+            groups.extend((j, s_i, rows) for s_i, rows in by_slot.items())
+        # 5) Gather per slot on the device using host-built INTEGER indices
+        #    (static shapes, no nonzero(), no implicit D2H in the loop).
+        for j, s_i, rows in groups:
+            idx = torch.tensor(rows, dtype=torch.long, device=dev)
+            y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(
+                gu[s_i, 0:intermediate],
+                gu[s_i, intermediate : 2 * intermediate],
+                dn[s_i],
+                flat.index_select(0, idx),
+            )
+            out.index_add_(0, idx, y)
         return out
 
 

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -215,10 +215,15 @@ class OffloadMoeCache:
     def materialize_layer(self, layer_id: int, expert_ids: torch.Tensor | None = None) -> None:
         """Place a whole layer into the slot pool for a prefill forward.
 
-        If ``expert_ids`` ([n, k] routed expert ids) is given, it is rewritten
-        in place to *slot* ids (a position whose expert was evicted stays -1),
-        matching the contract :meth:`ensure_experts` establishes for decode --
-        so the offload forward indexes the slot pool identically on both phases.
+        ``expert_ids`` is accepted for signature compatibility only; this method
+        does NOT rewrite it. The offload forward maps routed *expert* ids to slot
+        ids on the host (from :attr:`slot_for_id`) and never reads a device-side
+        slot-id view of the routing tensor. Rewriting ``expert_ids`` in place to
+        slot ids (the old contract) is what leaked stale slot ids: ``torch.topk``
+        reuses that same storage each step, so an unchanged routing skipped the
+        rewrite and the next step read the *prior* step's slot ids as if they were
+        expert ids -- an out-of-bounds slots[] read (XPU IndexError) / a silent
+        wrong-expert gather (CPU logit divergence, issue #7).
 
         This is a *batched timestamp-LRU* pass over the whole layer's experts,
         not a fixed-slot double buffer: the pool is a single global LRU shared by
@@ -303,24 +308,11 @@ class OffloadMoeCache:
         # _resync_slot_for_id). id_of_slot was already set for every touched slot
         # above, so this rebuilds slot_for_id exactly.
         self._resync_slot_for_id()
-        # Rebind the row view (the resync may have reallocated the tensor storage
-        # via fill_); Phase 3 reads this layer's fresh rows.
-        layer_slots = self.slot_for_id[layer_id]
-
-        # Phase 3: rewrite every routed position to its (new) slot id so the
-        # prefill forward indexes the slot pool by slot id, exactly as decode
-        # (ensure_experts Phase 3) does. A position whose expert was evicted
-        # (slot -1) is left -1 (skipped by the forward's routed >= 0 mask).
-        if expert_ids is not None:
-            flat = expert_ids.reshape(-1)
-            for i in range(flat.numel()):
-                flat[i] = int(layer_slots[int(flat[i].item())].item())
 
     # -- decode: timestamp LRU -------------------------------------------------
 
     def ensure_experts(self, layer_id: int, expert_ids: torch.Tensor) -> None:
-        """Make this layer's routed experts resident; rewrite ``expert_ids`` to
-        slot ids in place (the downstream gather indexes the slot cache by it).
+        """Make this layer's routed experts resident in the global LRU pool.
 
         The pool is a single **global** timestamp LRU shared by every layer.
         A routed expert that is already resident (in *any* slot, any layer) is a
@@ -402,13 +394,11 @@ class OffloadMoeCache:
         # LRU slot, which another layer may own; the flat clear above only
         # touches the evicting layer's row, so the evicted layer's stale
         # entries would otherwise survive (see _resync_slot_for_id).
+        # (The old Phase-3 in-place rewrite of ``expert_ids`` -> slot ids was
+        # removed: see the class/`materialize_layer` docstrings. The forward
+        # maps expert -> slot on the host; the routing tensor must keep holding
+        # *expert* ids so the next step's topk snapshot is always in-bounds.)
         self._resync_slot_for_id()
-        layer_slots = self.slot_for_id[layer_id]
-
-        # Phase 3: rewrite every position to its (new) slot; a position whose
-        # expert was left non-resident (pool exhausted) stays -1.
-        for i in range(flat.numel()):
-            flat[i] = int(layer_slots[int(flat[i].item())].item())
 
     # -- copy engine -----------------------------------------------------------
 

--- a/python/freetoken/scheduler/__init__.py
+++ b/python/freetoken/scheduler/__init__.py
@@ -1,3 +1,15 @@
+from .config import SchedulerConfig
+from .decode import DecodeManager
+from .prefill import ChunkedReq, PendingReq, PrefillAdder, PrefillManager, make_pending_req
 from .scheduler import Scheduler
 
-__all__ = ["Scheduler"]
+__all__ = [
+    "Scheduler",
+    "SchedulerConfig",
+    "DecodeManager",
+    "PrefillManager",
+    "PrefillAdder",
+    "PendingReq",
+    "ChunkedReq",
+    "make_pending_req",
+]

--- a/python/freetoken/scheduler/config.py
+++ b/python/freetoken/scheduler/config.py
@@ -1,14 +1,54 @@
 """Scheduler knobs.
 
 Upstream NVIDIA path: python/freetoken/scheduler/config.py
-Fill in: GitHub issue `scheduler` (see docs/architecture.md).
+Filled in: GitHub issue ``scheduler`` (see docs/architecture.md).
+
+The upstream config carries ZMQ / overlap-scheduling knobs for a distributed
+multi-worker daemon. The Intel port is a single-process loop inside
+:class:`~freetoken.engine.engine.Engine`, so only the scheduling-relevant
+knobs survive the port:
+
+* ``max_extend_tokens`` -- the per-step prefill token budget. A prompt longer
+  than this is *chunked* (see :class:`~freetoken.scheduler.prefill.PrefillAdder`):
+  only ``min(budget, remaining)`` tokens are scheduled per step and the request
+  stays pending until its whole prompt has been extended.
+* ``max_running_req`` -- the cap on concurrently admitted requests. It is
+  inherited from :class:`~freetoken.engine.config.EngineConfig` (the page table
+  and the token pool are both sized from it upstream).
+
+Everything else (ZMQ addrs, overlap cadence) is engine-internal and stays in
+:mod:`freetoken.engine`. This module is import-safe without torch: it only
+subclasses the engine config and adds plain-Python fields, which keeps the
+dual-venv contract (``import freetoken.scheduler`` never pulls in torch).
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from dataclasses import dataclass
+
+# Import the config *module* directly, not the `freetoken.engine` package: the
+# package's __init__ eagerly imports engine.py, which imports torch. The
+# scheduler must stay torch-free on the CPU venv (the dual-venv contract), so it
+# must not trigger that import. config.py itself is torch-free (it only imports
+# `DistributedInfo` from freetoken.distributed and stdlib dataclasses).
+from freetoken.engine.config import EngineConfig
 
 
-class SchedulerConfig:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+# Frozen, to match the parent (a non-frozen dataclass cannot inherit from a
+# frozen one). Only the scheduling-relevant field is added; everything else is
+# inherited from EngineConfig. ``max_running_req`` is inherited and *not*
+# re-declared -- re-declaring a field already declared in the parent is a
+# dataclass error in a frozen class.
+@dataclass(frozen=True)
+class SchedulerConfig(EngineConfig):
+    """Scheduling knobs layered on top of the engine config.
 
+    ``Engine`` accepts any :class:`EngineConfig` and builds its own
+    :class:`SchedulerConfig` view internally, so a plain engine config keeps
+    working unchanged while callers may pass a :class:`SchedulerConfig` to tune
+    the prefill budget.
+    """
+
+    # Per-step prefill budget (token count). Prompts longer than this chunk.
+    # The upstream default is 8192; a shorter budget is valid and is exactly
+    # what forces a long prompt to split across several prefill steps.
+    max_extend_tokens: int = 8192

--- a/python/freetoken/scheduler/decode.py
+++ b/python/freetoken/scheduler/decode.py
@@ -1,17 +1,85 @@
 """Decode batching.
 
 Upstream NVIDIA path: python/freetoken/scheduler/decode.py
-Fill in: GitHub issue `scheduler` (see docs/architecture.md).
+Filled in: GitHub issue ``scheduler`` (see docs/architecture.md).
+
+The decode manager owns the set of requests that have already finished their
+prompt (``cached_len == device_len``) and are one token per step. Its job is
+pure bookkeeping: admit requests that just finished prefilling, drop the ones
+that hit their stop condition, and (in :meth:`schedule_next_batch`) emit the
+batch of live decode requests. There is no per-token state to manage beyond the
+request's own history length, so this stays plain-Python and torch-free.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from freetoken.core import Batch, Req
+
+# A set that preserves insertion order. A plain ``set`` has no ordering, so the
+# decode batch (and the slot-freeing that follows a step) would iterate in an
+# arbitrary, hash-dependent order. Upstream schedules the decode batch in uid
+# order; mirroring that with an insertion-ordered set keeps the ported policy
+# deterministic and the same order as upstream.
+OrderedSet = OrderedDict
 
 
+@dataclass
 class DecodeManager:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    """Holds the in-flight decode requests and emits the decode batch."""
 
-    def prepare(self, *args, **kwargs):
-        unimplemented("DecodeManager.prepare", "scheduler")
+    page_size: int
+    running_reqs: "OrderedSet[Req]" = field(default_factory=OrderedSet)
 
+    def filter_reqs(self, reqs: Iterable[Req]) -> None:
+        """Admit / refresh the running set from a batch that just executed.
+
+        ``reqs`` is the batch that just ran. After a *prefill* step a request
+        has its first token, so ``can_decode`` (``remain_len > 0``) is what decides whether it
+        moves into the decode set. After a *decode* step the request is either
+        still decoding (stays) or finished (``remain_len`` drops to 0 ->
+        dropped, mirroring the upstream filter). Requests that are neither
+        decodable nor runnable are dropped, so the running set only ever
+        contains live decode requests. Insertion order is preserved (new admits
+        append, survivors keep their place), so the emitted batch stays in
+        admission/uid order.
+        """
+        merged = OrderedDict(self.running_reqs)
+        for req in reqs:
+            merged[req] = None  # move-to-end if present (re-admit / refresh)
+        self.running_reqs = OrderedDict((k, v) for k, v in merged.items() if k.can_decode)
+
+    def remove_req(self, req: Req) -> None:
+        self.running_reqs.pop(req, None)
+
+    def abort_req(self, uid: int) -> Req | None:
+        """Remove (and return) the running decode request with ``uid``.
+
+        Returns ``None`` when the uid is not in the decode set. The freed page
+        slot is released by the caller (the engine frees the table index); this
+        only updates the bookkeeping.
+        """
+        for req in self.running_reqs:
+            if req.uid == uid:
+                del self.running_reqs[req]
+                return req
+        return None
+
+    @property
+    def inflight_tokens(self) -> int:
+        # Upstream reserves (page_size - 1) tokens per request so a decode step
+        # that crosses a page boundary never overruns the pool; with
+        # page_size == 1 (the Intel token-granular pool) this is 0.
+        tokens_reserved = (self.page_size - 1) * len(self.running_reqs)
+        return sum(req.remain_len for req in self.running_reqs) + tokens_reserved
+
+    def schedule_next_batch(self) -> Batch | None:
+        if not self.runnable:
+            return None
+        return Batch(reqs=sorted(self.running_reqs, key=lambda req: req.uid), phase="decode")
+
+    @property
+    def runnable(self) -> bool:
+        return len(self.running_reqs) > 0

--- a/python/freetoken/scheduler/prefill.py
+++ b/python/freetoken/scheduler/prefill.py
@@ -1,17 +1,420 @@
-"""Double-buffered full-layer prefill streaming.
+"""Chunked-prefill admission.
 
 Upstream NVIDIA path: python/freetoken/scheduler/prefill.py
-Fill in: GitHub issue `scheduler` (see docs/architecture.md).
+Filled in: GitHub issue ``scheduler`` (see docs/architecture.md).
+
+The prefill manager holds the queue of not-yet-extended requests and, each
+step, decides how much of each prompt can be extended *within the per-step
+token budget* (``max_extend_tokens``). A prompt that fits in the budget is
+prefilled whole and moves on to decode; a prompt that does not is *chunked* --
+only ``min(budget, remaining)`` tokens are extended this step and the request
+stays in the queue to continue next step. This is the core acceptance criterion
+for the scheduler: a long prompt is split across steps and the budget is
+respected on every step.
+
+The upstream file is coupled to the radix / SWA cache manager (prefix caching,
+the ``kvcache`` issue) and to CUDA streams / pinned-memory copies. None of that
+exists in the Intel loop yet, so the two currency gates upstream adds -- the
+prefix-cache ``match_req`` and the sliding-window pool reservation -- collapse
+to a single gate: the number of admitted requests must fit ``max_running_req``
+(page slots). The budget / chunk / continuation logic, which is the actual
+scheduling policy being ported, is carried over verbatim.
+
+This module is torch-free at import time. :class:`PendingReq` holds the
+prompt's token ids, and the upstream stores those as a ``torch.Tensor``; the
+Intel engine stores prompt ids as a plain Python ``list[int]`` (see
+:class:`~freetoken.core.Req`), so ``PendingReq`` stores a list too.
+:mod:`torch` is imported only inside :meth:`PrefillManager.schedule_next_batch`
+to build the batch's id tensor -- keeping ``import freetoken.scheduler` (and
+the CPU venv) clean, per the dual-venv contract.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List
+
+from freetoken.core import Batch, Req
+
+if TYPE_CHECKING:
+    from freetoken.core import SamplingParams
 
 
+@dataclass(eq=False)
+class PendingReq:
+    """A queued prompt awaiting prefill.
+
+    Mirrors the upstream ``PendingReq``: the raw prompt ids, the sampling
+    settings, and -- when the prompt was chunked -- the partial
+    :class:`ChunkedReq` that tracks how far the chunked prefill has progressed.
+    ``chunked_req`` is ``None`` for a prompt that has not yet been split.
+
+    ``eq=False`` (identity equality + identity hash), matching :class:`Req`:
+    a queued prompt is an identity (its uid), not a value. With field-wise
+    equality, a chunked continuation and its original entry (identical
+    prompt/sampling fields) hash *and* compare equal, so the ``set`` bookkeeping
+    in :class:`DecodeManager.filter_reqs` would collapse them and the scheduler
+    would free a slot that is still in use. Identity hashing keeps the two
+    distinct.
+    """
+
+    uid: int
+    input_ids: List[int]
+    sampling_params: "SamplingParams"
+    chunked_req: "ChunkedReq | None" = None
+    # Assigned by Scheduler.add when the request is queued: the page-table row
+    # (table_idx) and the next free row to hand the request once it finishes
+    # (next_table_idx). ``_``-prefixed so they stay out of the dataclass's
+    # public surface; the adder reads them at admission time. ``cache_handle``
+    # is the prefix-cache ticket (kvcache issue's scope) -- None until #12.
+    _table_idx: int = 0
+    _next_table_idx: int = 0
+    _cache_handle: object = None
+
+    @property
+    def input_len(self) -> int:
+        return len(self.input_ids)
+
+    @property
+    def output_len(self) -> int:
+        return self.sampling_params.max_tokens
+
+
+def make_pending_req(
+    uid: int, input_ids: List[int], sampling_params: "SamplingParams", cache_handle=None
+) -> PendingReq:
+    """Build a :class:`PendingReq` from raw request fields.
+
+    The engine's ``add_request`` takes a :class:`~freetoken.core.Req` (the
+    server path's shape) and wraps it this way before handing the
+    :class:`~freetoken.scheduler.Scheduler` a :class:`PendingReq`. It lives here
+    (not in the engine) so the wrap stays in the torch-free scheduler package --
+    the engine imports it on the XPU path but the CPU-venv policy tests never do.
+    """
+    return PendingReq(uid=uid, input_ids=list(input_ids), sampling_params=sampling_params, _cache_handle=cache_handle)
+
+
+class ChunkedReq(Req):
+    """A prompt's in-progress chunk: prefilling but not yet sampling.
+
+    A chunk is a prefill with a known "not finished" status, so it must never be
+    added to the decode set (that would hand it a next token before its prompt
+    is fully extended). Overriding :attr:`Req.can_decode` with ``False`` keeps
+    the decode manager's ``filter_reqs`` from admitting it, exactly as upstream.
+
+    Sampling is enforced at the type level the same way: :meth:`append_host`
+    raises, so a chunk can never be appended a generated token. The engine's
+    step loop therefore samples (and appends) only the *final* chunk -- the one
+    that fully extends the prompt and is admitted as a plain :class:`Req` -- and
+    skips every intermediate chunk.
+    """
+
+    @property
+    def can_decode(self) -> bool:
+        return False  # avoid being added to the decode manager
+
+    def append_host(self, next_token) -> None:
+        raise NotImplementedError("ChunkedReq should not be sampled")
+
+
+@dataclass
+class PrefillAdder:
+    """Admits requests into one prefill batch within the token budget.
+
+    ``token_budget`` is the per-step extend budget (``max_extend_tokens``) and
+    is decremented by each admitted chunk; ``reserved_size`` is the token count
+    the decode manager is already holding so a new admission cannot push the
+    step past the pool the decode set is depending on (upstream folds this in
+    from ``decode_manager.inflight_tokens``). ``step_budget`` snapshots the
+    step's starting budget so the admission loop can tell "the first prompt in
+    this step" (``token_budget == step_budget``) from "a later prompt" -- the
+    former may use the whole budget (and chunk if longer), the latter must fit
+    the remainder whole.
+    """
+
+    token_budget: int
+    step_budget: int
+    reserved_size: int
+    max_running_req: int
+    cache_budget: int
+    running_count: int
+
+    # -- admission -----------------------------------------------------------
+
+    def _try_allocate_one(self, req: PendingReq):
+        # Request-cap gate: a live request needs a page-table row (table_idx).
+        # running_count counts running + admitted-this-pass, so this is the
+        # only currency the Intel pool exposes (the upstream's radix / SWA
+        # currency gates are the kvcache issue's scope).
+        if self.running_count >= self.max_running_req:
+            return None
+        # KV-pool gate: this request's full extend (prompt + requested output)
+        # must fit the pool budget, with headroom for the in-flight decode set.
+        # The flat Intel pool has no prefix caching, so every prompt token
+        # is new (cached_len == 0) and the extend is the whole prompt.
+        extend_len = req.input_len
+        estimated_len = extend_len + req.output_len
+        if self.reserved_size + estimated_len > self.cache_budget:
+            return None
+        # Reserve the request's footprint + a running slot up front so the
+        # per-step admission is an atomic decide-then-commit: a later gate
+        # (the all-or-nothing budget check in _add_one_req) can defer the
+        # request and _undo_allocation rolls these back. This mirrors upstream,
+        # whose try_add_one unlocks / frees the row when a continuation or a
+        # not-yet-admitted request is turned down after passing the pool gates.
+        self.reserved_size += extend_len + req.output_len
+        self.running_count += 1
+        return req.input_len  # cached_len (== 0, no prefix cache yet)
+
+    def _undo_allocation(self, req: PendingReq) -> None:
+        """Roll back the reservation :meth:`_try_allocate_one` made.
+
+        The all-or-nothing step-budget check in :meth:`_add_one_req` can defer a
+        fresh prompt that already passed the pool gates; without this undo the
+        deferred prompt would keep its running slot and pool reservation for the
+        rest of the pass (and every later pass, since the PendingReq stays
+        queued), starving later prompts and inflating the in-flight estimate the
+        decode manager is sized against. The table row itself is untouched: it
+        is owned by the scheduler (reserved at add()) and the PendingReq stays
+        queued with it, so a deferred prompt neither leaks a row nor needs one.
+        """
+        self.reserved_size -= req.input_len + req.output_len
+        self.running_count -= 1
+
+    # -- sizing + construction ------------------------------------------------
+
+    def _add_one_req(
+        self,
+        pending_req: PendingReq,
+        table_idx: int,
+        cached_len: int,
+        next_table_idx: int,
+        cache_handle,
+        chunked: bool = False,
+    ) -> Req | None:
+        remain_len = pending_req.input_len - cached_len
+        if chunked:
+            # A continuation resumes an in-flight chunk: extend the next
+            # budget-sized slice of the remaining prompt (a prompt longer than
+            # the budget is split across steps). The token budget is a per-step
+            # limit, so only the *new* tokens this slice extends are charged.
+            chunk_size = min(self.token_budget, remain_len)
+            # No room for even one token this pass (budget spent, or nothing
+            # left of the prompt): leave the request in the queue for the next step.
+            if chunk_size <= 0:
+                return None
+        else:
+            # A fresh prompt is admitted only if its *whole* prompt fits the
+            # remaining step budget. The per-step budget is an all-or-nothing
+            # admission gate for a not-yet-started request (a prompt that does
+            # not fully fit is deferred to a step with room for it, rather than
+            # being split behind another prompt in the same step); only an
+            # already-started continuation is chunked (see ``chunked=True``).
+            # The caller checks ``token_budget`` before calling, so
+            # remain_len <= token_budget is the precise "fits whole" test.
+            if remain_len > self.token_budget:
+                return None
+            chunk_size = remain_len
+        # For a continuation, chunk_size < remain_len means the prompt is split:
+        # this step extends only [cached_len, cached_len + chunk_size) and the
+        # remainder continues next step. A fresh prompt is never split (see the
+        # chunked=False branch: it is admitted whole or deferred), so this is a
+        # no-op there. The class swap (Req vs ChunkedReq) is what stops a partial
+        # prompt from being sampled.
+        is_chunked = chunk_size < remain_len
+        CLS = ChunkedReq if is_chunked else Req
+        # The per-step token budget is spent only by the *new* tokens this
+        # chunk extends (chunk_size), not by the already-prefilled prefix
+        # (cached_len) -- a continuation must not re-pay for prefix tokens.
+        # (The pool footprint + running slot were already reserved by
+        # _try_allocate_one on the fresh path; a continuation skips both.)
+        self.token_budget -= chunk_size
+        # input_ids carries the prompt prefix extended so far: [0, chunk_size)
+        # for a first admit, or [0, cached_len + chunk_size) for a continuation
+        # (the prior chunk's ids plus the new slice). device_len then becomes
+        # cached_len + chunk_size, so extend_len (device_len - cached_len) is
+        # exactly this step's new chunk, not the whole row.
+        input_ids = pending_req.input_ids[: cached_len + chunk_size]
+        req = CLS(
+            input_ids=input_ids,
+            table_idx=table_idx,
+            cached_len=cached_len,
+            output_len=pending_req.output_len,
+            uid=pending_req.uid,
+            cache_handle=cache_handle,
+            sampling_params=pending_req.sampling_params,
+        )
+        req._next_table_idx = next_table_idx  # noqa: SLF001 - engine fills after forward
+        return req
+
+    def try_add_one(self, pending_req: PendingReq) -> Req | None:
+        if self.token_budget <= 0:
+            return None
+        # A continuation resumes the in-flight chunk: it keeps the original
+        # table_idx and cached_len (the already-extended prefix) and extends the
+        # next budget-sized slice. The table slot was already allocated when the
+        # first chunk was admitted, so only the budget / running-count are spent.
+        if chunked_req := pending_req.chunked_req:
+            table_idx = chunked_req.table_idx
+            # A continuation resumes the in-flight chunk. device_len is the
+            # field that reflects how far the prompt has been extended: the
+            # engine extends the chunk this step (device_len = cached_len +
+            # chunk_size) and, for a ChunkedReq, does NOT append a sampled token
+            # (final-chunk-only -- the chunk's append_host raises and step()
+            # skips it), so device_len is the pure extended prefix (0,1,2,3).
+            # Using it as the resume offset keeps remain_len = input_len -
+            # cached_len shrinking (5,4,3,2,1) so the final chunk completes the
+            # prompt, and -- because _add_one_req builds the new slice as
+            # input_ids[:cached_len + chunk_size] -- each continuation reads the
+            # RIGHT slice (positions [prefix, prefix+chunk)), not the first
+            # chunk again. (cached_len is NOT used here: for an intermediate
+            # chunk it is the slice's START, not its end, so it would re-read
+            # chunk 0 forever. Only the final chunk's cached_len is snapped to
+            # the prompt boundary, and that one is a plain Req, not a
+            # ChunkedReq, so it never reaches this branch.)
+            cached_len = chunked_req.device_len
+            next_table_idx = chunked_req._next_table_idx  # noqa: SLF001
+            cache_handle = chunked_req.cache_handle
+            req = self._add_one_req(
+                pending_req, table_idx, cached_len, next_table_idx, cache_handle, chunked=True
+            )
+            # A continuation must not be dropped for lack of budget (it already
+            # occupies a slot): the caller re-queues it and retries next step.
+            return req
+        resource = self._try_allocate_one(pending_req)
+        if resource is None:
+            return None
+        # _try_allocate_one returns the (zero) cached_len; the table index is
+        # assigned by the scheduler at admission time (it owns the free list).
+        # The adder only decides *whether* to admit and *how much* to extend.
+        table_idx = pending_req._table_idx  # noqa: SLF001 - set by Scheduler.add
+        next_table_idx = pending_req._next_table_idx  # noqa: SLF001
+        cache_handle = pending_req._cache_handle  # noqa: SLF001
+        # The per-step budget is an all-or-nothing gate *between* prompts: the
+        # first prompt admitted into an empty step may use the whole budget (and,
+        # if it is longer than that, is chunked and continues next step); any
+        # prompt admitted *after* one is admitted only if it fits the *remaining*
+        # budget whole (otherwise it defers to a step with room, rather than
+        # splitting behind another prompt in the same step). token_budget == the
+        # step's budget iff nothing has been admitted this step, so "first in"
+        # is exactly token_budget == the step's max_extend_tokens.
+        first_in_step = self.token_budget == self.step_budget
+        # A fresh prompt admitted as the *first* prompt in the step may use the
+        # whole budget and, if longer than it, be chunked (the original
+        # budget-splitting policy). Any prompt admitted *after* one must fit the
+        # remaining budget whole or defer (chunked=False -> whole-or-defer).
+        # _try_allocate_one above already reserved this prompt's pool footprint
+        # + running slot, so a deferral must roll those back (undo) or the
+        # deferred prompt would keep them for the rest of the pass and every
+        # later pass. The table row is unaffected (scheduler-owned, pending
+        # stays queued with it).
+        req = self._add_one_req(
+            pending_req, table_idx, 0, next_table_idx, cache_handle, chunked=first_in_step
+        )
+        if req is None:
+            self._undo_allocation(pending_req)
+        return req
+
+
+@dataclass
 class PrefillManager:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    """The pending-queue plus the per-step prefill admission.
 
-    def prepare(self, *args, **kwargs):
-        unimplemented("PrefillManager.prepare", "scheduler")
+    ``schedule_next_batch`` walks the queue (continuations first, then fresh
+    requests in admission order) and admits as many as the budget and the pool
+    allow, mirroring upstream. A request that fits whole is removed from the
+    queue (it moves to decode after its step); a chunked request stays in the
+    queue with its :class:`ChunkedReq` so the next step continues it.
+    """
 
+    max_running_req: int
+    cache_budget: int
+    page_size: int
+    decode_manager: object
+    pending_list: List[PendingReq] = field(default_factory=list)
+
+    def add_one_req(self, pending_req: PendingReq) -> None:
+        self.pending_list.append(pending_req)
+
+    def schedule_next_batch(self, prefill_budget: int):
+        # The policy itself is torch-free: it decides *which* requests to run and how many
+        # tokens each extends, and the batch carries plain-Python id lists. The
+        # engine (which *does* have torch) turns those lists into the model's
+        # device tensors in step(). This keeps `import freetoken.scheduler` and
+        # the policy testable on the torch-free CPU venv (dual-venv contract).
+        if len(self.pending_list) == 0:
+            return None
+
+        # Estimated offset due to in-flight decode (the decode set is reserving
+        # pool capacity for its remaining tokens).
+        adder = PrefillAdder(
+            token_budget=prefill_budget,
+            step_budget=prefill_budget,
+            reserved_size=self.decode_manager.inflight_tokens,
+            max_running_req=self.max_running_req,
+            cache_budget=self.cache_budget,
+            running_count=len(self.decode_manager.running_reqs),
+        )
+        reqs: List[Req] = []
+        chunked_list: List[PendingReq] = []
+        admitted_pending: List[PendingReq] = []
+        prompt_admissions: list[tuple[int, int, int]] = []
+        log_new_tokens = 0
+        for pending_req in self.pending_list:
+            is_continuation = pending_req.chunked_req is not None
+            if req := adder.try_add_one(pending_req):
+                # The admitted chunk is this step's row. If the prompt is not
+                # finished the PendingReq keeps the ChunkedReq so the next step
+                # resumes it (and it stays in the queue); if it is finished the
+                # PendingReq is dropped from the queue (removed below).
+                pending_req.chunked_req = req if isinstance(req, ChunkedReq) else None
+                if isinstance(req, ChunkedReq):
+                    chunked_list.append(pending_req)
+                reqs.append(req)
+                admitted_pending.append(pending_req)
+                if not is_continuation:
+                    # First chunk: record the prompt size + prefix hit (0 today)
+                    # once at admission, as upstream. Continuations contribute 0
+                    # to the cache-hit stat (the prefix was already counted), as upstream.
+                    prompt_admissions.append((req.uid, pending_req.input_len, 0))
+                log_new_tokens += req.extend_len
+            else:
+                if is_continuation:
+                    # A continuation already owns a row and must not be starved
+                    # by a not-fitting fresh prompt ahead of it: stop the pass.
+                    break
+                # A fresh prompt was not admitted because its *whole* prompt does
+                # not fit the remaining step budget (the all-or-nothing policy).
+                # That does NOT mean the budget is exhausted -- a *shorter* prompt
+                # later in the queue can still fit -- so skip it (it stays queued
+                # and its row is untouched) and keep admitting later requests.
+                continue
+        if len(reqs) == 0:
+            return None
+        # Rebuild the queue by *identity*: every admitted PendingReq is removed
+        # from the tail (it is either a chunked continuation -- re-inserted at
+        # the front via chunked_list -- or a fully-prefilled prompt -- dropped
+        # entirely, having moved to the decode set). The un-admitted tail keeps
+        # its original order. Rebuilding from identity (rather than a positional
+        # slice) is what makes this correct when the admitted set is not a clean
+        # prefix of pending_list: a continuation re-uses its PendingReq in place
+        # (same object in pending_list and chunked_list), so a slice would
+        # double-count it.
+        admitted_ids = {id(p) for p in admitted_pending}
+        unadmitted = [p for p in self.pending_list if id(p) not in admitted_ids]
+        self.pending_list = chunked_list + unadmitted
+        batch = Batch(reqs=reqs, phase="prefill")
+        batch.log_new_tokens = log_new_tokens
+        batch.log_cached_tokens = 0
+        batch.prompt_admissions = prompt_admissions
+        return batch
+
+    def abort_req(self, uid: int) -> Req | None:
+        for i, req in enumerate(self.pending_list):
+            if req.uid == uid:
+                self.pending_list.pop(i)
+                return req.chunked_req  # None for a not-yet-chunked prompt
+        return None
+
+    @property
+    def runnable(self) -> bool:
+        return len(self.pending_list) > 0

--- a/python/freetoken/scheduler/scheduler.py
+++ b/python/freetoken/scheduler/scheduler.py
@@ -1,20 +1,203 @@
-"""Prefill/decode scheduler with chunked prefill.
+"""The scheduler: per-step batch selection for the Intel loop.
 
 Upstream NVIDIA path: python/freetoken/scheduler/scheduler.py
-Fill in: GitHub issue `scheduler` (see docs/architecture.md).
+Filled in: GitHub issue ``scheduler`` (see docs/architecture.md).
+
+Upstream the scheduler is a multi-worker daemon: it talks to the model over
+ZMQ, owns its own process group, and runs an ``while True`` receive/schedule/
+forward loop. The Intel port is the *scheduling policy* of that daemon,
+exposed as a plain object the single-process
+:class:`~freetoken.engine.engine.Engine` drives:
+
+* ``add(req)`` / ``add_all(reqs)`` -- admit a prompt into the pending queue
+  (allocating a page-table row + a unique uid).
+* ``abort(uid)`` -- drop a pending or in-flight request, freeing its row.
+* ``schedule()`` -- pick this step's batch: a prefill batch (chunked to the
+  token budget) if there is a pending prompt, else a decode batch.
+* ``complete(batch)`` -- record that a batch just ran: move finished prefills
+  into the decode set, refresh the decode set, and free rows that hit their
+  stop condition.
+
+The scheduler owns the request uid sequence and the page-table rows
+(``table_idx``); the engine owns the token pool and does the actual
+``model.forward`` + sampling, handing the scheduler a :class:`Batch` back via
+:meth:`complete`. This split keeps the scheduler testable against a dummy
+engine (the issue's acceptance criterion) and keeps torch out of the import
+path (torch is only needed by the managers when they build a batch tensor).
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from typing import List, Optional
+
+from freetoken.core import Batch, Req
+from freetoken.scheduler.config import SchedulerConfig
+from freetoken.scheduler.decode import DecodeManager
+from freetoken.scheduler.prefill import PendingReq, PrefillManager, make_pending_req
 
 
 class Scheduler:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    """Selects each step's prefill/decode batch for a single-process engine."""
 
-    def schedule(self, *args, **kwargs):
-        unimplemented("Scheduler.schedule", "scheduler")
+    def __init__(
+        self,
+        config: SchedulerConfig,
+        *,
+        max_pages: int,
+        cache_budget: int,
+    ):
+        self.config = config
+        self.max_pages = max_pages
+        self.cache_budget = cache_budget
+        self._next_uid = 0
+        # Free page-table rows (table_idx), kept sorted. The engine owns the
+        # rows (it is the one that allocates them in the pool); the scheduler
+        # borrows this list to hand requests a table_idx. add() pops the lowest
+        # free index and complete() / abort() append freed ones back (sorted),
+        # so admission is deterministic (lowest index first).
+        self._free_slots: List[int] = sorted(range(config.max_running_req))
+        self.decode_manager = DecodeManager(page_size=config.page_size)
+        self.prefill_manager = PrefillManager(
+            max_running_req=config.max_running_req,
+            cache_budget=cache_budget,
+            page_size=config.page_size,
+            decode_manager=self.decode_manager,
+        )
 
-    def abort(self, *args, **kwargs):
-        unimplemented("Scheduler.abort", "scheduler")
+    # -- admission -----------------------------------------------------------
 
+    def add(self, pending: PendingReq) -> int:
+        """Admit a prompt: hand it a page-table row and queue it for prefill.
+
+        ``pending.uid`` must already be set (the engine assigns it at
+        ``add_request``); the scheduler only assigns the page-table row. Returns
+        the uid (``pending.uid``). Raises :class:`RuntimeError` when the request
+        cap is reached (no free page-table row) so the engine can reject the
+        request cleanly. ``pending._table_idx`` is overwritten here.
+        """
+        if not self._free_slots:
+            raise RuntimeError(
+                f"request cap reached (max_running_req={self.config.max_running_req}); "
+                "cannot admit a new request"
+            )
+        table_idx = self._free_slots.pop(0)
+        pending._table_idx = table_idx  # noqa: SLF001
+        pending._next_table_idx = -1  # noqa: SLF001 - assigned post-step
+        self.prefill_manager.add_one_req(pending)
+        # Keep the uid sequence past this admission so a later internal
+        # allocation (none today) never re-issues a uid the engine already used.
+        self._next_uid = max(self._next_uid, pending.uid + 1)
+        return pending.uid
+
+    # -- abort ---------------------------------------------------------------
+
+    def abort(self, uid: int) -> bool:
+        """Free a request's row and drop it from whichever set it is in.
+
+        Returns ``True`` if the request was found and freed (pending, chunked,
+        or decoding). The engine uses this to clear a row when a request is
+        cancelled or hits a stop condition.
+        """
+        # Pending (not yet admitted, or a chunk awaiting continuation).
+        pending = self.prefill_manager.pending_list
+        for i, pr in enumerate(pending):
+            if pr.uid == uid:
+                # The row was allocated at add() (recorded on the PendingReq);
+                # free it now. A prompt not yet split has no ChunkedReq, so the
+                # table_idx comes from the pending entry, not from a chunk.
+                table_idx = pr.chunked_req.table_idx if pr.chunked_req is not None else pr._table_idx
+                self.prefill_manager.pending_list.pop(i)
+                self._free_slots.append(table_idx)
+                self._free_slots.sort()
+                return True
+        # In-flight decode.
+        if (req := self.decode_manager.abort_req(uid)) is not None:
+            self._free_slots.append(req.table_idx)
+            self._free_slots.sort()
+            return True
+        return False
+
+    # -- per-step ------------------------------------------------------------
+
+    def schedule(self) -> Optional[Batch]:
+        """Pick this step's batch: prefill if anything is queued, else decode.
+
+        Mirrors the upstream policy -- a pending prompt always preempts a decode
+        step (prefill-first), and a chunked prompt's continuation is always
+        scheduled ahead of new prompts (PrefillManager keeps continuations at
+        the front of the queue).
+
+        The prefill batch is returned *as-is*; promoting its fully-prefilled
+        requests into the decode set happens in :meth:`complete`, *after* the
+        step runs. Promoting at schedule time (before the forward) would drop a
+        just-prefilled request -- its first token has not been sampled yet, so ``device_len``
+        still equals the prompt length, ``remain_len`` is 0 and ``can_decode`` is
+        False -- and the prefill step's first token would be lost. Deferring the
+        promotion to :meth:`complete` lets the step bump ``device_len`` first
+        (``remain_len`` goes positive again), so the request is admitted with its
+        first token intact. A partial (:class:`ChunkedReq`) prefill is never
+        promoted: ``ChunkedReq.can_decode`` is False (see prefill.py), so
+        :meth:`complete` keeps it out until a later step finishes the prompt.
+        """
+        batch = self.prefill_manager.schedule_next_batch(self.config.max_extend_tokens)
+        if batch is None:
+            batch = self.decode_manager.schedule_next_batch()
+        if batch is None:
+            # No pending prefill and no live decode: nothing to run this step.
+            # The decode set is empty too (it would have scheduled), so the
+            # loop is idle.
+            return None
+        return batch
+
+    def complete(self, batch: Batch) -> None:
+        """Record that ``batch`` just executed: update the bookkeeping.
+
+        Called by the engine after ``model.forward`` + sampling + id append.
+        Two things happen:
+
+        * A request whose prompt was *fully* extended by this step (a plain
+          :class:`Req` -- a whole prompt, or the final chunk of a split one) is
+          admitted into the decode set here, *after* the step ran. The step has
+          already sampled its first token and bumped ``device_len``, so
+          ``remain_len > 0`` and ``can_decode`` is True. Promoting at
+          :meth:`schedule` time instead would drop it and lose that first token
+          (see :meth:`schedule`).
+        * A request that hit its stop condition during this step (max_tokens /
+          EOS / abort) is pruned from the decode set and its row freed. A
+          *partial* (:class:`ChunkedReq`) prefill is neither admitted nor freed:
+          it stays queued (PrefillManager re-queued its PendingReq) to be
+          continued next step; ``ChunkedReq.can_decode`` is False so
+          ``filter_reqs`` never puts it in the decode set, and it is not in
+          ``running_before`` so it is not freed here.
+
+        ``filter_reqs`` is idempotent (a request already present is moved to the
+        end), so a decode request that survived the step is re-admitted (a no-op
+        for its presence) while any just-finished ones are dropped.
+        """
+        running_before = self.decode_manager.running_reqs  # OrderedDict
+        self.decode_manager.filter_reqs(batch.reqs)
+        running_after = self.decode_manager.running_reqs  # OrderedDict
+        # Free the rows of requests that were running before the step but are
+        # no longer decodable after it. Both sides are OrderedDict keyed by Req
+        # (identity hash), so the key-difference is well-defined. A fully
+        # prefill request admitted *here* is not in running_before, so it is
+        # never freed; a decode request that just hit its stop condition was in
+        # running_before and is dropped from running_after, so its row is freed.
+        freed = [req.table_idx for req in running_before.keys() - running_after.keys()]
+        if freed:
+            self._free_slots.extend(freed)
+            self._free_slots.sort()
+
+    # -- introspection --------------------------------------------------------
+
+    @property
+    def idle(self) -> bool:
+        return not self.schedule()
+
+    @property
+    def next_table_idx_of(self, req: Req) -> int:
+        """The next free row ``req`` will be moved to once it completes.
+
+        Used by the engine to assign ``req._next_table_idx`` at admission /
+        step boundaries so a completing request can be compacted in place.
+        """
+        return self._free_slots[0] if self._free_slots else -1

--- a/tests/test_moe_offload_cache.py
+++ b/tests/test_moe_offload_cache.py
@@ -107,8 +107,10 @@ def test_decode_hit_bumps_usage_no_copy():
     # With S > E (the default 8 > 4), after materializing layer 0 then layer 1
     # the pool is NOT full: layer 0 keeps 4 resident slots and layer 1's 4 experts
     # land in the 4 free slots. Routing a layer-1 expert is therefore a pure HIT
-    # (already resident -> no new miss, no scheduled copy, slot id rewritten in
-    # place) -- the hit bookkeeping path under the global-LRU scheme.
+    # (already resident -> no new miss, no scheduled copy) -- the hit bookkeeping
+    # path under the global-LRU scheme. (The routed tensor is NOT rewritten in
+    # place: the forward maps expert -> slot on the host, so the expert id is
+    # preserved -- see test_decode_repeat_routing_is_in_bounds for issue #7.)
     c = OffloadMoeCache(L, E, S, DEVICE, prefill_overlap=False)
     c.set_bank_sources(_bank_sources())
     c.materialize_layer(0)
@@ -121,8 +123,10 @@ def test_decode_hit_bumps_usage_no_copy():
     # Expert 1 is already resident -> a hit: no new miss, no scheduled copy.
     assert c.stat_missing.item() == before_missing
     assert c.num_indices.item() == 0
-    # The routed position was rewritten to the expert's (hit) slot.
-    assert ids[0].item() == c.slot_for_id[1, 1].item()
+    # The routed expert id is preserved (not rewritten to a slot id); the expert
+    # is resident in the (hit) slot the map points to.
+    assert ids[0].item() == 1, "expert id must not be rewritten in place (issue #7)"
+    assert c.slot_for_id[1, 1].item() != -1, "hit expert must be resident"
     # Its slot's usage was bumped to the newest step (the LRU key moved).
     assert c.usage[c.slot_for_id[1, 1].item()].item() == c.step.item()
 

--- a/tests/test_scheduler_policy.py
+++ b/tests/test_scheduler_policy.py
@@ -1,0 +1,274 @@
+"""Tests for the scheduler (issue ``scheduler``, #13).
+
+Two layers, matching the issue's acceptance criteria:
+
+* **Policy tests** (this file, ``test_scheduler_policy.py``) exercise the
+  scheduler against a *dummy engine* -- no torch, no model -- so they run in
+  the CPU venv (the dual-venv contract: ``import freetoken.scheduler`` never
+  pulls in torch). They pin the scheduling *decisions*: chunked prefill respects
+  the per-step token budget, prefill preempts decode, decode batches are
+  uid-ordered and pruned on completion, and abort frees a slot.
+* **Integration tests** (``test_scheduler_integration.py``, torch-marked) run
+  the scheduler wired into the real :class:`~freetoken.engine.engine.Engine`
+  over a tiny dummy-weight model, on the CPU, to prove the engine's
+  ``add_request`` / ``step`` / ``generate`` hand off to the scheduler correctly.
+"""
+from __future__ import annotations
+
+from freetoken.core import Batch, Req, SamplingParams
+from freetoken.scheduler import (
+    ChunkedReq,
+    DecodeManager,
+    PendingReq,
+    PrefillAdder,
+    PrefillManager,
+    Scheduler,
+    SchedulerConfig,
+    make_pending_req,
+)
+
+
+def _config(**overrides) -> SchedulerConfig:
+    # EngineConfig requires model_path / tp_info / dtype; the policy tests never
+    # run a model, so dummies stand in. Only the scheduling fields matter here.
+    base = dict(
+        model_path="/dummy",
+        tp_info=None,
+        dtype=None,
+        max_running_req=4,
+        page_size=1,
+        max_extend_tokens=8192,
+    )
+    base.update(overrides)
+    return SchedulerConfig(**base)
+
+
+def _pending(prompt_len: int, output_len: int, uid: int, table_idx: int) -> PendingReq:
+    pr = PendingReq(
+        uid=uid,
+        input_ids=list(range(prompt_len)),
+        sampling_params=SamplingParams(max_tokens=output_len),
+    )
+    # The Scheduler normally assigns these at add(); the unit tests set them
+    # directly so PrefillAdder can read them without a full Scheduler.
+    pr._table_idx = table_idx  # noqa: SLF001
+    pr._next_table_idx = -1  # noqa: SLF001
+    return pr
+
+
+def _scheduler(*, max_extend_tokens: int = 8, max_running_req: int = 4) -> Scheduler:
+    config = _config(max_extend_tokens=max_extend_tokens, max_running_req=max_running_req)
+    # A generous pool budget so the request cap (not the pool) is the binding
+    # constraint in the policy tests; the cap is max_running_req.
+    return Scheduler(config, max_pages=256, cache_budget=4096)
+
+
+# -- chunked prefill ---------------------------------------------------------
+
+
+def test_chunked_prefill_splits_to_budget():
+    """A 16-token prompt with an 8-token budget splits across two prefill steps.
+
+    Step 1 extends [0,8) (a ChunkedReq, can_decode False). Step 2 extends
+    [8,16) (a full Req, can_decode True) and the prompt leaves the pending queue
+    -- the budget is respected on every step (8 tokens each, never 16).
+    """
+    sched = _scheduler(max_extend_tokens=8)
+    sched.add(_to_pending(_full_req(prompt_len=16, output_len=2)))
+    # One pending prompt, nothing running yet.
+    assert len(sched.prefill_manager.pending_list) == 1
+
+    batch1 = sched.schedule()
+    assert batch1 is not None
+    assert batch1.phase == "prefill"
+    (req1,) = batch1.reqs
+    # First chunk: 8 tokens, not finished, so it is a ChunkedReq.
+    assert isinstance(req1, ChunkedReq)
+    assert req1.extend_len == 8  # exactly the budget
+    assert req1.can_decode is False
+    # The prompt is not done: it stays in the pending queue (1 continuation).
+    assert len(sched.prefill_manager.pending_list) == 1
+
+    # Capture step 1's extension up front: the lines below mutate req1's
+    # cached_len/device_len to simulate the engine having run step 1, which
+    # would otherwise zero out req1.extend_len (device_len - cached_len) by
+    # step 113. The per-step extensions are what the budget is measured against.
+    step1_extend = req1.extend_len
+
+    # The engine "ran" step 1: extend [0,8) -> device_len 8.
+    req1.cached_len = 8
+    req1.device_len = 8
+    sched.complete(batch1)
+    # A ChunkedReq is not yet decodable, so it is NOT in the decode set.
+    assert len(sched.decode_manager.running_reqs) == 0
+
+    batch2 = sched.schedule()
+    assert batch2 is not None
+    assert batch2.phase == "prefill"
+    (req2,) = batch2.reqs
+    # Second chunk extends the remaining 8 tokens and completes the prompt.
+    assert isinstance(req2, Req)
+    assert not isinstance(req2, ChunkedReq)
+    assert req2.extend_len == 8  # exactly the budget (16 - 8 remaining)
+    # The prompt left the pending queue (fully prefilled).
+    assert len(sched.prefill_manager.pending_list) == 0
+    # The prompt is NOT yet in the decode set: promotion happens in complete()
+    # (after the step runs), not in schedule(). can_decode is already True
+    # (prompt done, 2 output tokens remain), but the decode set only sees it
+    # once the step finishes.
+    assert req2.can_decode is True
+    assert len(sched.decode_manager.running_reqs) == 0
+    # Budget respected across both steps: 8 + 8 = 16 = the whole prompt.
+    assert step1_extend + req2.extend_len == 16
+
+    # Simulate the engine running step 2: extend [8,16), sample first token.
+    req2.device_len = 16
+    req2.input_ids = req2.input_ids + [100]  # first generated token
+    sched.complete(batch2)
+    # Now the prompt is in the decode set (promoted in complete()).
+    assert len(sched.decode_manager.running_reqs) == 1
+
+
+def test_short_prompt_not_chunked():
+    """A prompt that fits the budget is prefilled whole in one step."""
+    sched = _scheduler(max_extend_tokens=8)
+    sched.add(_to_pending(_full_req(prompt_len=4, output_len=2)))
+    batch = sched.schedule()
+    (req,) = batch.reqs
+    assert isinstance(req, Req) and not isinstance(req, ChunkedReq)
+    assert req.extend_len == 4
+    req.device_len = 4
+    sched.complete(batch)
+    assert len(sched.decode_manager.running_reqs) == 1
+    assert len(sched.prefill_manager.pending_list) == 0
+
+
+def test_budget_is_per_step_not_per_request():
+    """Two 6-token prompts with an 8-token budget: step 1 takes one fully, the
+    other is deferred (8 < 6+6) and runs alone in step 2 -- the budget is a
+    per-step limit, not a per-request one."""
+    sched = _scheduler(max_extend_tokens=8)
+    sched.add(_to_pending(_full_req(prompt_len=6, output_len=1, uid=0, table_idx=0)))
+    sched.add(_to_pending(_full_req(prompt_len=6, output_len=1, uid=1, table_idx=1)))
+    batch1 = sched.schedule()
+    # Only the first prompt fits (6 <= 8); the second would need 6 more (8 < 12).
+    assert len(batch1.reqs) == 1
+    assert batch1.reqs[0].uid == 0
+    (batch1.reqs[0]).device_len = 6
+    sched.complete(batch1)
+    # Step 2 now runs the deferred second prompt.
+    batch2 = sched.schedule()
+    assert batch2 is not None
+    assert len(batch2.reqs) == 1
+    assert batch2.reqs[0].uid == 1
+
+
+# -- prefill preempts decode -------------------------------------------------
+
+
+def test_prefill_preempts_decode():
+    """With a prompt pending and a request decoding, the next step prefills."""
+    sched = _scheduler(max_extend_tokens=8)
+    decoding = _full_req(prompt_len=2, output_len=10)
+    # Put `decoding` directly in the decode set (it already finished its prompt).
+    sched.decode_manager.running_reqs.update({decoding: None})
+    # A new prompt is admitted.
+    sched.add(_to_pending(_full_req(prompt_len=3, output_len=2, uid=50, table_idx=2)))
+    batch = sched.schedule()
+    # Prefill wins over decode even though a request is already decoding.
+    assert batch.phase == "prefill"
+    assert batch.reqs[0].uid == 50
+
+
+# -- decode batching ---------------------------------------------------------
+
+
+def test_decode_batch_uid_ordered():
+    """The decode batch runs the live requests in uid order."""
+    sched = _scheduler()
+    for uid, table_idx in [(7, 0), (3, 1), (11, 2)]:
+        decoding = _full_req(prompt_len=1, output_len=5, uid=uid, table_idx=table_idx)
+        decoding.device_len = 1
+        sched.decode_manager.running_reqs.update({decoding: None})
+    batch = sched.schedule()
+    assert batch.phase == "decode"
+    assert [req.uid for req in batch.reqs] == [3, 7, 11]
+
+
+def test_decode_prunes_completed():
+    """A decode request that hits max_tokens is pruned and its slot freed."""
+    sched = _scheduler()
+    done = _full_req(prompt_len=1, output_len=1, uid=1, table_idx=0)
+    alive = _full_req(prompt_len=1, output_len=5, uid=2, table_idx=1)
+    done.device_len = 1
+    alive.device_len = 1
+    sched.decode_manager.running_reqs.update({done: None, alive: None})
+    free_before = sorted(sched._free_slots)
+    # Step 1: `done` emits its 1st (final) token -> device_len 2 == max, aborts.
+    batch = sched.schedule()
+    assert batch.phase == "decode" and len(batch.reqs) == 2
+    for req in batch.reqs:
+        req.device_len += 1  # one decode token each
+        if req.device_len >= req.max_device_len:
+            req.aborted = True
+    sched.complete(batch)
+    # `done` is pruned (device_len == max_device_len -> not can_decode), `alive`
+    # remains. The freed slot is back in the free list.
+    assert {req.uid for req in sched.decode_manager.running_reqs} == {2}
+    assert sorted(sched._free_slots) == sorted(free_before + [0])
+
+
+def test_idle_when_nothing_pending_or_decoding():
+    sched = _scheduler()
+    assert sched.schedule() is None
+    assert sched.idle is True
+
+
+# -- abort -------------------------------------------------------------------
+
+
+def test_abort_pending_frees_slot():
+    sched = _scheduler()
+    req = _full_req(prompt_len=4, output_len=2, uid=9, table_idx=0)
+    sched.add(_to_pending(req))
+    assert 0 in sched._free_slots or len(sched._free_slots) < 4
+    assert sched.abort(9) is True
+    # The slot is released.
+    assert 0 in sched._free_slots
+    # Nothing left to schedule.
+    assert sched.schedule() is None
+
+
+def test_abort_decoding_frees_slot():
+    sched = _scheduler()
+    decoding = _full_req(prompt_len=1, output_len=5, uid=4, table_idx=2)
+    decoding.device_len = 1
+    sched.decode_manager.running_reqs.update({decoding: None})
+    assert sched.abort(4) is True
+    assert 2 in sched._free_slots
+    assert len(sched.decode_manager.running_reqs) == 0
+
+
+def _full_req(prompt_len: int, output_len: int, uid: int = 0, table_idx: int = 0) -> Req:
+    # The caller (server path) sets uid; the scheduler assigns the page-table
+    # row at add(). table_idx is a placeholder here. sampling_params is required
+    # -- the scheduler wraps the Req in a PendingReq at admission.
+    return Req(
+        input_ids=list(range(prompt_len)),
+        table_idx=table_idx,
+        cached_len=0,
+        output_len=output_len,
+        uid=uid,
+        sampling_params=SamplingParams(max_tokens=output_len),
+        cache_handle=None,
+    )
+
+
+def _to_pending(req: Req) -> PendingReq:
+    """Wrap a raw Req in a PendingReq, as the engine's add_request does.
+
+    The scheduler's add() takes a PendingReq (which carries the caller's uid);
+    this mirrors the engine's wrap so the policy tests exercise the same path
+    the integration tests will.
+    """
+    return make_pending_req(req.uid, req.input_ids, req.sampling_params, req.cache_handle)


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟠 **PR-Agent Score: 70** `score-70-79` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/103#issuecomment-5488928513) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 41f9b7c](https://github.com/Performant-Labs/FreeToken-Intel/commit/41f9b7c0890f392a94aff729188f55791fa20752) · run [#33469786594](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33469786594) · 2026-08-31 22:33 MDT / 2026-09-01 04:33 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary

Implements chunked-prefill admission for the scheduler (issue #13) and fixes the
attention/KV path so a chunked run is **bit-identical** to a non-chunked one.

### Chunked-prefill admission
The prefill manager now admits requests within a **per-step token budget**
(`max_extend_tokens`): a prompt that fits in the budget is prefilled whole and
moves on to decode; a prompt that does not is *chunked* — only
`min(budget, remaining)` tokens are extended this step, and the request is
tracked by `ChunkedReq` and resumed on subsequent steps. Decode requests are
batched by uid and pruned on completion.

### Correctness: bsz-invariant attention
The key fix is making the attention output layout independent of the batch size,
so one whole-prompt prefill (bsz = prompt len) and N one-token prefill chunks
produce identical logits:
- **q/k/v layout** — projected outputs are laid out token-major
  `[bsz, heads, head_dim]` then transposed to the head-major
  `[heads, bsz, head_dim]` the RoPE / KV-pool path expects. (A flat
  `.view(heads, bsz, head_dim)` reinterprets memory linearly and scrambles which
  token lands in which head for bsz > 1.)
- **o_proj fold** — moves the *token* axis to the front (`transpose(0, 1)`) then
  `.contiguous()` before reshape. The old `transpose(1, 2)` moved the head_dim
  axis to the front, so for bsz > 1 each row interleaved the **wrong heads'**
  tokens and the o_proj input was silently scrambled. bsz == 1 (every decode /
  chunked step) hid it — which is exactly why chunked prefill *looked* correct
  while a whole-prompt prefill diverged.
- **KV pool** — `write_kv` / `read_kv` carry `layer_id` so a mixed step reads
  the correct pool rows.

## Verification
- `tests/test_scheduler_policy.py` (new) covers the admission/batching policy
  per the issue acceptance criteria: budget splitting, short-prompt no-chunk,
  per-step (not per-request) budget, prefill preempts decode, uid-ordered decode
  batching, completion pruning, idle, and abort (pending + decoding).
- Chunked (`max_extend_tokens=1`) now emits **identical** token ids to
  non-chunked (`max_extend_tokens=5`) across prompt lengths 5/6/10.
- Full CPU test suite: 159 passed.

## Notes
One pre-existing, unrelated failure remains on the branch:
`test_models_qwen35_loader.py::test_forward_writes_full_attention_kv_into_pool`
(the `qwen3_5_moe` K-buffer is `[1024, ...]` where the test expects
`[NKV=2, ...]`). It fails identically with and without this PR's changes and is
tracked separately.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add chunked-prefill scheduler admission with per-step token budget

- Fix q/k/v and o_proj layouts for batch-size invariance

- Segregate KV cache per layer and layer-aware read/write paths

- Refactor MoE offload host routing; stop expert-id rewrite


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Engine["Engine step"] --> Scheduler["Scheduler"]
  Scheduler -->|"prefill chunk"| PrefillManager["PrefillManager"]
  Scheduler -->|"decode"| DecodeManager["DecodeManager"]
  Engine --> Model["Qwen3/MoE layers"]
  Model --> KVPool["Per-layer KV pool"]
  KVPool --> Attention["Attention backend"]
  Model --> Offload["MoE offload host routing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>triton.py</strong><dd><code>Use `batch.phase` and layer-aware KV reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-818a55a2203b4bd840161ef989795eda5653e2508e412689e4aa674ee4297562">+46/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong><dd><code>Segregate K/V pool per decoder layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-cf193a37ef22b84d322b6a711eef6c15be7a178c663c086b41f3593a94addae3">+53/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Layer-aware KV writes and phase-based offload routing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+31/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Correct q/k/v layout and o_proj fold for `bsz`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-7df44a0f5eb5c411dc8b6f5d672093944a031ba3e91e79a23781674f3ceb1a3e">+95/-54</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>offload_cache.py</strong><dd><code>Stop rewriting expert ids to slot ids</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-2b28912e9e23e80a09b8bbfbfe7a0ceba4db2a916f9ba2fc974704f1f455702d">+14/-24</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Lazy re-export torch modules via `__getattr__`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-408859278fdc405a04310931ce2ba708a00aae91f1338133695d8cc147410cd1">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>engine.py</strong><dd><code>Drive scheduler-managed prefill/decode batches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-ac01fc4935708ecb318c53b01021cb308dbea3f1d1d356d68b796fc860dda54c">+215/-79</a></td>

</tr>

<tr>
  <td><strong>config.py</strong><dd><code>Add `SchedulerConfig` with prefill token budget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-89b37a01f3c7006efcd9eb5e254f42112c08069fd076cb1658ec57573035766f">+45/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>decode.py</strong><dd><code>Implement decode set batching and pruning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-64c81e5366b34a476564b9ac797f8349b905c5466cbcc5c621dff980fdc99fda">+74/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prefill.py</strong><dd><code>Implement chunked-prefill admission and queue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-ccf1c073fbf297797eb3aafc4b6bc41b8a8928b545023f94921658fb3971cce1">+410/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>scheduler.py</strong><dd><code>Add scheduler orchestration for prefill/decode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-7107a99ca3478dc89c26e38648209031d4c51bfe44d4fbf9e74ce5a0fe1ab5f0">+192/-9</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Export scheduler components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-3d7e5d27207f470b08cf5d58a562b27e334569ab43aefed8f2856323a99aceba">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_moe_offload_cache.py</strong><dd><code>Update MoE offload cache tests for expert ids</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-c2712f272677a738ae6656c4413d67fd90f109aa7b06137cd3e2871f5df4c059">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_scheduler_policy.py</strong><dd><code>Add scheduler policy unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/103/files#diff-0a0912e7df3bb85dd84df04449af866d9c9a28ebf13fd96c66cfd814e2d68dde">+274/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___