### PR TITLE
fix(engine): stop OOM/EOS-runaway in decode, close M3 hybrid live test

### DIFF
--- a/python/freetoken/core.py
+++ b/python/freetoken/core.py
@@ -52,7 +52,7 @@ class Req:
 
     @property
     def can_decode(self) -> bool:
-        return self.remain_len > 0
+        return self.remain_len > 0 and not self.aborted
 
 
 @dataclass

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -346,6 +346,7 @@ class Engine:
 
     # -- the loop -------------------------------------------------------------
 
+    @torch.inference_mode()
     def step(self) -> ForwardOutput:
         """Run one engine step (one model forward + one sample) over the batch
         the :class:`~freetoken.scheduler.Scheduler` selected.

--- a/tests/test_moe_hybrid_e2e_real_xpu.py
+++ b/tests/test_moe_hybrid_e2e_real_xpu.py
@@ -217,8 +217,13 @@ def test_hybrid_real_model_streams_readable_tokens(tmp_path, monkeypatch):
         # M3 evidence: a real (non-503) stream came back, now as readable text.
         assert content, "the stream must be non-empty -- the real model generated tokens"
         assert "<tok-" not in content, f"decoder still emits placeholders: {content!r}"
-        # Readable prose, not undecoded binary or a raw token-id blob.
-        assert content.isprintable() or content.strip() == "", f"undecoded binary leaked: {content!r}"
+        # Readable prose, not undecoded binary or a raw token-id blob. Ordinary
+        # whitespace (newlines, tabs) is expected in real prose -- str.isprintable()
+        # treats it as "not printable", so check per-character against isprintable
+        # OR isspace instead of gating the whole string on isprintable() alone.
+        assert all(ch.isprintable() or ch.isspace() for ch in content), (
+            f"undecoded binary leaked: {content!r}"
+        )
         assert not re.search(r"\d{6,}", content), f"decoded stream looks like raw ids: {content!r}"
 
         # The decode steps must have actually driven the slot pool (the hybrid q*


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 51080a8](https://github.com/Performant-Labs/FreeToken-Intel/commit/51080a8b1d1bcdadd0abe83d88498b4d943e0356) · run [#33656675668](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33656675668) · 2026-09-02 10:46 MDT / 2026-09-02 16:46 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
- `Engine.step()` never disabled autograd, so every decode-step forward pass retained a full computation graph; the hybrid backend's per-step fp32 expert upcast made this balloon host RSS to ~26 GB and get OOM-killed within a couple of decode steps. Fixed with `@torch.inference_mode()` on `step()`.
- `Req.can_decode` only checked the token budget, never `req.aborted` — so a request that hit EOS kept being scheduled until `max_tokens` ran out instead of stopping, producing leaked `<|im_end|>` text and a greedy repetition loop. Fixed: `can_decode` now also requires `not self.aborted`.
- `tests/test_moe_hybrid_e2e_real_xpu.py`'s own readability assertion was broken (`str.isprintable()` treats `\n` as non-printable, so it would fail on any real multi-line response) — fixed to check per-character against `isprintable() or isspace()`.

Closes the last M3 ("Hybrid q* online", issue #299 row 3) gap: `tests/test_moe_hybrid_e2e_real_xpu.py` now passes on real B70 hardware — real 2.4B Qwen3-MoE checkpoint, hybrid backend, real `ft bench bw` fetch_fraction=0.5, 308 decode_miss_stats calls, readable non-degenerate output, 0 XPU exec-queue resets.

## Test plan
- [x] `tests/test_moe_hybrid_forward.py`, `test_moe_offload_forward.py`, `test_moe_cpu_forward.py` (tiny fabricated-model unit tests) — pass
- [x] `tests/test_scheduler_policy.py`, `test_core.py` — pass (no regression from the `can_decode` change)
- [x] `pytest tests/ -m "not xpu"` — 230 passed, 13 pre-existing unrelated failures confirmed identical on `main` before this change (git stash comparison)
- [x] `ft bench bw --dtype bf16 --repeats 2` — clean, writes real profile
- [x] `tests/test_moe_hybrid_e2e_real_xpu.py` on real XPU hardware (B70) — passes, 0 exec-queue resets, RSS stayed flat (~8 GB) through decode instead of OOM-killing at ~26 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `@torch.inference_mode()` to `Engine.step()` to prevent graph retention.

- Require `not self.aborted` in `Req.can_decode` to halt decode after EOS.

- Fix e2e readability assertion to allow whitespace characters.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.py</strong><dd><code>Stop decode after abort</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/core.py

- Add `not self.aborted` guard to `can_decode` property.


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/108/files#diff-1097b18ff55b87a6ef3c0a4e33c37b567bc6a4d42ed78173b44652968591785c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine.py</strong><dd><code>Disable autograd in engine step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/engine/engine.py

<ul><li>Decorate <code>step</code> with <code>@torch.inference_mode()</code>.<br> <li> Prevent per-step autograd graph retention during decode.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/108/files#diff-ac01fc4935708ecb318c53b01021cb308dbea3f1d1d356d68b796fc860dda54c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_moe_hybrid_e2e_real_xpu.py</strong><dd><code>Fix hybrid e2e readability assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_moe_hybrid_e2e_real_xpu.py

<ul><li>Replace whole-string <code>isprintable()</code> with per-character check.<br> <li> Allow <code>isspace()</code> characters such as newlines and tabs.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/108/files#diff-278bcf41b38c42a266d88bd4b322f1924b0792eeee9f09956dd55701c641e94c">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___