### PR TITLE
fix(models): update qwen3_5_moe KV-pool test for the per-layer buffer (issue #13)

### DIFF
--- a/tests/test_models_qwen35_loader.py
+++ b/tests/test_models_qwen35_loader.py
@@ -314,14 +314,21 @@ def test_forward_writes_full_attention_kv_into_pool(qwen35_ckpt):
     _, ctx = _drive_prefill(model, seq, T)
     full_layers = [l for l in model.layers if l.self_attn is not None]
     assert full_layers, "the fabricated tower must have a full-attention layer"
-    k = ctx.kv_cache.k_buffer
-    assert k.shape[1] == NKV and k.shape[2] == HD
-    # The rows holding the written K/V (slot == position under the identity
-    # table) are populated: some norm over the first T rows is nonzero.
-    assert (k[:T].float().norm() > 0).item()
-    # And at least one full-attention layer's K was written (the row for position
-    # 0 of that layer is nonzero) -- a no-op write would leave the pool empty.
-    assert bool((k[:T].float().pow(2).sum() > 0).item())
+    # The paged pool is segregated per layer: ``k_buffer`` is
+    # ``[num_layers, num_slots, num_kv_heads, head_dim]``, so each layer
+    # attends to its *own* K/V. The full-attention layers (the linear-attention
+    # ones keep their recurrent state in a separate pool) write into their own
+    # layer slice; inspect that slice's per-token geometry.
+    for l in full_layers:
+        k = ctx.kv_cache.k_buffer[l.layer_id]
+        assert k.shape[1] == NKV and k.shape[2] == HD
+        # The rows holding the written K/V (slot == position under the identity
+        # table) are populated: some norm over the first T rows is nonzero.
+        assert (k[:T].float().norm() > 0).item()
+        # And at least one full-attention layer's K was written (the row for
+        # position 0 of that layer is nonzero) -- a no-op write would leave the
+        # pool empty.
+        assert bool((k[:T].float().pow(2).sum() > 0).item())
 
 
 def test_forward_cross_checked_against_independent_reference(qwen35_ckpt):


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit f3c3cad](https://github.com/Performant-Labs/FreeToken-Intel/commit/f3c3cad3dc08822399a26f6ddc0205976815d584) · run [#33471563939](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33471563939) · 2026-08-31 22:55 MDT / 2026-09-01 04:55 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## What

Fixes the last known red test on `main`: `test_forward_writes_full_attention_kv_into_pool` in `tests/test_models_qwen35_loader.py`.

## Why it was red

PR #13 (chunked-prefill admission + bsz-invariant attention) added a **leading per-layer dim** to the paged KV pool so each decoder layer owns its own K/V slice:

- before #13: `k_buffer` = `[num_slots, num_kv_heads, head_dim]`
- after #13:  `k_buffer` = `[num_layers, num_slots, num_kv_heads, head_dim]`

The per-token head axes shifted from positions `(1, 2)` to `(2, 3)`. This test was written against the pre-#13 layout and still asserts the old indices:

```python
k = ctx.kv_cache.k_buffer
assert k.shape[1] == NKV and k.shape[2] == HD   # now shape[1] == num_slots (1024)
```

It also read `k_buffer[:T]` across the **whole** buffer, which mixes in the linear-attention (Gated-Delta-Net) layers' slices. Those layers keep their recurrent/conv state in a *separate* `linear_state_pool` and never write to the paged KV pool, so `k_buffer[0]` (the linear layer) is all zeros and the whole-buffer probe is misleading.

This was a **stale test**, not a code bug — the model's full-attention layer writes its K/V into its own `k_buffer[layer_id]` slice correctly.

## The fix

Inspect the full-attention layer's **own** slice and check the correct per-token geometry:

```python
for l in full_layers:
    k = ctx.kv_cache.k_buffer[l.layer_id]
    assert k.shape[1] == NKV and k.shape[2] == HD
    assert (k[:T].float().norm() > 0).item()
    assert bool((k[:T].float().pow(2).sum() > 0).item())
```

## Verification

- `test_forward_writes_full_attention_kv_into_pool` — **passes**.
- `tests/test_models_qwen35_loader.py` — **8/8 pass**.
- Full CPU suite: **230 passed**; the only failures are the pre-existing XPU-hardware gates (`test_attention_sycl` / `test_kernel_toolchain`, `@xpu_only`, need a B70) — unaffected by this change.

## Scope

Test-only, one file. No production code touched. Closes out the last red test introduced by #13.


___

### **PR Type**
Tests


___

### **Description**
- Update KV-pool test for per-layer `k_buffer` layout.

- Loop over full-attention layers and inspect `k_buffer[layer_id]`.

- Verify K/V geometry and non-empty rows per layer.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Test["Updated KV-pool test"] --> Loop["Iterate full-attention layers"]
  Loop --> Slice["Read k_buffer[layer_id]"]
  Slice --> Shape["Assert shape[1] == NKV, shape[2] == HD"]
  Slice --> Nonzero["Check K/V rows are nonzero"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_qwen35_loader.py</strong><dd><code>Update KV-pool test for per-layer buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_qwen35_loader.py

<ul><li>Changed test to iterate over <code>full_layers</code> instead of reading the whole <br><code>k_buffer</code>.<br> <li> Reads <code>ctx.kv_cache.k_buffer[l.layer_id]</code> for each full-attention layer.<br> <li> Asserts per-layer K/V head geometry at indices <code>1</code> and <code>2</code>.<br> <li> Verifies non-zero norm and squared sum for the first <code>T</code> rows per layer.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/104/files#diff-a6033b042354d3944a84d9a2e3636f7ba9b2641d0fadd5df6447456feeb1e2b5">+15/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___