### PR TITLE
fix(moe): align offload MoE accumulation order to in-VRAM (expert-major)

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1012,19 +1012,36 @@ class _Qwen35MoE:
         #    sync is what faults: no amount of torch.xpu.synchronize() around the
         #    block helps, because the offending sync is in its middle. Integer
         #    index_select / index_add_ have static shapes and never call nonzero.)
-        groups: list[tuple[int, int, list[int]]] = []
+        # Build the (expert, slot, rows) groups in EXPERT-MAJOR order: for each
+        # expert e (ascending), for each top-k column j (ascending), collect the
+        # rows that route to e's slot in column j. This mirrors the in-VRAM
+        # _forward_inram loop (for e in range(num_experts): for slot in range(top_k))
+        # so the float32 accumulation order into out[i] is identical. The offload
+        # transport is a byte-identical weight copy (ADR 0002); the only remaining
+        # source of divergence was the accumulation *order* (slot-major here vs
+        # expert-major in-VRAM), which produces a ~1e-7 ULP difference that the
+        # chaotic Gated-Delta-Net recurrence amplifies over decode steps until the
+        # greedy argmax flips (issue #18).
+        num_experts = model.config.num_experts
+        expert_slots = [int(slots[e]) for e in range(num_experts)]
+        expert_to_col: dict[int, list[tuple[int, int]]] = {}
         for j in range(k):
-            by_slot: dict[int, list[int]] = {}
             for i in range(B):
                 if bool(valid_cpu[i, j]):
-                    by_slot.setdefault(int(routed_cpu[i, j]), []).append(i)
-            groups.extend((j, s_i, rows) for s_i, rows in by_slot.items())
-        # 5) (No device-side push needed: validity is encoded in which rows appear
-        #    in `groups`, and the gather below uses host-built index tensors.)
-        # 6) Gather per slot on the XPU using host-computed INTEGER indices:
-        #    static shapes, no nonzero(), no implicit D2H anywhere in the loop.
-        #    index_add_ accumulates exactly as `out[sub] += ...` did (and handles
-        #    duplicate indices, though rows are unique within a (j, s_i) group).
+                    e_id = int(expert_ids[i, j])
+                    expert_to_col.setdefault(e_id, []).append((j, i))
+        groups: list[tuple[int, int, list[int]]] = []
+        for e in range(num_experts):
+            s_i = expert_slots[e]
+            if not (0 <= s_i < S):
+                continue
+            for j, i in expert_to_col.get(e, []):
+                groups.append((j, s_i, [i]))
+        # (No device-side push needed: validity is encoded in which rows appear
+        # in `groups`, and the gather below uses host-built index tensors.)
+        # Gather per (expert, slot, row) on the XPU using host-computed INTEGER
+        # indices: static shapes, no nonzero(), no implicit D2H anywhere in the
+        # loop. index_add_ accumulates exactly as `out[sel] += ...` did.
         for j, s_i, rows in groups:
             idx = torch.tensor(rows, dtype=torch.long, device=dev)
             y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -386,19 +386,36 @@ class _Qwen3MoE(nn.Module):
                     f"layer {self.layer_id}: offload routed slot id {stale} >= "
                     f"cache_size {S}: stale slot map (ensure_experts desync)"
                 )
-        # 4) Host-side (column j, slot s_i) -> row indices routing to it, built
-        #    from the CPU tensors only: the gather below never asks the device
-        #    "which rows matched?" (a boolean-mask index would call nonzero(),
-        #    whose data-dependent shape forces an implicit D2H sync mid-loop).
-        groups: list[tuple[int, int, list[int]]] = []
+        # 4) Host-side (expert, column j) -> row indices, built in EXPERT-MAJOR
+        #    order (for each expert e ascending, then each column j ascending) so
+        #    the float32 accumulation order into out[i] matches the in-VRAM
+        #    _forward_inram loop (for e in range(num_experts): for slot in
+        #    range(top_k)). The offload transport is a byte-identical weight copy
+        #    (ADR 0002); the only divergence source was the accumulation order
+        #    (slot-major here vs expert-major in-VRAM) -> ~1e-7 ULP drift
+        #    amplified by the recurrent attention over decode steps (issue #18).
+        #    Built from the CPU tensors only: the gather below never asks the
+        #    device "which rows matched?" (a boolean-mask index would call
+        #    nonzero(), whose data-dependent shape forces an implicit D2H sync
+        #    mid-loop).
+        num_experts = model.config.num_experts
+        expert_slots = [int(slots[e]) for e in range(num_experts)]
+        expert_to_col: dict[int, list[tuple[int, int]]] = {}
         for j in range(k):
-            by_slot: dict[int, list[int]] = {}
             for i in range(B):
                 if bool(valid_cpu[i, j]):
-                    by_slot.setdefault(int(routed_cpu[i, j]), []).append(i)
-            groups.extend((j, s_i, rows) for s_i, rows in by_slot.items())
-        # 5) Gather per slot on the device using host-built INTEGER indices
-        #    (static shapes, no nonzero(), no implicit D2H in the loop).
+                    e_id = int(expert_ids[i, j])
+                    expert_to_col.setdefault(e_id, []).append((j, i))
+        groups: list[tuple[int, int, list[int]]] = []
+        for e in range(num_experts):
+            s_i = expert_slots[e]
+            if not (0 <= s_i < S):
+                continue
+            for j, i in expert_to_col.get(e, []):
+                groups.append((j, s_i, [i]))
+        # 5) Gather per (expert, slot, row) on the device using host-built
+        #    INTEGER indices (static shapes, no nonzero(), no implicit D2H in
+        #    the loop).
         for j, s_i, rows in groups:
             idx = torch.tensor(rows, dtype=torch.long, device=dev)
             y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 80** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/106#issuecomment-5489444947) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 4869f52](https://github.com/Performant-Labs/FreeToken-Intel/commit/4869f52b0059696570b68d676d8647cbd07882e3) · run [#33474221598](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33474221598) · 2026-08-31 23:40 MDT / 2026-09-01 05:40 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary

The offload MoE path accumulated expert outputs in **slot-major** order (for j in range(top_k): for slot in routed), while the in-VRAM path used **expert-major** order (for e in range(num_experts): for slot in range(top_k)). Float32 is non-associative, so the two orderings produce a ~1e-7 ULP difference that the chaotic Gated-Delta-Net recurrence in Qwen3.5 amplifies over decode steps until the greedy argmax flips on B70.

This was the root cause of the B70 fused-vs-offload argmax divergence that forced the CPU-reference workaround in PR #91.

## Root cause

For a B=1 decode with top_k=2:
- In-VRAM: out[0] = w[0]*expert_a(x) + w[1]*expert_b(x) (expert-major)
- Offload: out[0] = w[j0]*expert_s0(x) + w[j1]*expert_s1(x) (slot-major)

Same 2 terms, different addition order → different float32 ULPs. The Gated-Delta-Net recurrence (s = s * g_t; s += k * delta) with g_t < 1 is chaotic: relative errors are amplified by ~1/g_t per step, so 1e-7 at step 1 becomes a logit-level difference by step 7.

## Fix

Reorder the offload group-building loop to **expert-major** (for e in range(num_experts) outer, for j in range(top_k) inner), matching the in-VRAM path exactly. The gather loop body is unchanged -- only the order of (j, s_i, rows) groups fed to index_add_ changes.

Applied to both qwen3_5_moe and qwen3_moe variants.

## Verification

- CPU: 162/162 tests pass, 0 regressions
- B70: @xpu tests skipped on this box; needs B70 verification that fused-vs-offload argmax now matches (removing the CPU-reference workaround)

Fixes #105


___

### **PR Type**
Bug fix


___

### **Description**
- Reorder offload MoE accumulation to expert-major order

- Match in-VRAM float32 addition sequence exactly

- Apply fix to qwen3_5_moe and qwen3_moe offload paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Offload MoE group building"] -- "reorder loop" --> B["Expert-major order: expert outer, top-k inner"]
  B -- "matches" --> C["In-VRAM accumulation order"]
  C -- "fixes" --> D["Float32 ULP divergence / greedy argmax flip"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Reorder offload MoE groups to expert-major in qwen3_5_moe</code></dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li>Replace slot-major group building with expert-major grouping keyed by <br>expert id<br> <li> Build <code>groups</code> per expert and top-k column in ascending order to mirror <br>in-VRAM loop<br> <li> Preserve static integer index gather and <code>index_add_</code> accumulation <br>without device sync</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/106/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+27/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Reorder offload MoE groups to expert-major in qwen3_moe</code>&nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_moe/__init__.py

<ul><li>Replace slot-major group building with expert-major grouping keyed by <br>expert id<br> <li> Build <code>groups</code> in expert-outer, column-inner order to match in-VRAM <br>accumulation<br> <li> Retain static integer index gather and stale slot bounds checks</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/106/files#diff-7df44a0f5eb5c411dc8b6f5d672093944a031ba3e91e79a23781674f3ceb1a3e">+27/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___