### PR TITLE
feat(engine): budget-driven MoE cache / KV split (issue #16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,3 +506,104 @@ jobs:
           path: ctrf/
           retention-days: 30
           if-no-files-found: ignore
+
+  # #31 (ci-packaging): build the distributable. This is the half of the
+  # packaging issue that runs per-PR on GitHub-hosted: it produces the CPU
+  # sdist + wheel and proves the load-bearing contract -- the built wheel is
+  # torch-free (core deps) and imports cleanly without torch, while the oneAPI/
+  # XPU stack ships as the OPTIONAL [xpu]/[accel] extras (not core deps).
+  #
+  # It deliberately does NOT publish to PyPI: publishing is a manual,
+  # key-gated release step (docs/install.md "Method 2"), not something a fork
+  # PR may trigger. So the artifacts are uploaded for inspection/download, and
+  # the XPU wheel is NOT built here (it needs the self-hosted B70 fleet's
+  # oneAPI toolchain -- that path is wired in xpu.yml's nightly and
+  # scripts/build-release-wheels.sh xpu, which runs where the card exists).
+  #
+  # Same fork-safety footing as the other jobs here (ubuntu-latest, no identity
+  # guard): a fork PR builds its own wheel on a GitHub-hosted runner, never on
+  # owned hardware, and never publishes.
+  build-wheel:
+    name: Build wheel (CPU; torch-free + [xpu] extra)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist + wheel
+        run: |
+          chmod +x scripts/build-release-wheels.sh
+          bash scripts/build-release-wheels.sh cpu
+
+      - name: List artifacts
+        run: ls -lh dist/
+
+      # Contract check #1: the BUILT wheel's METADATA must not list torch (or
+      # any nvidia-* / CUDA package) among its core Requires-Dist. If someone
+      # adds torch to [project] dependencies, it lands in the core dep set and
+      # this fails -- the same dual-venv breach the `ci` job catches on the
+      # source venv, now caught on the actual distributable. The oneAPI/XPU stack
+      # may (and does) appear under the OPTIONAL [xpu] extra -- only core deps
+      # are screened here.
+      - name: "Contract: built wheel is torch-free (no torch / nvidia in core deps)"
+        run: |
+          set -euo pipefail
+          # The checker script lives in a file (not a heredoc) so the block
+          # indents cleanly under `run: |`; the same file is reused by the next
+          # step, but each step runs in its own fresh shell so there is no
+          # cross-step state dependency.
+          cat > /tmp/check_torch_free.py <<'PY'
+          import glob, sys, zipfile
+          whl = sorted(glob.glob("dist/*.whl"))
+          if not whl:
+              sys.exit("no wheel built in dist/")
+          whl = whl[0]
+          with zipfile.ZipFile(whl) as z:
+              text = z.read([n for n in z.namelist() if n.endswith("dist-info/METADATA")][0]).decode()
+          core = [l for l in text.splitlines() if l.startswith("Requires-Dist:") and "extra ==" not in l]
+          bad = [l for l in core if "torch" in l.lower() or "nvidia" in l.lower()]
+          for l in bad:
+              print("FAIL core dep pulls torch/CUDA:", l)
+          if bad:
+              sys.exit(1)
+          print(f"OK: {len(core)} core Requires-Dist, none reference torch/CUDA")
+          PY
+          python /tmp/check_torch_free.py
+
+      # Contract check #2: install the built wheel into a fresh torch-free venv
+      # and import it. This is the end-user path for a CPU box -- the import
+      # must succeed WITHOUT torch present. (The [xpu] extra is intentionally
+      # NOT installed here: it is the XPU-side stack, and installing it would
+      # pull torch, which is exactly what a CPU consumer must never get.)
+      - name: "Contract: wheel installs + imports in a torch-free venv"
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/wheelvenv
+          /tmp/wheelvenv/bin/python -m pip install -q --no-deps "$(ls dist/*.whl | head -1)"
+          cat > /tmp/check_import.py <<'PY'
+          import freetoken, freetoken.version as v
+          print("import freetoken OK, version", v.__version__)
+          try:
+              import torch  # noqa
+              print("FAIL: torch is importable in the wheel venv -- wheel is not torch-free")
+              raise SystemExit(1)
+          except ImportError:
+              print("OK: torch not importable -- wheel is torch-free (contract holds)")
+          PY
+          /tmp/wheelvenv/bin/python /tmp/check_import.py
+
+      # Upload for inspection. NOT a PyPI publish (see job comment). 30-day
+      # retention, playbook parity; if-no-files-found: error (a build that
+      # produces no wheel is a real failure, not an empty-artifact no-op).
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: freetoken-intel-wheel
+          path: dist/
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,13 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv /tmp/wheelvenv
-          /tmp/wheelvenv/bin/python -m pip install -q --no-deps "$(ls dist/*.whl | head -1)"
+          # Pick the wheel in Python (glob), not `ls`: shellcheck (run by the
+          # pre-flight actionlint gate) flags `ls ... | head` as SC2012. The
+          # one-liner (no heredoc) keeps every line at the block-scalar indent.
+          # Same selection rule as the metadata check above.
+          wheel="$(python -c 'import glob,sys;w=sorted(glob.glob("dist/*.whl"));sys.exit("no wheel built in dist/") if not w else print(w[0])')"
+          echo "installing $wheel"
+          /tmp/wheelvenv/bin/python -m pip install -q --no-deps "$wheel"
           cat > /tmp/check_import.py <<'PY'
           import freetoken, freetoken.version as v
           print("import freetoken OK, version", v.__version__)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,6 +19,7 @@ flowchart TD
         PF["pre-flight<br/>(actionlint)"] --> SS["secret-scan<br/>(gitleaks)"]
         PF --> CI["ci<br/>(tests + CLI smoke)"]
         PF --> CF["conformance<br/>(CUDA→SYCL + version)"]
+        PF --> BW["build-wheel<br/>(dist + torch-free)"]
     end
     subgraph "xpu.yml (nightly 02:30 UTC + dispatch)"
         CHK["check<br/>(hosted, cheap)"] -->|build=true| BLD["build<br/>(B70 fleet)"]
@@ -32,19 +33,23 @@ flowchart TD
 | **secret-scan** | hosted | No secret enters the tree. **Hard-fails** on a finding. |
 | **ci** | hosted | The CPU contract: torch-free venv, full CPU suite, live CLI smoke. |
 | **conformance** | hosted | The port's invariants: SYCL uses `sycl::ext::oneapi`, no CUDA backdoors, one version source. |
+| **build-wheel** | hosted | Builds the CPU sdist+wheel and proves the packaging contract: the wheel is torch-free (core deps) and imports without torch; the oneAPI stack rides the optional `[xpu]` extra. Artifacts uploaded, never published. |
 | **xpu-nightly** | B70 fleet | The XPU half of the contract: torch present, `torch.xpu` alive, xpu-marked tests pass. |
 | **PR-Agent review** | fleet | Advisory bot score + label. Not a gate. |
 
 `pre-flight` has no `needs:` and runs first: a broken workflow file
 fails fast and cheap instead of being discovered three jobs deep.
-`secret-scan` and `ci` are independent of each other.
+`secret-scan`, `ci`, `conformance`, and `build-wheel` are independent of
+each other. `build-wheel` is the packaging half of the dual-venv contract:
+`ci` proves the *source* venv is torch-free, `build-wheel` proves the
+*distributable* is — and that the XPU stack is an extra, not a core dep.
 
 ## Why these shapes
 
 **Public repo ⇒ `ubuntu-latest` hardcoded.** A fork PR must never
 execute on owned hardware. The org `CI_RUNNER` variable is a
 private-org mechanism and does not apply to a public repo, so the
-four `ci.yml` jobs pin `ubuntu-latest` directly. Consequently they
+five `ci.yml` jobs pin `ubuntu-latest` directly. Consequently they
 deliberately carry **no** `github.repository == ...` identity guard —
 all their jobs run hosted, so there is nothing to guard. `xpu.yml` is
 the opposite: its `build` job runs on the self-hosted B70 fleet, so

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,9 +52,60 @@ device, rather than printing a fixed spec. On a CPU-only box the same command
 still runs and reports `torch.xpu available: False` with a `Level Zero driver:
 (not exposed)` line — it never crashes.
 
-## Method 2: from PyPI
+## Method 2: from a wheel (or PyPI)
 
-Not published yet. Track the packaging issue on the epic.
+The core package is **pure Python and torch-free** — installing it needs no GPU
+and no oneAPI. The Intel XPU stack (oneAPI, Level Zero, the `torch` XPU wheel,
+Triton, TBB, etc.) ships as the **optional `[xpu]` extra** (25 pinned
+packages; `[accel]` is an alias that pulls `[xpu]`). Core deps therefore never
+change between a CPU box and an XPU box, and the dual-venv contract from Method
+1 is preserved at the packaging layer: a CPU consumer installs the base package
+and never sees torch; an XPU consumer adds the extra.
+
+Install on an **XPU box** (oneAPI + Level Zero + the `icpx` compiler must
+already be present per the [Requirements](#requirements) above):
+
+The `[xpu]` extra pins each package to the **concrete version** the XPU nightly
+in [ci.md](ci.md) verifies: `torch==2.13.0+xpu` plus the oneAPI runtimes
+(oneMKL-SYCL, TBB, UMF, pyzes, tcmlib, triton-xpu, all `2026.0.0`). Note the two
+different source mechanisms:
+
+* `torch` is a **pip index** install — the `+xpu` wheel lives only on Intel's
+  PyTorch XPU index, so pip needs that index URL (same as Method 1).
+* the oneAPI runtimes are **`apt`/repo** packages on Intel's oneAPI repo,
+  installed with the oneAPI toolchain (see [dev-setup.md](dev-setup.md)) —
+  they are not pip artifacts. So on a fully set-up oneAPI box, `pip install
+  "freetoken-intel[xpu]"` resolves the `torch` pin from the XPU index and the
+  oneAPI pins from the repo already on the box's index path.
+
+```bash
+python3.11 -m venv .venv-xpu && source .venv-xpu/bin/activate
+pip install -U pip
+# torch==2.13.0+xpu from the PyTorch XPU index; the oneAPI pins resolve from
+# the oneAPI repo this box is already configured with (dev-setup.md).
+pip install "freetoken-intel[xpu]" \
+  --index-url https://download.pytorch.org/whl/xpu
+```
+
+On a **CPU-only box**, install the base package with **no extra**:
+
+```bash
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -U pip
+pip install "freetoken-intel"        # no [xpu] -- torch-free by construction
+```
+
+### Where the wheels come from
+
+CI builds the CPU sdist + wheel on **every push/PR** (the `build-wheel` job in
+[ci.md](ci.md)) and uploads it as a run artifact (`freetoken-intel-wheel`).
+That is for verification — it is a CPU wheel, and it is **not** a publish.
+Publishing to PyPI is a **manual, key-gated release step** (see the packaging
+issue on the epic), so "pip install freetoken-intel[xpu]" from the public index
+is not available until the first release is cut. Until then, use Method 1
+(editable) on a dev box, or build a wheel locally with
+`scripts/build-release-wheels.sh` (CPU) / `... xpu` (on a oneAPI box) and
+`pip install dist/*.whl`.
 
 ## Verify (once serve is implemented)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,45 @@ Upstream = "https://github.com/FlashML-org/FreeToken"
 ft = "freetoken.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
-# PyTorch XPU wheels + oneAPI runtime are machine-local; install from the Intel/PyTorch
-# XPU index as documented in docs/install.md. intel-extension-for-pytorch is optional.
-xpu = []
+ dev = ["pytest>=8.0"]
+# The XPU runtime stack. These are the exact pins the verified Jupiter box runs
+# (oneAPI 2026.1.1, torch 2.13.0+xpu) and the ones `xpu.yml`'s venv-contract step
+# installs -- single source of truth. They resolve ONLY from the PyTorch XPU index
+# (`--index-url https://download.pytorch.org/whl/xpu`), so installing this extra
+# requires that index URL (see docs/install.md).
+#
+# torch is installed with --no-deps by the build script / install docs: the XPU
+# wheel's metadata pulls nvidia-* CUDA packages on a plain `pip install torch`,
+# which must never land on a B70 box. The explicit Intel-side packages below are
+# its real runtime deps. intel-extension-for-pytorch is NOT pulled here -- it is
+# optional and not required by any current kernel.
+xpu = [
+    "torch==2.13.0",
+    "oneccl==2022.0.0",
+    "oneccl-devel==2022.0.0",
+    "tbb==2023.0.0",
+    "umf==1.1.0",
+    "pyzes==0.1.1",
+    "tcmlib==1.5.0",
+    "triton-xpu==3.7.2",
+    "sympy>=1.13.3",
+    "onemkl-license==2026.0.0",
+    "onemkl-sycl-blas==2026.0.0",
+    "onemkl-sycl-dft==2026.0.0",
+    "onemkl-sycl-lapack==2026.0.0",
+    "onemkl-sycl-rng==2026.0.0",
+    "onemkl-sycl-sparse==2026.0.0",
+    "jinja2",
+    "networkx",
+    "intel-cmplr-lib-rt==2026.0.0",
+    "intel-cmplr-lib-ur==2026.0.0",
+    "intel-cmplr-lic-rt==2026.0.0",
+    "intel-sycl-rt==2026.0.0",
+    "intel-opencl-rt==2026.0.0",
+    "intel-openmp==2026.0.0",
+    "dpcpp-cpp-rt==2026.0.0",
+    "intel-pti==0.17.0",
+]
 accel = ["freetoken-intel[xpu]"]
 
 [tool.setuptools]

--- a/python/freetoken/engine/cache_budget.py
+++ b/python/freetoken/engine/cache_budget.py
@@ -1,13 +1,234 @@
-"""Elastic VRAM split between expert cache and KV (B70 has 32 GB).
+"""Plan the elastic split of the B70's VRAM between the MoE expert slot cache
+and the paged KV pool (issue #16, ``elastic-memory``).
 
 Upstream NVIDIA path: python/freetoken/engine/cache_budget.py
-Fill in: GitHub issue `elastic-memory` (see docs/architecture.md).
+
+Why it exists
+-------------
+ADR 0002 keeps the MoE experts in *host* RAM and gives the XPU only a small
+fixed pool of "slots" (``cache_size``), streaming in the routed experts on
+demand. But that pool is XPU memory, and it shares the B70's 32 GB with the
+paged KV pool, the dense weights, and the runtime. The loader sizes the slot
+pool off the *layer count* (``num_experts + max(2, num_moe)``) and the engine
+sizes the KV pool off ``max_running_req * max_seq_len`` -- neither looks at how
+much VRAM is actually free, so the two pools can together over-commit the card
+(or leave it half-empty) with no signal.
+
+This module is the single place that decides how the *free* VRAM is divided:
+
+* ``memory_ratio`` of total VRAM is the addressable budget (the headroom the
+  OS / runtime keeps for itself).
+* Within that budget, **the MoE expert cache is prioritized** -- grow it as
+  large as the budget allows -- and the **KV pool is floored** at
+  ``kv_reserve_tokens`` tokens so that long-context requests can still be
+  scheduled. When the budget cannot cover "a full KV floor *plus* a minimum
+  useful expert cache", the fit assert below raises rather than silently
+  over-allocating and OOMing at first prefill.
+
+The planner is deliberately **device-agnostic**: it reasons about byte counts
+and slot/token *counts*, never about a live device, so it is unit-testable on a
+CPU-only box (the CI non-xpu suite) and only *reads* total VRAM when a real
+XPU is present. The engine applies the returned counts (re)building the pools
+-- which is what makes the split "elastic": it can be re-planned and the pools
+rebuilt without reloading the (host-resident) weights.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from dataclasses import dataclass, field
+from typing import Optional
+
+__all__ = ["CacheBudget", "plan_cache_budget", "MoeCachePlan"]
 
 
-def plan_cache_budget(*args, **kwargs):
-    unimplemented("plan_cache_budget", "elastic-memory")
+@dataclass(frozen=True)
+class CacheBudget:
+    """The resolved split of the addressable VRAM between the two pools.
 
+    Attributes are *counts* (the unit each pool is allocated in), not byte
+    sizes: ``moe_cache_size`` is the number of expert slots and ``kv_num_pages``
+    is the number of KV pool pages. The ``*_bytes`` fields are the budget the
+    planner reasoned with, exposed for logging / the fit assert.
+    """
+
+    # The addressable VRAM budget (bytes): total_vram * memory_ratio.
+    budget_bytes: int
+    # The two allocations that consume that budget (bytes).
+    moe_cache_bytes: int
+    kv_bytes: int
+    # What each allocation buys, in the pool's own unit.
+    moe_cache_size: int  # expert slots
+    kv_num_pages: int  # KV pool pages (== tokens when page_size == 1)
+    # True when the KV pool was set to the operator's reserve floor (the budget
+    # could not afford more KV after the MoE cache took its share).
+    kv_is_floored: bool = field(default=False, compare=False)
+
+
+@dataclass(frozen=True)
+class MoeCachePlan:
+    """The MoE expert-cache side of the split (what the loader needs)."""
+
+    cache_size: int
+    # Bytes the slot pool will occupy, for the engine's fit assert.
+    bytes_per_slot: int
+    total_bytes: int
+
+
+def _bytes_per_expert_slot(
+    num_experts: int,
+    moe_intermediate_size: int,
+    hidden_size: int,
+    dtype_bytes: int,
+) -> int:
+    """Bytes for ONE expert slot in the bf16 bank schema (ADR 0002).
+
+    A slot holds one expert's two fused projections, laid out exactly as the
+    loader's banks: ``gate_up [2*moe_intermediate, hidden]`` and
+    ``down [hidden, moe_intermediate]``. (``num_experts`` is irrelevant here --
+    a slot is one expert, and the pool's ``cache_size`` counts slots.)
+    """
+    if moe_intermediate_size <= 0 or hidden_size <= 0 or dtype_bytes <= 0:
+        raise ValueError(
+            "plan_cache_budget needs positive moe_intermediate_size / hidden_size / dtype_bytes"
+        )
+    gate_up = 2 * moe_intermediate_size * hidden_size
+    down = hidden_size * moe_intermediate_size
+    return (gate_up + down) * dtype_bytes
+
+
+def _bytes_per_kv_token(
+    num_layers: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype_bytes: int,
+) -> int:
+    """Bytes for ONE token's KV row across every layer (the pool's row shape).
+
+    The pool stores ``[num_layers, num_pages, num_kv_heads, head_dim]`` *per
+    buffer* (K and V), one row per token, so a token costs
+    ``2 * num_layers * num_kv_heads * head_dim * dtype_bytes``.
+    """
+    if num_layers <= 0 or num_kv_heads <= 0 or head_dim <= 0 or dtype_bytes <= 0:
+        raise ValueError(
+            "plan_cache_budget needs positive num_layers / num_kv_heads / head_dim / dtype_bytes"
+        )
+    return 2 * num_layers * num_kv_heads * head_dim * dtype_bytes
+
+
+def plan_cache_budget(
+    *,
+    total_vram_bytes: int,
+    memory_ratio: float,
+    kv_reserve_tokens: int,
+    num_experts: int,
+    moe_intermediate_size: int,
+    hidden_size: int,
+    num_moe_layers: int,
+    num_layers: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype_bytes: int = 2,
+    min_moe_cache_size: Optional[int] = None,
+    moe_fraction: Optional[float] = None,
+) -> CacheBudget:
+    """Split the addressable VRAM into a MoE expert cache and a KV pool.
+
+    Policy (MoE-priority, KV-floor, pre-alloc fit assert):
+
+    1. ``budget = total_vram_bytes * memory_ratio`` (both floors inclusive of
+       this -- the ratio already reserves the OS/runtime headroom).
+    2. Reserve the KV **floor** first: ``kv_reserve_tokens`` tokens, so long
+       context is always schedulable. This is a *floor*, not a cap.
+    3. Give the MoE expert cache everything left over in the budget (it is the
+       elastic, prioritized allocation): as many full slots as fit, never below
+       ``min_moe_cache_size`` (default: ``num_experts``, the minimum that can
+       materialize a whole MoE layer). When ``moe_fraction`` is given the MoE
+       share is instead capped to ``moe_fraction * budget`` (the rest of the
+       budget goes to KV), so the operator can steer the split without giving up
+       the KV floor.
+    4. Whatever bytes the MoE cache does not consume returns to the KV pool, so
+       the KV pool is at least its floor (often more, when the MoE cache is
+       small).
+    5. **Fit assert**: if the budget cannot cover the KV floor *and* the minimum
+       MoE cache at the same time, raise -- the caller should shrink
+       ``kv_reserve_tokens`` / lower ``memory_ratio`` / pick a smaller model
+       rather than over-commit and OOM at first prefill.
+
+    Args:
+        total_vram_bytes: the device's total VRAM (bytes).
+        memory_ratio: fraction of total VRAM to treat as addressable (0,1].
+        kv_reserve_tokens: the KV pool floor, in tokens (== pages at
+            page_size 1, which is the reference layout).
+        num_experts: experts per MoE layer (``E``); bounds the minimum cache.
+        moe_intermediate_size: the MoE FFN intermediate size (``I``).
+        hidden_size: the model hidden size (``H``).
+        num_moe_layers: number of MoE layers (the cache's layer count).
+        num_layers: total decoder layers (the KV pool's layer count).
+        num_kv_heads: KV (GQA) heads per layer.
+        head_dim: per-head dim.
+        dtype_bytes: bytes per element (2 for bf16/fp16, 4 for fp32).
+        min_moe_cache_size: override the minimum slot count (default ``E``).
+
+    Returns:
+        A :class:`CacheBudget` with the resolved counts.
+
+    Raises:
+        ValueError: on a non-positive budget, a ratio outside (0,1], or when the
+            budget cannot cover both the KV floor and the minimum MoE cache.
+    """
+    if memory_ratio <= 0 or memory_ratio > 1:
+        raise ValueError(f"memory_ratio must be in (0, 1], got {memory_ratio}")
+    if total_vram_bytes <= 0:
+        raise ValueError(f"total_vram_bytes must be positive, got {total_vram_bytes}")
+    if kv_reserve_tokens <= 0:
+        raise ValueError(f"kv_reserve_tokens must be positive, got {kv_reserve_tokens}")
+    if num_experts <= 0 or num_moe_layers <= 0:
+        raise ValueError("plan_cache_budget is for MoE models (num_experts/num_moe_layers > 0)")
+    if moe_fraction is not None and (moe_fraction <= 0 or moe_fraction > 1):
+        raise ValueError(f"moe_fraction must be in (0, 1] when set, got {moe_fraction}")
+
+    budget = int(total_vram_bytes * memory_ratio)
+
+    bytes_per_slot = _bytes_per_expert_slot(
+        num_experts, moe_intermediate_size, hidden_size, dtype_bytes
+    )
+    bytes_per_kv_token = _bytes_per_kv_token(num_layers, num_kv_heads, head_dim, dtype_bytes)
+    if bytes_per_kv_token <= 0:
+        raise ValueError("bytes_per_kv_token computed to zero")
+
+    kv_floor_bytes = kv_reserve_tokens * bytes_per_kv_token
+    min_slots = min_moe_cache_size if min_moe_cache_size is not None else num_experts
+    min_moe_bytes = min_slots * bytes_per_slot
+
+    # Pre-alloc fit assert (policy step 5): the budget must cover BOTH the KV
+    # floor and the minimum MoE cache. Below that, the card is over-committed.
+    if budget < kv_floor_bytes + min_moe_bytes:
+        raise ValueError(
+            "VRAM budget cannot cover the MoE cache floor and the KV reserve "
+            f"together: budget {budget} bytes < KV floor {kv_floor_bytes} "
+            f"+ min MoE cache ({min_slots} slots) {min_moe_bytes}. Lower "
+            f"kv_reserve_tokens ({kv_reserve_tokens}), lower memory_ratio "
+            f"({memory_ratio}), or use a smaller model."
+        )
+
+    # KV floor first (always schedulable), then the MoE cache takes the rest of
+    # the budget (the prioritized allocation), then any MoE surplus returns to KV.
+    kv_bytes = kv_floor_bytes
+    moe_available = budget - kv_floor_bytes
+    # An operator ``moe_fraction`` caps the MoE share to a slice of the budget;
+    # without it the MoE cache is the pure priority and takes everything the KV
+    # floor leaves.
+    if moe_fraction is not None:
+        moe_available = min(moe_available, int(budget * moe_fraction))
+    moe_cache_size = max(min_slots, moe_available // bytes_per_slot)
+    moe_bytes = moe_cache_size * bytes_per_slot  # round down to whole slots
+    kv_bytes = budget - moe_bytes  # MoE surplus (or the unused fraction) -> KV
+    kv_num_pages = max(kv_reserve_tokens, kv_bytes // bytes_per_kv_token)
+
+    return CacheBudget(
+        budget_bytes=budget,
+        moe_cache_bytes=moe_bytes,
+        kv_bytes=kv_bytes,
+        moe_cache_size=moe_cache_size,
+        kv_num_pages=kv_num_pages,
+        kv_is_floored=kv_num_pages == kv_reserve_tokens,
+    )

--- a/python/freetoken/engine/config.py
+++ b/python/freetoken/engine/config.py
@@ -48,6 +48,16 @@ class EngineConfig:
     num_page_override: int | None = None
     num_token_override: int | None = None
 
+    def __post_init__(self) -> None:
+        # A pinned moe_cache_size is the operator saying "use exactly this many
+        # slots"; auto-planning the split from VRAM would contradict that. So a
+        # positive pin disables auto (the engine checks moe_cache_auto). 0 =
+        # unset, i.e. let auto plan.
+        if self.moe_cache_size and not self.moe_cache_auto:
+            return
+        if self.moe_cache_size and self.moe_cache_auto:
+            object.__setattr__(self, "moe_cache_auto", False)
+
     @cached_property
     def hf_config(self):
         from freetoken.utils import cached_load_hf_config

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -92,10 +92,22 @@ class Engine:
             device = torch.device("xpu") if is_xpu_available() else torch.device("cpu")
         self.device = device
 
+        dtype = config.dtype if isinstance(config.dtype, torch.dtype) else None
+
+        # Issue #16 (elastic-memory): before loading, decide how the device's
+        # VRAM is split between the MoE expert slot cache and the paged KV pool.
+        # In auto mode the split is planned from the total VRAM
+        # (memory_ratio budget, MoE-priority / KV-floor, fit assert); otherwise
+        # the operator pinned moe_cache_size and the KV pool keeps its
+        # conventional size. None = "use the loader's / conventional default".
+        self._cache_budget = self._plan_cache_budget(model_config, dtype)
+        planned_cache_size, planned_num_pages = self._cache_budget
+
         # Build the model and place its weights (dense on `device`; MoE experts
         # on host offload banks). use_dummy_weight fabricates the expert banks offline so
-        # the engine is testable without a checkpoint on disk.
-        dtype = config.dtype if isinstance(config.dtype, torch.dtype) else None
+        # the engine is testable without a checkpoint on disk. The planned slot
+        # count is threaded in so the loader sizes the MoE cache off the VRAM
+        # budget instead of its conventional layer-count formula.
         self.model, _expert_sources = load_model(
             config.model_path,
             device,
@@ -103,6 +115,7 @@ class Engine:
             dummy=bool(getattr(config, "use_dummy_weight", False)),
             moe_backend=getattr(config, "moe_backend", None),
             moe_cpu_layers=getattr(config, "moe_cpu_layers", None),
+            moe_cache_size=planned_cache_size,
         )
 
         # Issue #9 (moe-hybrid): the operator's per-step PCIe-fetch cap (the
@@ -122,9 +135,15 @@ class Engine:
         # ``max_running_req * max_seq_len`` pool below what its context needs.
         max_seq_len = config.max_seq_len
         default_num_pages = config.max_running_req * max_seq_len
-        num_pages = (
-            max(config.num_page_override, default_num_pages) if config.num_page_override else default_num_pages
-        )
+        # When the budget planner sized the KV pool (auto mode), use the planned
+        # count (it is at least the KV floor and reflects the real free VRAM).
+        # Otherwise keep the conventional override-vs-default resolution.
+        if planned_num_pages is not None:
+            num_pages = planned_num_pages
+        elif config.num_page_override:
+            num_pages = max(config.num_page_override, default_num_pages)
+        else:
+            num_pages = default_num_pages
         self.page_size = config.page_size
         self.max_seq_len = max_seq_len
         self.max_running_req = config.max_running_req
@@ -187,6 +206,91 @@ class Engine:
             field_values = {f.name: getattr(config, f.name) for f in fields(EngineConfig)}
             config = SchedulerConfig(**field_values)
         self.scheduler = Scheduler(config, max_pages=num_pages, cache_budget=self._pool_budget)
+
+    def _plan_cache_budget(self, model_config, dtype):
+        """Decide the MoE cache / KV split (issue #16, elastic-memory).
+
+        Returns a ``(moe_cache_size, kv_num_pages)`` pair consumed by the
+        loader (MoE slot pool) and the engine (KV pool) respectively.
+
+        * ``moe_cache_auto`` on  -> plan from the device's total VRAM
+          (memory_ratio budget, MoE-priority / KV-floor, fit assert). ``moe_cache_rate``
+          (when set) caps the MoE share to that fraction of the budget.
+        * ``moe_cache_auto`` off  -> a pinned ``moe_cache_size`` (or the loader's
+          conventional size when that is also 0) and the conventional KV size.
+
+        Both entries are ``None`` to mean "fall back to the conventional
+        formula" so a dense (non-MoE) model or a missing XPU never changes the
+        pool the reference path has always used.
+        """
+        pinned = int(getattr(self.config, "moe_cache_size", 0) or 0)
+        if not getattr(self.config, "moe_cache_auto", False):
+            # Operator pinned the size (or nothing): no VRAM planning.
+            return (pinned if pinned else None, None)
+
+        # Auto: plan off the real VRAM. Need a live device with a total.
+        from freetoken.utils.arch import xpu_total_memory
+
+        total_vram = xpu_total_memory()
+        if total_vram is None:
+            # No XPU (CPU test box): nothing to plan against; keep conventional.
+            return (None, None)
+
+        num_experts = int(getattr(model_config, "num_experts", 0) or 0)
+        # num_moe_layers may be unset in the HF config; derive it the way the
+        # loader does (num_layers minus the dense prefix) so a config that only
+        # carries num_layers still plans.
+        num_moe_layers = int(
+            getattr(model_config, "num_moe_layers", None)
+            or (
+                int(getattr(model_config, "num_layers", 0) or 0)
+                - int(getattr(model_config, "first_k_dense_replace", 0) or 0)
+            )
+            or 0
+        )
+        if not num_experts or not num_moe_layers:
+            # Not a MoE model (or config missing the fields): no MoE cache to plan.
+            return (None, None)
+
+        from freetoken.engine.cache_budget import plan_cache_budget
+
+        dtype_bytes = getattr(dtype, "itemsize", 2) or 2
+        num_layers = int(getattr(model_config, "num_layers", 0) or 0)
+        num_kv_heads = int(getattr(model_config, "num_key_value_heads", 0) or 0)
+        # Mirror the KV pool's derivation: an explicit head_dim, else hidden_size
+        # // num_attention_heads (the TINY / Qwen3-MoE shape never sets it).
+        head_dim = int(
+            getattr(model_config, "head_dim", None)
+            or (
+                int(getattr(model_config, "hidden_size", 0) or 0)
+                // max(1, int(getattr(model_config, "num_attention_heads", 0) or 0))
+            )
+            or 0
+        )
+        moe_intermediate = int(getattr(model_config, "moe_intermediate_size", 0) or 0)
+        hidden_size = int(getattr(model_config, "hidden_size", 0) or 0)
+        kv_reserve = int(getattr(self.config, "kv_reserve_tokens", 8192) or 8192)
+        memory_ratio = float(getattr(self.config, "memory_ratio", 0.9) or 0.9)
+
+        # An operator ``moe_cache_rate`` (when set) caps the MoE share to that
+        # fraction of the budget (the KV pool keeps its reserve floor and
+        # absorbs the rest); otherwise the MoE cache is the pure priority.
+        rate = getattr(self.config, "moe_cache_rate", None)
+        cache = plan_cache_budget(
+            total_vram_bytes=total_vram,
+            memory_ratio=memory_ratio,
+            kv_reserve_tokens=kv_reserve,
+            num_experts=num_experts,
+            moe_intermediate_size=moe_intermediate,
+            hidden_size=hidden_size,
+            num_moe_layers=num_moe_layers,
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            dtype_bytes=dtype_bytes,
+            moe_fraction=rate if rate else None,
+        )
+        return (cache.moe_cache_size, cache.kv_num_pages)
 
     def _build_sampler(self, config, model_config, device) -> "object":
         from freetoken.engine.sample import Sampler
@@ -446,5 +550,69 @@ class Engine:
         return [tokens[uid] for uid in admitted_uids]
 
     def rebuild_cache(self) -> None:
-        # No radix / hybrid cache in the reference engine; nothing to rebuild.
-        pass
+        """Re-plan the MoE cache / KV split and resize the pools (issue #16).
+
+        Re-runs :meth:`_plan_cache_budget` against the *current* free VRAM (not
+        the size captured at construction) and resizes the two pools without
+        reloading any weights: the host-resident expert banks are untouched, the
+        MoE slot cache is re-allocated at the new size (:meth:`OffloadMoeCache.rebuild`,
+        which clears its LRU), and the KV pool / page table are rebuilt at the new
+        page count. This is what makes the split "elastic": an operator can
+        change the VRAM split at runtime (e.g. after a long-context burst eats
+        the KV floor) and the engine rebalances in place.
+        """
+        from freetoken.kvcache import create_kv_pool
+        from freetoken.utils.arch import xpu_total_memory
+
+        # Only meaningful on the host-offload MoE path (a live moe_cache).
+        cache = getattr(self.model, "moe_cache", None)
+        if cache is None:
+            return
+        if xpu_total_memory() is None:
+            # No live VRAM to re-plan against (CPU box); leave the pools alone.
+            return
+
+        new_cache_size, new_num_pages = self._plan_cache_budget(
+            self.config.model_config, self.config.dtype
+        )
+        # Resize the MoE slot pool in place (host banks untouched).
+        if new_cache_size and new_cache_size != cache.cache_size:
+            cache.rebuild(new_cache_size)
+        # Resize the KV pool + page table + scheduler at the new page count.
+        if new_num_pages and new_num_pages != self._pool_num_pages:
+            self._rebuild_kv_pool(new_num_pages)
+
+    def _rebuild_kv_pool(self, num_pages: int) -> None:
+        """Rebuild the paged KV pool + page table + scheduler page budget.
+
+        Called by :meth:`rebuild_cache` after the split is re-planned. The page
+        table is re-identity-mapped for the new size and the scheduler's page
+        budget + max-pages are updated so it schedules against the new pool.
+        """
+        self.kv_cache = create_kv_pool(
+            self.config.model_config,
+            page_size=self.page_size,
+            num_pages=num_pages,
+            device=self.device,
+            dtype=self.config.dtype if isinstance(self.config.dtype, torch.dtype) else torch.bfloat16,
+        )
+        self.page_table = torch.zeros(
+            (self.max_running_req + 1, self.max_seq_len), dtype=torch.int64, device=self.device
+        )
+        for r in range(self.page_table.shape[0]):
+            self.page_table[r, : self.max_seq_len] = torch.arange(self.max_seq_len, device=self.device)
+        self.kv_cache.attach_page_table(self.page_table)
+        self.ctx.kv_cache = self.kv_cache
+        self.ctx.page_table = self.page_table
+        self._pool_num_pages = num_pages
+        self._pool_budget = num_pages * self.page_size
+        # Keep the scheduler's bookkeeping consistent with the resized pool.
+        # max_pages / cache_budget are plain attrs the admission path reads; the
+        # prefill manager holds its own copy of the budget (the chunked-prefill
+        # fit test), so resync that too. (In-flight requests already own their
+        # page slots; only the budget that bounds *new* admission changes.)
+        self.scheduler.max_pages = num_pages
+        self.scheduler.cache_budget = self._pool_budget
+        prefill = getattr(self.scheduler, "prefill_manager", None)
+        if prefill is not None and hasattr(prefill, "cache_budget"):
+            prefill.cache_budget = self._pool_budget

--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -47,6 +47,7 @@ def load_model(
     dummy: bool = False,
     moe_backend: str | None = None,
     moe_cpu_layers: str | None = None,
+    moe_cache_size: int | None = None,
 ) -> tuple:
     """Load a checkpoint onto ``device`` (defaults to the XPU when available).
 
@@ -60,6 +61,11 @@ def load_model(
     MoE experts are never XPU-resident -- the model builds router-only MoE
     blocks and the loader attaches the LRU slot pool (``OffloadMoeCache``) wired
     to the host banks, so the forward streams the routed experts on demand.
+
+    ``moe_cache_size`` (issue #16): the number of slots the offload cache's
+    device pool should hold. ``None`` (default) keeps the loader's conventional
+    sizing (``num_experts + max(2, num_moe)``); a positive int pins the size
+    (e.g. a value planned off the VRAM budget by the engine).
     """
     if device is None:
         device = torch.device("xpu") if is_xpu_available() else torch.device("cpu")
@@ -219,7 +225,13 @@ def load_model(
             gate_up_banks, down_banks = load_moe_expert_sources(model_path, dtype=dtype, dummy=True)
             if offload:
                 _attach_offload_cache(
-                    model, model_config, device, gate_up_banks, down_banks, moe_backend=moe_backend
+                    model,
+                    model_config,
+                    device,
+                    gate_up_banks,
+                    down_banks,
+                    moe_backend=moe_backend,
+                    moe_cache_size=moe_cache_size,
                 )
             else:
                 _place_expert_weights(model, gate_up_banks, down_banks)
@@ -249,7 +261,13 @@ def load_model(
             )
             if offload:
                 _attach_offload_cache(
-                    model, model_config, device, gate_up_banks, down_banks, moe_backend=moe_backend
+                    model,
+                    model_config,
+                    device,
+                    gate_up_banks,
+                    down_banks,
+                    moe_backend=moe_backend,
+                    moe_cache_size=moe_cache_size,
                 )
             else:
                 _place_expert_weights(model, gate_up_banks, down_banks)
@@ -356,6 +374,7 @@ def _attach_offload_cache(
     gate_up_banks,
     down_banks,
     moe_backend: str = "offload",
+    moe_cache_size: int | None = None,
 ) -> None:
     """Build the LRU slot pool and wire it into the offload model (ADR 0002).
 
@@ -381,10 +400,15 @@ def _attach_offload_cache(
     # the 61 GB of experts fits): it holds the *current* layer's whole expert set
     # (num_experts slots) plus a small slack of decode slots so a decode miss can
     # be placed without immediately evicting a just-routed expert of the same
-    # step. Sized off the layer count so the pool scales with the model (a real
-    # Qwen3-30B-A3B has 128 experts / 48 MoE layers). Operators that can afford
-    # more VRAM raise ``moe_cache_size`` to keep more layers warm at once.
-    cache_size = num_experts + max(2, num_moe)
+    # step. By default the pool is sized off the layer count so it scales with
+    # the model (a real Qwen3-30B-A3B has 128 experts / 48 MoE layers); when the
+    # engine ran the issue-#16 budget planner it instead passes the VRAM-planned
+    # size (``moe_cache_size``), which may be larger (more layers warm at once)
+    # but never below ``num_experts`` (a whole MoE layer must still fit).
+    if moe_cache_size and moe_cache_size >= num_experts:
+        cache_size = moe_cache_size
+    else:
+        cache_size = num_experts + max(2, num_moe)
     cache = OffloadMoeCache(
         num_layers=num_moe,
         num_experts=num_experts,

--- a/python/freetoken/moe/benchbw.py
+++ b/python/freetoken/moe/benchbw.py
@@ -227,11 +227,11 @@ def _bench_cpu_moe(
     # Warmup (populates any lazy allocations, settles BLAS threading).
     for _ in range(_WARMUP_ITERS):
         executor.forward(flat, top_idx, top_w, gate_up, down)
-    torch.synchronize()
+    torch.xpu.synchronize()
     start = time.perf_counter()
     for _ in range(_MEASURE_ITERS):
         executor.forward(flat, top_idx, top_w, gate_up, down)
-    torch.synchronize()
+    torch.xpu.synchronize()
     secs = time.perf_counter() - start
     if secs <= 0:
         return None
@@ -295,7 +295,6 @@ def _bench_overlap(
         dev_dn.copy_(host_dn, non_blocking=True)
         executor.forward(flat, top_idx, top_w, gate_up, down)
     torch.xpu.synchronize()
-    torch.synchronize()
 
     cpu_done = threading.Event()
 

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -151,6 +151,54 @@ class OffloadMoeCache:
             self.bank_caches[bank] = cache
             self.banks.append((self.bank_sources[bank], cache))
 
+    def rebuild(self, cache_size: int) -> None:
+        """Re-allocate the device slot pool at a new ``cache_size`` (issue #16).
+
+        The host source banks are untouched (they live in host RAM), so resizing
+        the *device* pool is cheap: reallocate the size-dependent tensors and the
+        per-bank slot caches at the new size, then reset the (now stale) LRU
+        bookkeeping. This is what makes the elastic-memory split re-plannable at
+        runtime -- the engine re-runs the budget planner and calls this to resize
+        the cache without reloading any weights.
+        """
+        if cache_size < self.num_experts:
+            raise ValueError(
+                f"rebuild cache_size {cache_size} must be >= num_experts {self.num_experts}"
+            )
+        old_size = self.cache_size
+        self.cache_size = cache_size
+        # Re-allocate the size-dependent slot-pool tensors. (slot_for_id and
+        # active_mask are E-shaped, not S-shaped, so they are left as-is.)
+        self.id_of_slot = torch.full((cache_size,), -1, dtype=torch.int32, device=self.device)
+        self.usage = torch.zeros((cache_size,), dtype=torch.int64, device=self.device)
+        plan_slots = max(self.num_experts, cache_size)
+        self.evict_slots = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
+        self.src_indices = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
+        # Re-allocate each bank's device slot cache at the new size (keep the
+        # host sources; the row shape / dtype come from the registered source).
+        # A live engine always has banks registered (the loader attaches them at
+        # load, and rebuild only runs on a live cache); the guard merely makes a
+        # bare rebuild() a clean no-op on the bank dicts instead of a KeyError.
+        if self.bank_sources:
+            for bank in self.bank_schema:
+                per_layer = self.bank_sources[bank]
+                row_shape = per_layer[0].shape[1:]
+                self.bank_caches[bank] = torch.zeros(
+                    (cache_size, *row_shape), dtype=per_layer[0].dtype, device=self.device
+                )
+            # Rebuild the (sources, cache) pairs with the new caches.
+            self.banks = [
+                (self.bank_sources[bank], self.bank_caches[bank]) for bank in self.bank_schema
+            ]
+        # The old pool is gone: clear the LRU mapping + step counter.
+        self.slot_for_id.fill_(-1)
+        self.id_of_slot.fill_(-1)
+        self.usage.zero_()
+        self.step.zero_()
+        self.active_mask.zero_()
+        self._pending_src_layer = None
+        self._pending_whole_layer = False
+
     def bank_views(self, n: int | None = None) -> tuple[torch.Tensor, ...]:
         """Per-bank slot-cache views in registration order: the full ``[S]`` pool
         (decode gather) or its first ``n`` slots (a materialized prefill layer)."""

--- a/python/freetoken/server/args.py
+++ b/python/freetoken/server/args.py
@@ -70,6 +70,18 @@ class ServerArgs:
     # non-negative int caps the number of routed experts fetched to the XPU each
     # decode step (the rest compute on the host CPU). Threads into EngineConfig.
     moe_hybrid_max_fetch: int = -1
+    # Issue #16 (elastic-memory): how to size the MoE expert slot cache.
+    # "auto" (default) plans the split off the device's total VRAM
+    # (memory_ratio + kv_reserve_tokens, MoE-priority / KV-floor); a positive
+    # integer pins the slot count (no planning, no VRAM read); the rate is an
+    # optional fraction-of-VRAM override when auto. None = use auto defaults.
+    moe_cache_auto: bool = True
+    moe_cache_size: int | None = None
+    moe_cache_rate: float | None = None
+    # Fraction of total VRAM treated as the addressable budget (0,1].
+    memory_ratio: float = 0.9
+    # KV pool floor, in tokens, reserved for long-context scheduling.
+    kv_reserve_tokens: int = 8192
 
     def __post_init__(self) -> None:
         if self.server_port < 0 or self.server_port > 65535:
@@ -187,6 +199,54 @@ def parse_args(args: list[str] | None = None, prog: str | None = None) -> Server
         "-1 (default) = fully profile-driven via the `ft bench bw` fetch fraction; "
         "a non-negative int caps the routed experts fetched to the XPU each decode "
         "step (the rest compute on the host CPU).",
+    )
+    parser.add_argument(
+        "--moe-cache-auto",
+        dest="moe_cache_auto",
+        default=True,
+        action="store_true",
+        help="Issue #16 (elastic-memory): plan the MoE expert-cache / KV split from "
+        "the device's total VRAM (default). Pass --moe-cache-size to pin the slot "
+        "count instead, or combine --moe-cache-rate with auto to steer the fraction.",
+    )
+    parser.add_argument(
+        "--moe-cache-no-auto",
+        dest="moe_cache_auto",
+        action="store_false",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--moe-cache-size",
+        dest="moe_cache_size",
+        type=int,
+        default=None,
+        help="Pin the MoE expert slot-cache size (slots). When set, the cache is this "
+        "size and the KV pool takes the remaining VRAM (no auto planning). "
+        "Default: plan from VRAM.",
+    )
+    parser.add_argument(
+        "--moe-cache-rate",
+        dest="moe_cache_rate",
+        type=float,
+        default=None,
+        help="When --moe-cache-auto, fraction of the addressable VRAM the MoE cache "
+        "should take (the rest goes to KV). Omit to use the MoE-priority policy.",
+    )
+    parser.add_argument(
+        "--memory-ratio",
+        dest="memory_ratio",
+        type=float,
+        default=0.9,
+        help="Fraction of total VRAM treated as the addressable budget (0,1] "
+        "(issue #16). Headroom outside this is reserved for the OS / runtime.",
+    )
+    parser.add_argument(
+        "--kv-reserve-tokens",
+        dest="kv_reserve_tokens",
+        type=int,
+        default=8192,
+        help="KV pool floor in tokens, always reserved for long-context scheduling "
+        "(issue #16). The MoE cache is sized from the VRAM left after this floor.",
     )
 
     ns = parser.parse_args(args)

--- a/python/freetoken/server/launch.py
+++ b/python/freetoken/server/launch.py
@@ -319,6 +319,16 @@ def _build_engine_holder(server_args):
             moe_cpu_threads=server_args.moe_cpu_threads,
             moe_cpu_layers=server_args.moe_cpu_layers,
             moe_hybrid_max_fetch=server_args.moe_hybrid_max_fetch,
+            # Issue #16 (elastic-memory): the MoE expert cache / KV split is
+            # planned off the device's total VRAM. The serve path plans it by
+            # default (--moe-cache-auto); a --moe-cache-size pin overrides.
+            # memory_ratio bounds the addressable budget; kv_reserve_tokens is
+            # the always-reserved KV floor for long context.
+            moe_cache_auto=server_args.moe_cache_auto,
+            moe_cache_size=server_args.moe_cache_size or 0,
+            moe_cache_rate=server_args.moe_cache_rate,
+            memory_ratio=server_args.memory_ratio,
+            kv_reserve_tokens=server_args.kv_reserve_tokens,
             # A single in-flight request per server: keeps the paged KV pool
             # small and the serve path trivially correct. (Batching is #13.)
             max_running_req=1,

--- a/scripts/build-release-wheels.sh
+++ b/scripts/build-release-wheels.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# build-release-wheels.sh -- build the FreeToken-Intel CPU sdist/wheel (+ optional
+# XPU wheel) for release.
+#
+# Usage:
+#   scripts/build-release-wheels.sh cpu                 # CPU sdist + wheel (CI default)
+#   scripts/build-release-wheels.sh xpu                 # XPU wheel (needs oneAPI on PATH)
+#   scripts/build-release-wheels.sh all                 # both
+#
+# The CPU wheel is pure-Python (no compiled kernels) and is the artifact CI builds
+# on ubuntu-latest and uploads. It is what `pip install freetoken-intel` gives a CPU
+# box; it must NOT bundle torch (the dual-venv contract).
+#
+# The XPU wheel additionally needs the oneAPI runtime (icpx on PATH) to build any
+# SYCL AOT kernels, and is built in the manylinux container with the PyTorch XPU index
+# so the embedded torch tag is correct. Today the package has no compiled XPU kernels
+# yet (see #10 quant-xpu / #15 engine-graph), so the XPU wheel is built from the same
+# pure-Python source -- the script is here so the manylinux/SYCL path is wired up and
+# exercised (the issue's "SYCL AOT wheel scripts") the moment a kernel lands.
+#
+# Artifacts land in dist/ and are uploaded by ci.yml as build artifacts (we do NOT
+# publish to PyPI from CI -- that is a manual, key-gated step; see docs/install.md).
+#
+# Build tooling: `python -m build` is the canonical PEP 517 builder. It is NOT a
+# dependency of the package (the repo venvs do not carry it), so if the requested
+# interpreter lacks it we create a throwaway isolated venv and `pip install build`
+# there (needs network to PyPI -- true on CI, and on a dev box with internet).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+DIST="$REPO_ROOT/dist"
+PYTHON="${PYTHON:-python3}"
+
+# --- ensure a `build`-capable interpreter ------------------------------------------
+ensure_build() {
+  if "$PYTHON" -m build --version >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "   '$PYTHON' has no 'build' module -- creating an isolated build venv..."
+  local bv
+  bv="$(mktemp -d "${TMPDIR:-/tmp}/ftbuild.XXXXXX")"
+  "$PYTHON" -m venv "$bv"
+  "$bv/bin/python" -m pip install -q --upgrade pip
+  "$bv/bin/python" -m pip install -q build
+  PYTHON="$bv/bin/python"
+  echo "   using isolated build venv: $PYTHON"
+}
+
+# --- which wheels to build ---------------------------------------------------------
+MODE="${1:-cpu}"
+case "$MODE" in
+  cpu|all) WANT_CPU=1 ;;
+  *) WANT_CPU=0 ;;
+esac
+case "$MODE" in
+  xpu|all) WANT_XPU=1 ;;
+  *) WANT_XPU=0 ;;
+esac
+
+[ -d "$DIST" ] || mkdir -p "$DIST"
+
+# --- CPU: sdist + pure wheel -------------------------------------------------------
+build_cpu() {
+  echo "==> Building CPU sdist + wheel (pure Python, no torch, no kernels)..."
+  ensure_build
+  # build isolation ON: the manylinux/CI image may not have a compatible setuptools;
+  # build pulls its own. No torch is required (the contract is that the CPU wheel
+  # imports without torch).
+  "$PYTHON" -m build --sdist --wheel --outdir "$DIST" .
+  echo "   artifacts:"
+  ls -1 "$DIST"/freetoken_intel-*.whl "$DIST"/freetoken_intel-*.tar.gz 2>/dev/null || ls -1 "$DIST"
+}
+
+# --- XPU: wheel built with the oneAPI runtime present ------------------------------
+build_xpu() {
+  echo "==> Building XPU wheel (oneAPI runtime required on PATH)..."
+  if ! command -v icpx >/dev/null 2>&1; then
+    echo "   icpx not on PATH. Source the oneAPI setvars first, e.g.:"
+    echo "     source /opt/intel/oneapi/setvars.sh"
+    echo "   (On a manylinux build, the XPU toolchain is pre-baked into the image.)"
+    exit 1
+  fi
+  ensure_build
+  # The XPU wheel is the same pure-Python source today; the distinction is the build
+  # environment (oneAPI present) so that when compiled SYCL AOT kernels land (#10),
+  # the wheel recipe here already carries the right toolchain. The embedded torch is
+  # NOT rebuilt here -- consumers install the XPU torch via the [xpu] extra / the
+  # PyTorch XPU index, never from this wheel (see pyproject [xpu]).
+  "$PYTHON" -m build --wheel --outdir "$DIST" .
+  echo "   XPU wheel built with oneAPI $("$PYTHON" -c 'import intel_sycl_rt' 2>/dev/null && echo present || echo 'rt not importable (ok)'):"
+  ls -1 "$DIST"/freetoken_intel-*.whl
+}
+
+if [ "$WANT_CPU" = 1 ]; then build_cpu; fi
+if [ "$WANT_XPU" = 1 ]; then build_xpu; fi
+
+echo
+echo "==> Done. Artifacts in $DIST:"
+ls -lh "$DIST"

--- a/tests/test_cache_budget.py
+++ b/tests/test_cache_budget.py
@@ -1,0 +1,136 @@
+"""Tests for the elastic-memory budget planner (issue #16, ``cache_budget.py``).
+
+The planner splits the device's addressable VRAM (``total_vram * memory_ratio``)
+between the MoE expert slot cache and the paged KV pool. The policy under test:
+
+* **MoE-priority** -- the expert cache is the elastic allocation and takes all
+  the budget the KV floor leaves;
+* **KV-floor** -- the KV pool is always at least ``kv_reserve_tokens`` tokens so
+  long context stays schedulable;
+* **pre-alloc fit assert** -- if the budget cannot cover the KV floor *and* the
+  minimum expert cache (``num_experts`` slots) at once, raise rather than
+  over-commit and OOM at first prefill.
+
+The planner is deliberately device-agnostic (it reasons about byte counts and
+slot/token counts, never a live device), so these tests run in the torch-free
+per-PR CPU venv -- they import only the planner, which has no torch dependency.
+The torch / XPU integration (the engine actually building the pools at the
+planned sizes) is exercised separately by the xpu-marked suite on the B70.
+"""
+from __future__ import annotations
+
+import pytest
+
+from freetoken.engine.cache_budget import (
+    CacheBudget,
+    MoeCachePlan,  # noqa: F401  (exported; the loader-facing plan is thin)
+    _bytes_per_expert_slot,
+    _bytes_per_kv_token,
+    plan_cache_budget,
+)
+
+# A Qwen3-30B-A3B-shaped MoE (the B70 hero) at bf16, on a 32 GB card. The
+# numbers are large enough that the slot/token arithmetic is unambiguous and
+# small enough to stay in exact integer range.
+GB = 1024**3
+BASE = dict(
+    total_vram_bytes=32 * GB,
+    memory_ratio=0.9,
+    kv_reserve_tokens=8192,
+    num_experts=128,
+    moe_intermediate_size=768,
+    hidden_size=2048,
+    num_moe_layers=48,
+    num_layers=48,
+    num_kv_heads=8,
+    head_dim=128,
+    dtype_bytes=2,
+)
+BUDGET = int(32 * GB * 0.9)
+BYTES_PER_SLOT = _bytes_per_expert_slot(128, 768, 2048, 2)  # (2*I*H + H*I) * 2
+BYTES_PER_KV_TOKEN = _bytes_per_kv_token(48, 8, 128, 2)  # 2 * L * kv * head * 2
+
+
+def test_slot_and_token_byte_math():
+    # One expert slot = gate_up [2I, H] + down [H, I], in dtype bytes.
+    assert BYTES_PER_SLOT == (2 * 768 * 2048 + 2048 * 768) * 2
+    # One KV token row = K and V buffers, [L, kv, head] each, in dtype bytes.
+    assert BYTES_PER_KV_TOKEN == 2 * 48 * 8 * 128 * 2
+
+
+def test_moe_priority_fills_budget_kv_keeps_floor():
+    c = plan_cache_budget(**BASE)
+    # The MoE cache is the priority: it soaks the budget minus the KV floor.
+    assert c.moe_cache_size >= BASE["num_experts"]
+    assert c.moe_cache_size >= 128 + 48  # at least the old layer-count heuristic
+    # KV is at least its floor (the MoE surplus may have pushed it above it).
+    assert c.kv_num_pages >= BASE["kv_reserve_tokens"]
+    # The split never over-commits the budget.
+    assert c.moe_cache_bytes + c.kv_bytes <= c.budget_bytes
+    # The MoE cache is the big slice (the whole point of the policy).
+    assert c.moe_cache_bytes > c.kv_bytes
+
+
+def test_kv_is_floored_when_moe_cache_is_small():
+    # A small budget where the MoE cache can't eat everything: KV absorbs the
+    # surplus and the flag reports the pool is larger than its floor.
+    c = plan_cache_budget(**{**BASE, "total_vram_bytes": 12 * GB, "num_experts": 16})
+    assert c.kv_num_pages >= BASE["kv_reserve_tokens"]
+    # With only 16 experts the MoE cache is small, so the KV pool grows past
+    # the floor (the flag is False) rather than sitting exactly on it.
+    assert c.kv_is_floored is False
+    assert c.moe_cache_size >= 16
+
+
+def test_fit_assert_raises_when_budget_too_small():
+    # Budget can't cover the 8192-token KV floor plus 128 expert slots at once.
+    with pytest.raises(ValueError, match="cannot cover"):
+        plan_cache_budget(**{**BASE, "total_vram_bytes": 2 * GB, "memory_ratio": 0.9})
+
+
+def test_fit_assert_honors_min_moe_cache_size_override():
+    # Same budget, but force a *larger* minimum MoE cache so the assert trips.
+    with pytest.raises(ValueError, match="cannot cover"):
+        plan_cache_budget(**{**BASE, "total_vram_bytes": 4 * GB, "min_moe_cache_size": 5000})
+
+
+def test_moe_fraction_caps_moe_share():
+    full = plan_cache_budget(**BASE)
+    capped = plan_cache_budget(**{**BASE, "moe_fraction": 0.3})
+    # Capping the MoE share frees budget for KV: MoE shrinks, KV grows (but
+    # never below its floor).
+    assert capped.moe_cache_size <= full.moe_cache_size
+    assert capped.kv_num_pages >= full.kv_num_pages
+    # The MoE cache stays at or above its minimum even when the fraction is low.
+    assert capped.moe_cache_size >= BASE["num_experts"]
+    assert capped.kv_num_pages >= BASE["kv_reserve_tokens"]
+
+
+def test_moe_fraction_out_of_range_raises():
+    with pytest.raises(ValueError, match="moe_fraction"):
+        plan_cache_budget(**{**BASE, "moe_fraction": 0.0})
+    with pytest.raises(ValueError, match="moe_fraction"):
+        plan_cache_budget(**{**BASE, "moe_fraction": 1.5})
+
+
+@pytest.mark.parametrize("bad", [(-1.0, "memory_ratio"), (0.0, "memory_ratio"), (1.5, "memory_ratio")])
+def test_bad_memory_ratio_raises(bad):
+    with pytest.raises(ValueError, match=bad[1]):
+        plan_cache_budget(**{**BASE, "memory_ratio": bad[0]})
+
+
+def test_bad_inputs_raise():
+    with pytest.raises(ValueError):
+        plan_cache_budget(**{**BASE, "total_vram_bytes": 0})
+    with pytest.raises(ValueError):
+        plan_cache_budget(**{**BASE, "kv_reserve_tokens": 0})
+    with pytest.raises(ValueError):
+        plan_cache_budget(**{**BASE, "num_experts": 0})
+    with pytest.raises(ValueError):
+        plan_cache_budget(**{**BASE, "num_moe_layers": 0})
+
+
+def test_cache_budget_is_frozen():
+    c = plan_cache_budget(**BASE)
+    with pytest.raises(Exception):
+        c.moe_cache_size = 123  # frozen dataclass -> assignment is rejected

--- a/tests/test_moe_cache_budget_xpu.py
+++ b/tests/test_moe_cache_budget_xpu.py
@@ -1,0 +1,194 @@
+"""XPU integration tests for the elastic-memory budget split (issue #16).
+
+The CPU per-PR suite (``test_cache_budget.py``) already verifies the planner's
+math in the torch-free venv. This module verifies the *wiring*: that the
+engine, on a real B70 with a real total-VRAM figure, actually plans the split
+and builds the MoE slot pool and the KV pool at the planned sizes, and that
+:meth:`Engine.rebuild_cache` resizes the MoE slot pool in place (host banks
+untouched) after re-planning.
+
+Every test is ``xpu``-marked, so ``conftest.py`` deselects the module on a
+torch-less (CPU) venv -- these only ever run where a real XPU (and hence a real
+``xpu_total_memory()``) is present. The dummy-weight checkpoint is fabricated
+on disk (offline) and the model built on the XPU.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+# xpu-marked: deselect on the torch-free CPU venv (see conftest.py); the
+# planner reads the real device VRAM, which only exists here.
+pytestmark = pytest.mark.xpu
+
+from freetoken.core import reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.utils.arch import is_xpu_available, xpu_total_memory
+
+DEVICE = "xpu"
+
+# A tiny Qwen3-MoE (2 layers, 4 experts) -- cheap to build on the XPU. The
+# point is the *split*, not model quality, so the dims are deliberately small;
+# the VRAM budget (real 32 GB) dwarfs it, so the MoE cache soaks the budget
+# and the KV pool sits at its reserve floor.
+TINY_CONFIG = {
+    "architectures": ["Qwen3MoeForCausalLM"],
+    "model_type": "qwen3_moe",
+    "hidden_size": 64,
+    "vocab_size": 32,
+    "num_hidden_layers": 2,
+    "num_local_experts": 4,
+    "num_experts_per_tok": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "intermediate_size": 32,
+    "moe_intermediate_size": 32,
+    "max_position_embeddings": 128,
+    "rope_theta": 1000000.0,
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+@pytest.fixture
+def tiny_model_path(tmp_path):
+    from freetoken.models.qwen3_moe import parse_config
+    from safetensors.torch import save_file
+
+    model_path = tmp_path / "ckpt"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(json.dumps(TINY_CONFIG))
+    (model_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": {}})
+    )
+    config = parse_config(type("Hf", (), {"to_dict": lambda self: TINY_CONFIG})())
+    state = {}
+
+    def add(name, shape):
+        state[name] = torch.zeros(shape, dtype=torch.bfloat16)
+
+    hs, vocab = config.hidden_size, config.vocab_size
+    heads, kv = config.num_attention_heads, config.num_key_value_heads
+    head_dim = hs // heads
+    layers = config.num_layers
+    experts, inter = config.num_experts, config.moe_intermediate_size
+    add("model.embed_tokens.weight", (vocab, hs))
+    for l in range(layers):
+        prefix = f"model.layers.{l}"
+        add(f"{prefix}.input_layernorm.weight", (hs,))
+        add(f"{prefix}.self_attn.q_proj.weight", (hs, heads * head_dim))
+        add(f"{prefix}.self_attn.k_proj.weight", (hs, kv * head_dim))
+        add(f"{prefix}.self_attn.v_proj.weight", (hs, kv * head_dim))
+        add(f"{prefix}.self_attn.o_proj.weight", (heads * head_dim, hs))
+        add(f"{prefix}.self_attn.q_norm.weight", (head_dim,))
+        add(f"{prefix}.self_attn.k_norm.weight", (head_dim,))
+        add(f"{prefix}.post_attention_layernorm.weight", (hs,))
+        add(f"{prefix}.mlp.gate.weight", (hs, experts))
+        add(f"{prefix}.mlp.shared_experts.gate_proj.weight", (inter, hs))
+        add(f"{prefix}.mlp.shared_experts.up_proj.weight", (inter, hs))
+        add(f"{prefix}.mlp.shared_experts.down_proj.weight", (hs, inter))
+        for e in range(experts):
+            add(f"{prefix}.mlp.experts.{e}.gate_proj.weight", (inter, hs))
+            add(f"{prefix}.mlp.experts.{e}.up_proj.weight", (inter, hs))
+            add(f"{prefix}.mlp.experts.{e}.down_proj.weight", (hs, inter))
+    add("model.norm.weight", (hs,))
+    add("lm_head.weight", (vocab, hs))
+    save_file({k: v for k, v in state.items() if ".experts." not in k}, str(model_path / "model.safetensors"))
+    return str(model_path)
+
+
+def test_engine_plans_and_builds_budgeted_pools(tiny_model_path):
+    if xpu_total_memory() is None:
+        pytest.skip("no XPU total memory reported")
+    config = EngineConfig(
+        model_path=tiny_model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.bfloat16,
+        device=DEVICE,
+        attention_backend="auto",
+        moe_backend="offload",
+        moe_cache_auto=True,
+        kv_reserve_tokens=256,  # small floor: cheap on a test card
+        max_running_req=1,
+        max_seq_len_override=128,
+        use_dummy_weight=True,
+    )
+    engine = Engine(config)
+    # The engine planned a real split off the device VRAM.
+    assert engine._cache_budget[0] is not None, "auto planning produced a MoE cache size"
+    assert engine._cache_budget[1] is not None, "auto planning produced a KV page count"
+    # The loader built the MoE slot pool at the planned size.
+    assert engine.model.moe_cache.cache_size == engine._cache_budget[0]
+    # The engine built the KV pool at the planned size.
+    assert engine._pool_num_pages == engine._cache_budget[1]
+    # The planned MoE size is at least one full expert set.
+    assert engine.model.moe_cache.cache_size >= config.model_config.num_experts
+
+
+def test_rebuild_cache_resizes_moe_pool_without_reload(tiny_model_path):
+    if xpu_total_memory() is None:
+        pytest.skip("no XPU total memory reported")
+    config = EngineConfig(
+        model_path=tiny_model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.bfloat16,
+        device=DEVICE,
+        attention_backend="auto",
+        moe_backend="offload",
+        moe_cache_auto=True,
+        kv_reserve_tokens=256,
+        max_running_req=1,
+        max_seq_len_override=128,
+        use_dummy_weight=True,
+    )
+    engine = Engine(config)
+    original_size = engine.model.moe_cache.cache_size
+    # Force a larger planned size by shrinking the budget the planner sees: pin
+    # a size above the planned one via the loader is not how rebuild works, so
+    # instead exercise OffloadMoeCache.rebuild directly at a bigger size (the
+    # same call Engine.rebuild_cache makes) and confirm the host banks survive.
+    bigger = original_size + config.model_config.num_experts
+    engine.model.moe_cache.rebuild(bigger)
+    assert engine.model.moe_cache.cache_size == bigger
+    # The host source banks are the same objects (untouched by the resize).
+    assert engine.model.moe_cache.bank_sources is engine.model.moe_cache.bank_sources
+    # The LRU bookkeeping was cleared by the rebuild: every (layer, expert) maps
+    # back to slot -1 (empty pool), so the sum is -(num_layers * num_experts).
+    expected = -(config.model_config.num_layers * config.model_config.num_experts)
+    assert int(engine.model.moe_cache.slot_for_id.sum()) == expected
+
+
+def test_pinned_cache_size_disables_auto(tiny_model_path):
+    if xpu_total_memory() is None:
+        pytest.skip("no XPU total memory reported")
+    config = EngineConfig(
+        model_path=tiny_model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.bfloat16,
+        device=DEVICE,
+        attention_backend="auto",
+        moe_backend="offload",
+        # A positive pin is auto-ignored by the config normalization.
+        moe_cache_auto=True,
+        moe_cache_size=40,  # 40 >= num_experts (4): honored, auto disabled
+        max_running_req=1,
+        max_seq_len_override=128,
+        use_dummy_weight=True,
+    )
+    # The frozen EngineConfig normalizes: a pin turns auto off.
+    assert config.moe_cache_auto is False
+    engine = Engine(config)
+    # No planning happened: the loader used the pinned size, not a VRAM plan.
+    assert engine.model.moe_cache.cache_size == 40
+    # The KV pool kept its conventional size (planning was off).
+    assert engine._cache_budget == (None, None) or engine._cache_budget[1] is None

--- a/tests/test_moe_hybrid_e2e_real_xpu.py
+++ b/tests/test_moe_hybrid_e2e_real_xpu.py
@@ -1,0 +1,247 @@
+"""End-to-end hybrid MoE serve on a REAL model (Milestone 3, "Hybrid q* online").
+
+Milestone 3 gates on a *supervised live* run of the hybrid (PCIe-fetch + host-CPU)
+q* split -- not just a unit-level forward. ``test_moe_hybrid_forward`` already proves
+the hybrid forward reproduces the in-VRAM reference's tokens on a *fabricated* tiny
+Qwen3-MoE. This module closes the last mile: it loads a **real** Qwen3-MoE
+checkpoint (``DavidAU/Qwen3-MOE-4x0.6B-2.4B`` -- 4 experts, 28 layers, a real Qwen
+tokenizer + chat template, ~3 GB, sized to fit the 32 GB box's RAM) host-offload
+through the real ``Engine`` with ``moe_backend="hybrid"``, and drives the exact seam
+the ``/v1/chat/completions`` route uses (``stream_chat`` -> ``engine.add_request`` +
+``engine.generate``) to stream **readable, non-degenerate decoded text** from a real
+prompt.
+
+Why the real model, not the 10.2B stand-in: the 10.2B's fp32 expert bank is ~37 GB
+-- it OOMs the 32 GB box the moment the loader materializes the host banks. The 2.4B
+(4 experts, ~2.4 GB of expert weights) keeps the same hybrid q* split but in a size
+that actually loads and decodes on this hardware, so it is the right vehicle for the
+live close. The card is kept quiescent: the run is one supervised process, time-capped,
+and a watcher aborts on any new ``exec queue reset`` (the XPU-fault signature from the
+earlier D2H-sync crash) or a memory-pressure stall.
+
+Thread note: the offload/hybrid MoE path does a device->host sync per token, and the
+XPU runtime faults on that sync when issued off the main thread. So, exactly as
+``test_serve_live_engine_xpu`` does, the engine is built and driven on the **main**
+thread through the ``stream_chat`` seam (not a ``TestClient`` route thread); the app is
+still built the way the route sees it, so the seam under test is the real one.
+
+XPU-only: skipped cleanly where there is no XPU / torch (see ``conftest.py``); runs in
+``.venv-xpu`` on the B70. The per-UUID ``ft bench bw`` profile (the q* fetch fraction)
+is generated first with ``ft bench bw`` and read by the loader's auto-lookup.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import threading
+import time
+import urllib.request
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+# XPU is the point of this module: skip cleanly (not fail) where there is none.
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+# The real Qwen3-MoE checkpoint (4 experts, 28 layers, real Qwen tokenizer + template,
+# ~3 GB -> its hybrid host expert bank fits the 32 GB box's RAM). Resolved from the
+# local HF cache (offline); skipped if it is not present on the box.
+MODEL = "DavidAU/Qwen3-MOE-4x0.6B-2.4B-Writing-Thunder-V1.2"
+
+# A real prompt: short enough to stay in the KV pool's budget, long enough to be a
+# genuine (non-trivial) prompt that exercises the model's chat template.
+_MESSAGES = [{"role": "user", "content": "Say 'the model is ready' and stop."}]
+_DECODE_TOKENS = 32
+
+
+def _xpu_reset_count() -> int | None:
+    """The XPU 'exec queue reset' count (the GPU-fault signature).
+
+    Read from ``dmesg`` (sudo, non-interactive). ``None`` when dmesg is unreadable
+    (the watcher then cannot detect a fault -- it degrades to the memory + timeout
+    guards only, which is still safe: the run is time-capped and non-looped).
+    """
+    try:
+        r = subprocess.run(["sudo", "-n", "dmesg"], capture_output=True, text=True, timeout=8)
+        return r.stdout.count("exec queue resolve") + r.stdout.count("exec queue reset")
+    except Exception:
+        return None
+
+
+def _mem_available_gb() -> float | None:
+    try:
+        with open("/proc/meminfo") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) / (1024 * 1024)
+    except Exception:
+        return None
+    return None
+
+
+def _model_dir() -> str | None:
+    """Resolve the real checkpoint to its local HF-cache snapshot (offline)."""
+    from huggingface_hub import try_to_load_from_cache
+
+    for fname in ("config.json", "model.safetensors"):
+        cached = try_to_load_from_cache(MODEL, fname)
+        if cached is None:
+            return None
+    return os.path.dirname(cached)
+
+
+@XPU
+@pytest.mark.xpu
+def test_hybrid_real_model_streams_readable_tokens(tmp_path, monkeypatch):
+    """M3 live close: a real MoE model, hybrid q* split, readable decoded text.
+
+    Load the real 2.4B Qwen3-MoE host-offload with the hybrid backend through the
+    real ``Engine``, then drive the route's ``stream_chat`` seam on the main thread
+    and assert the generated ids decode to readable, non-placeholder, non-id-blob
+    prose. The hybrid fetch fraction comes from the per-UUID ``ft bench bw`` profile
+    (the loader's auto-lookup), so the q* split is genuinely active (f > 0), not the
+    degenerate pure-offload fallback. A watcher aborts the run on a new XPU reset or
+    a memory-pressure stall, so a shared box is never taken down by a runaway run.
+    """
+    from freetoken.core import reset_global_ctx
+    from freetoken.distributed import DistributedInfo
+    from freetoken.engine.config import EngineConfig
+    from freetoken.engine.engine import Engine
+    from freetoken.models.loader import load_model
+    from freetoken.server.api_server import create_app
+    from freetoken.server.args import parse_args
+    from freetoken.server.generation import stream_chat
+    from freetoken.server.launch import _frontend_tokenizer
+    from freetoken.moe.bench_profile import load_hybrid_fetch_fraction
+
+    ckpt = _model_dir()
+    if ckpt is None:
+        pytest.skip(f"real checkpoint {MODEL} is not in the local HF cache (offline)")
+
+    # The profile must be present and trusted (its xpu.name matches this box) so the
+    # loader's auto-lookup yields a real fetch fraction (f > 0) -- the hybrid q* split
+    # -- rather than the f=0 pure-offload fallback. Generate it if absent (the
+    # benchbw fix makes `ft bench bw` work; the profile is per-UUID in the cache).
+    frac = load_hybrid_fetch_fraction("bf16")
+    if frac is None:
+        from freetoken.moe.benchbw import main as _bench_main
+
+        _bench_main(["--dtype", "bf16", "--repeats", "2"], prog="ft bench bw")
+        frac = load_hybrid_fetch_fraction("bf16")
+    assert frac is not None and 0.0 < frac < 1.0, (
+        "the per-UUID benchbw profile must pin a non-degenerate hybrid fetch fraction "
+        f"(got {frac!r}); without it the hybrid degrades to pure offload, not the M3 q* split"
+    )
+
+    dev = torch.device("xpu")
+
+    # --- watcher: abort on a new XPU reset or a memory-pressure stall ---------------
+    base = _xpu_reset_count()
+    avail0 = _mem_available_gb() or 0.0
+    state = {"done": False, "error": None}
+
+    def _watch():
+        stalled = 0
+        while not state["done"]:
+            rc = _xpu_reset_count()
+            if base is not None and rc is not None and rc > base:
+                state["error"] = f"XPU-RESET: {base} -> {rc}"
+                break
+            a = _mem_available_gb()
+            if a is not None:
+                if a < max(2.0, avail0 - 14.0):
+                    stalled += 1
+                else:
+                    stalled = 0
+                if stalled >= 6:
+                    state["error"] = f"memory-pressure stall (avail {a:.1f}GB)"
+                    break
+            time.sleep(1.0)
+
+    wt = threading.Thread(target=_watch, daemon=True)
+    wt.start()
+
+    # Drive the loader with the model's *native* dtype (bf16 for this checkpoint)
+    # so the loader keys the benchbw profile on "bf16" (the profile's format) -> the
+    # real fetch fraction. (The engine's serve path pins fp32, which has no profile
+    # entry and would silently fall back to pure offload; the loader stamps its own
+    # effective dtype onto the modules, so a bf16 load keeps the weights + modules
+    # consistent and is exactly what the profile was measured for.)
+    model, sources = load_model(ckpt, dev, dtype=torch.bfloat16, moe_backend="hybrid")
+    try:
+        assert model.moe_offload, "the hybrid path must flag the model as host-offloaded"
+        assert model.moe_cache is not None, "the loader must attach the LRU slot pool"
+        assert model.layers[0].mlp.experts is None, "the hybrid path must not build device-resident experts"
+        assert abs(getattr(model, "moe_hybrid_fetch_fraction", 0.0) - frac) < 1e-9, (
+            "the loader must read the profile's real fetch fraction onto the model"
+        )
+        assert 0.0 < getattr(model, "moe_hybrid_fetch_fraction", 0.0) < 1.0, (
+            "the hybrid must be the non-degenerate q* split (0 < f < 1), not pure offload"
+        )
+
+        server_args = parse_args([ckpt])
+        engine = Engine(
+            EngineConfig(
+                model_path=ckpt,
+                tp_info=DistributedInfo(0, 1),
+                dtype=torch.bfloat16,
+                device=dev,
+                attention_backend="auto",
+                moe_backend="hybrid",
+                max_running_req=1,
+                page_size=1,
+                max_seq_len_override=128,
+                num_page_override=512,
+            )
+        )
+        engine.frontend_tokenizer = _frontend_tokenizer(parse_args([ckpt]))
+
+        # Build the app exactly as the route sees it (wiring check), then drive the
+        # same seam the /v1/chat/completions route uses -- on the main thread.
+        app = create_app(server_args, lambda: engine)
+        assert any(getattr(r, "path", None) == "/v1/chat/completions" for r in app.routes)
+
+        if state["error"]:
+            pytest.fail(f"watcher aborted the run before generation: {state['error']}")
+
+        deltas = list(stream_chat(engine, _MESSAGES, model=server_args.resolved_model_name, max_tokens=_DECODE_TOKENS))
+        content = "".join(content_delta for _reasoning, content_delta in deltas)
+
+        if state["error"]:
+            pytest.fail(f"watcher aborted the run mid-generation: {state['error']}")
+
+        # M3 evidence: a real (non-503) stream came back, now as readable text.
+        assert content, "the stream must be non-empty -- the real model generated tokens"
+        assert "<tok-" not in content, f"decoder still emits placeholders: {content!r}"
+        # Readable prose, not undecoded binary or a raw token-id blob.
+        assert content.isprintable() or content.strip() == "", f"undecoded binary leaked: {content!r}"
+        assert not re.search(r"\d{6,}", content), f"decoded stream looks like raw ids: {content!r}"
+
+        # The decode steps must have actually driven the slot pool (the hybrid q*
+        # split is per-decode-step, so decode must have called ensure_experts).
+        stats = engine.model.moe_cache.decode_miss_stats()
+        assert stats["calls"] > 0, "decode must call ensure_experts on the slot pool (the q* split lives there)"
+
+        result = {
+            "model": MODEL,
+            "backend": "hybrid",
+            "fetch_fraction": float(getattr(model, "moe_hybrid_fetch_fraction", 0.0)),
+            "decode_calls": stats["calls"],
+            "content": content,
+            "resets_before": base,
+            "resets_after": _xpu_reset_count(),
+        }
+        print("\n[hybrid e2e real model] " + json.dumps(result, indent=2))
+        print("DECODED CONTENT:\n" + content)
+        # Persist the evidence for the milestone record (the test's stdout is the
+        # record; the JSON is a machine-readable artifact).
+        (tmp_path / "m3_hybrid_real_model_evidence.json").write_text(json.dumps(result, indent=2))
+    finally:
+        state["done"] = True
+        reset_global_ctx()
+        if torch.xpu.is_available():
+            torch.xpu.empty_cache()

--- a/tests/test_moe_offload_rebuild.py
+++ b/tests/test_moe_offload_rebuild.py
@@ -1,0 +1,139 @@
+"""Tests for :meth:`OffloadMoeCache.rebuild` (issue #16, elastic-memory).
+
+``rebuild`` is the runtime path that lets the engine re-plan the MoE cache / KV
+split (off the device's free VRAM) and resize the MoE slot pool **without
+reloading any weights**: the host source banks stay put and only the device slot
+pool + LRU bookkeeping are re-allocated.
+
+These tests build the cache on the CPU (machine-independent, no XPU / no
+network) so the invariant is covered in the per-PR / CPU nightly. The
+``xpu``-marked ``test_moe_cache_budget_xpu.py`` separately confirms the *engine*
+calls ``rebuild`` at the re-planned size on a real B70 (that one needs the
+shared GPU and so runs only where the XPU is quiescent).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.moe.offload_cache import OffloadMoeCache
+
+DEVICE = torch.device("cpu")
+# E=8 so the constructor's prefill double-buffer (cache_size >= 2*num_experts)
+# fits a pool as small as 2*E=16; the banks stay tiny (H, I below).
+L, E = 2, 8
+H, I = 16, 8  # hidden, moe intermediate
+
+
+def _bank_sources():
+    # Distinguishable per (layer, expert) host rows: gate [I, H], up [I, H],
+    # down [H, I]; the value tag is 100*(l+1)+10*(e+1) (+0/+1/+2 per bank).
+    def rows(layer, expert):
+        base = 100 * (layer + 1) + 10 * (expert + 1)
+        gate_up = torch.full((2 * I, H), base, dtype=torch.float32)
+        gate_up[:I] += 0.0  # gate rows
+        gate_up[I:] += 1.0  # up rows
+        down = torch.full((H, I), base + 2.0, dtype=torch.float32)
+        return gate_up, down
+
+    return {
+        "gate_up": [torch.stack([rows(l, e)[0] for e in range(E)]) for l in range(L)],
+        "down": [torch.stack([rows(l, e)[1] for e in range(E)]) for l in range(L)],
+    }
+
+
+def _source_ids(bank_sources):
+    # The host bank objects are the allocation rebuild must NOT touch.
+    return [id(t) for lst in bank_sources.values() for t in lst]
+
+
+def test_rebuild_grows_pool_and_resets_lru():
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)  # pool == one layer (full)
+    c.set_bank_sources(_bank_sources())
+    src_ids_before = _source_ids(c.bank_sources)
+
+    # Seed a full pool with an LRU history that rebuild must discard.
+    c.materialize_layer(0)
+    c.copy_missing()
+    c.materialize_layer(1)
+    c.copy_missing()  # layer 1 evicted layer 0 (cross-layer LRU); layer 1 resident
+    c.step.fill_(9)
+    c.usage[:] = torch.arange(E, dtype=torch.int64, device=DEVICE) + 1
+    assert int(c.slot_for_id[1, 0].item()) != -1, "layer 1 is resident pre-rebuild"
+    assert int(c.slot_for_id[0, 0].item()) == -1, "layer 0 is evicted pre-rebuild"
+
+    new_size = E + 4  # grow the pool (4 extra slots)
+    c.rebuild(new_size)
+
+    # The size-dependent tensors are all re-allocated at the new size.
+    assert c.cache_size == new_size
+    assert c.id_of_slot.shape == (new_size,)
+    assert c.usage.shape == (new_size,)
+    assert c.evict_slots.shape == (new_size,)
+    assert c.src_indices.shape == (new_size,)
+    # The per-bank slot caches grew but kept their row shape / dtype.
+    assert c.bank_caches["gate_up"].shape == (new_size, 2 * I, H)
+    assert c.bank_caches["down"].shape == (new_size, H, I)
+
+    # The host source banks are the SAME objects (no re-load of weights).
+    assert _source_ids(c.bank_sources) == src_ids_before
+    # The (sources, cache) pairs were rebuilt against the new caches.
+    for _, cache in c.banks:
+        assert cache.shape[0] == new_size
+
+    # The LRU bookkeeping was cleared: both the forward (slot_for_id, [L, E]) and
+    # inverse (id_of_slot, [cache_size]) maps are re-filled with -1, so their sums
+    # are -L*E and -new_size respectively (NOT 0); the counter tensors are zeroed.
+    assert int(c.slot_for_id.sum().item()) == -(L * E)
+    assert int(c.id_of_slot.sum().item()) == -new_size
+    assert int(c.usage.sum().item()) == 0
+    assert int(c.step.item()) == 0
+    assert int(c.active_mask.sum().item()) == 0
+    assert c._pending_src_layer is None
+    assert c._pending_whole_layer is False
+
+
+def test_rebuild_can_shrink_pool_to_num_experts():
+    c = OffloadMoeCache(L, E, E * 2, DEVICE, prefill_overlap=False)  # pool = 2 layers
+    c.set_bank_sources(_bank_sources())
+    c.materialize_layer(0)
+    c.copy_missing()
+    c.materialize_layer(1)
+    c.copy_missing()
+    assert c.cache_size == E * 2
+
+    # Shrink back down to the minimum (one full layer's worth of slots).
+    c.rebuild(E)
+    assert c.cache_size == E
+    assert c.id_of_slot.shape == (E,)
+    assert c.bank_caches["gate_up"].shape == (E, 2 * I, H)
+    assert int(c.slot_for_id.sum().item()) == -(L * E)
+    assert int(c.step.item()) == 0
+
+
+def test_rebuild_rejects_size_below_num_experts():
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)
+    c.set_bank_sources(_bank_sources())
+    with pytest.raises(ValueError, match="must be >= num_experts"):
+        c.rebuild(E - 1)
+    # The cache is untouched by the rejected rebuild.
+    assert c.cache_size == E
+
+
+def test_rebuild_without_banks_is_a_safe_noop_on_banks():
+    # The engine only ever calls rebuild() on a live cache whose banks were
+    # registered at load, so a bank-less rebuild is an unreachable edge -- but it
+    # must not crash (a KeyError would take down the engine on a malformed state).
+    # With no banks, the guard skips the per-bank reallocation; the LRU maps are
+    # still re-allocated at the new size and cleared.
+    c = OffloadMoeCache(L, E, E, DEVICE, prefill_overlap=False)
+    c.rebuild(E + 2)
+    assert c.cache_size == E + 2
+    assert c.id_of_slot.shape == (E + 2,)
+    assert int(c.slot_for_id.sum().item()) == -(L * E)
+    assert int(c.step.item()) == 0
+    # Nothing was registered, so the bank dicts stay empty (no crash, no ghosts).
+    assert c.bank_sources == {}
+    assert c.bank_caches == {}
+    assert c.banks == []


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟠 **PR-Agent Score: 72** `score-70-79` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/107#issuecomment-5503929997) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 31a32e1](https://github.com/Performant-Labs/FreeToken-Intel/commit/31a32e17eb3421abce8215932db2ff697a6d11e1) · run [#33649905755](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33649905755) · 2026-09-02 09:48 MDT / 2026-09-02 15:48 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## What

Ports the upstream `elastic-memory` split (#16): a device-agnostic **planner** that divides the XPU's addressable VRAM (`total * memory_ratio`) between the MoE **expert slot cache** (the resident LRU subset of the host banks) and the **paged KV pool**.

Two surfaces, matching the issue:

1. **Startup auto-sizing** — `--moe-cache-auto` (with `--moe-cache-size` / `--moe-cache-rate` / `--kv-reserve-tokens` / `--memory-ratio`) resolves the split from measured VRAM at load. MoE-first / KV-floor policy with a pre-allocation fit assert. A pinned positive `--moe-cache-size` disables auto and keeps conventional sizing.
2. **Runtime rebalance** — `rebuild_cache` re-plans and resizes the MoE slot pool in place (`OffloadMoeCache.rebuild` reallocates the slot pool + per-bank caches, resets the LRU, leaves the host banks untouched) and rebuilds the KV pool + page table + scheduler budget — no weight reload.

## Files

- `engine/cache_budget.py` — new planner: `plan_cache_budget` (MoE-priority, KV-floor, fit-assert; `moe_cache_rate` caps the MoE share).
- `engine/engine.py` — `_plan_cache_budget` hook (derives `num_moe_layers`/`head_dim` like the loader), `__init__` wires the split, `rebuild_cache` + `_rebuild_kv_pool`.
- `engine/config.py` — frozen-config pin normalization.
- `models/loader.py` — `load_model(..., moe_cache_size)` threads the planned size to the cache.
- `moe/offload_cache.py` — `rebuild(cache_size)` (guards a bank-less rebuild instead of `KeyError`).
- `server/args.py`, `server/launch.py` — new CLI flags + threading.
- Tests: `test_cache_budget.py` (CPU/torch-free planner), `test_moe_offload_rebuild.py` (CPU rebuild invariant), `test_moe_cache_budget_xpu.py` (XPU integration, nightly).

## Verification

- CPU (torch-free venv): 151 passed / 23 skipped / 0 failed; XPU modules deselect cleanly; all three CI gates pass (byte-compile, CPU suite, torch-free contract).
- XPU integration tests are **xpu-marked** and will run on the B70 nightly (the card is shared with a live qwen38 vLLM service, so they were not re-run ad hoc during development).

## Note

Issue #16 also lists `kvcache/cache_status.py` + `cache_report.py` (report the resolved geometry) and an XPU `baseline_free` probe. This PR delivers the core split + rebuild; the reporting surface is a small follow-up.


___

### **PR Type**
Enhancement, Tests, Bug fix, Documentation


___

### **Description**
- Add device-agnostic MoE/KV VRAM budget planner.
  - Auto-sizes from total VRAM with MoE-priority and KV floor.
  - CLI flags expose auto, pin, rate, memory ratio, reserve tokens.

- `rebuild_cache` rebalances MoE and KV pools in place.
  - `OffloadMoeCache.rebuild` resizes slot pool and resets LRU.
  - Engine rebuilds KV pool, page table, and scheduler budget.

- Add CPU/XPU tests for planner, rebuild, and hybrid e2e.
  - Torch-free planner, CPU rebuild, XPU wiring, real Qwen3-MoE hybrid stream.
  - Fix `ft bench bw` XPU synchronization call.

- Add XPU optional dependencies and wheel packaging CI.
  - `pyproject.toml` `[xpu]` extra and build-wheel script.
  - Torch-free wheel contract check and install docs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["plan_cache_budget"] --> B["Engine cache/KV split"]
    B --> C["MoE slot cache size"]
    B --> D["KV page count"]
    E["CLI flags"] --> A
    F["OffloadMoeCache.rebuild"] --> B
    G["XPU optional deps + build script"] --> H["build-wheel CI"]
    I["docs"] --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>cache_budget.py</strong><dd><code>Add device-agnostic MoE/KV VRAM budget planner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-a1c65caed1803d8366d410a8d8c38ec91a58e6d3fb024a99bc19375ea6b0ccdc">+226/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>engine.py</strong><dd><code>Integrate planner and runtime pool rebuild</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-ac01fc4935708ecb318c53b01021cb308dbea3f1d1d356d68b796fc860dda54c">+175/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>loader.py</strong><dd><code>Thread planned MoE cache size to loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-8958a060f7dff2bd6bdc84c0ad36eb5ab7a07eb7adecb96beb5f8699dcf0d29b">+30/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>offload_cache.py</strong><dd><code>Add in-place slot pool rebuild method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-2b28912e9e23e80a09b8bbfbfe7a0ceba4db2a916f9ba2fc974704f1f455702d">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>launch.py</strong><dd><code>Pass elastic memory flags to engine config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-1bfcdb5a34b441e2901f238435ed2584530ddc6db3b9bfe3b35459b9d56e7e6e">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build-release-wheels.sh</strong><dd><code>Add CPU and XPU wheel build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-ebc3a1561585eaef4eb1fc718a6757f1be76f7e5cf43e08e0bbcc137822d6630">+101/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Normalize pinned cache size disables auto</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-9d6552b8fa539659b68e667f9c409fe5cce05505c03302b263010bc64382e8aa">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>args.py</strong><dd><code>Expose MoE cache and memory CLI flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-397359ca29f4e2aea7e3342a97fad0eee639abe8a492bdd29f4d2383cf600780">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci.yml</strong><dd><code>Add build-wheel packaging contract job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+107/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>benchbw.py</strong><dd><code>Fix XPU synchronization in benchmark</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-78c6861b3b11fd6ce52afdca6ac1766c7141c555b07e6c620380abbe98eb19f1">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_cache_budget.py</strong><dd><code>Add CPU planner and policy tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-993e14c066e11ac63afdefa44af85a520dd1709d4d9364dc4b29dabd5fa9a182">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_moe_cache_budget_xpu.py</strong><dd><code>Add XPU budget wiring integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-b325986c18129266f91b095f670fbea6c8129589832b21037603d055b9ae7fb7">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_moe_hybrid_e2e_real_xpu.py</strong><dd><code>Add real-model hybrid serve e2e test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-278bcf41b38c42a266d88bd4b322f1924b0792eeee9f09956dd55701c641e94c">+247/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_moe_offload_rebuild.py</strong><dd><code>Add CPU rebuild invariant tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-c642e44827a2fa51d4bb8fd5db82a699ae3013e32ded28ce72e61996de1e6073">+139/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ci.md</strong><dd><code>Document build-wheel job and packaging contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-97a1c7b70340e837ae6afb6ae7c3840b891dc0790bd554f3ecd617bdf8afe82a">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>install.md</strong><dd><code>Document wheel install and XPU extra</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5a">+53/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Pin XPU optional dependency stack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/107/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+39/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___