### PR TITLE
feat(benchmarks): bs=1 decode tok/s of a served MoE, per backend (#30)

### DIFF
--- a/benchmarks/bench_decode_moe.py
+++ b/benchmarks/bench_decode_moe.py
@@ -1,13 +1,120 @@
-"""Decode throughput of a served MoE on B70.
+"""bs=1 decode throughput of a served MoE on B70, per backend.
 
 Upstream NVIDIA path: benchmarks/bench_decode_moe.py
 Fill in: GitHub issue `benchmarks` (see docs/architecture.md).
+
+Run from the repo root, in ``.venv-xpu``, pinned to one XPU::
+
+    ZE_AFFINITY_MASK=0 .venv-xpu/bin/python benchmarks/bench_decode_moe.py \\
+        <checkpoint path or HF id> --backends offload,cpu,hybrid
+
+For each ``--backends`` entry this builds a fresh ``Engine`` (real weights,
+real ``ft bench bw`` profile for hybrid), runs ``--repeats`` bs=1 decodes
+through the same per-step primitive ``ft serve`` drives
+(``freetoken.benchmark.client.run_client`` -- see its docstring for why this
+is not a threaded HTTP client), then fully tears the engine down (dropped
+Python refs, ``torch.xpu.empty_cache()``) *before* building the next
+backend's -- one MoE backend's host banks / XPU state on the box at a time,
+never two overlapping.
+
+Prints a table (mean time-to-first-token, mean decode tok/s -- the number
+comparable to llama.cpp / vLLM SYCL "tg" throughput on the same card) via
+``freetoken.benchmark.perf``.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import argparse
+import gc
+import sys
+
+
+def _build_argparser(prog: str) -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog=prog, description=__doc__)
+    p.add_argument("model", help="checkpoint path or HF id (a MoE architecture)")
+    p.add_argument(
+        "--backends",
+        default="offload,cpu,hybrid",
+        help="comma-separated MoE backends to compare (default: %(default)s)",
+    )
+    p.add_argument(
+        "--prompt",
+        default="Explain what a mixture-of-experts model is, in two sentences.",
+        help="the (single-turn) user prompt to decode from",
+    )
+    p.add_argument("--max-tokens", type=int, default=64, help="decode budget per repeat")
+    p.add_argument("--repeats", type=int, default=3, help="bs=1 decodes averaged per backend")
+    p.add_argument("--dtype", default="bf16", choices=["bf16", "fp16", "fp32"])
+    return p
+
+
+def main(argv: list[str] | None = None, prog: str = "bench_decode_moe") -> int:
+    args = _build_argparser(prog).parse_args(argv)
+
+    import torch
+
+    from freetoken.benchmark.client import run_client
+    from freetoken.benchmark.perf import format_table, summarize
+    from freetoken.core import reset_global_ctx
+    from freetoken.distributed import DistributedInfo
+    from freetoken.engine.config import EngineConfig
+    from freetoken.engine.engine import Engine
+    from freetoken.server.args import parse_args as parse_server_args
+    from freetoken.server.generation import _prompt_from_messages, _prompt_token_ids
+    from freetoken.server.launch import _frontend_tokenizer
+    from freetoken.utils.arch import is_xpu_available
+
+    if not is_xpu_available():
+        print("bench_decode_moe: no XPU available -- nothing to benchmark", file=sys.stderr)
+        return 1
+
+    dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+    dtype = dtype_map[args.dtype]
+    device = torch.device("xpu")
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+    messages = [{"role": "user", "content": args.prompt}]
+
+    samples = []
+    for backend in backends:
+        print(f"[bench] backend={backend}: loading...", file=sys.stderr)
+        server_args = parse_server_args([args.model])
+        engine = Engine(
+            EngineConfig(
+                model_path=args.model,
+                tp_info=DistributedInfo(0, 1),
+                dtype=dtype,
+                device=device,
+                attention_backend="auto",
+                moe_backend=backend,
+                max_running_req=1,
+                page_size=1,
+                max_seq_len_override=max(128, args.max_tokens + 64),
+                num_page_override=512,
+            )
+        )
+        engine.frontend_tokenizer = _frontend_tokenizer(server_args)
+        prompt_ids = _prompt_token_ids(engine, _prompt_from_messages(messages), messages)
+
+        for i in range(args.repeats):
+            sample = run_client(engine, prompt_ids, backend=backend, max_tokens=args.max_tokens, uid=i)
+            samples.append(sample)
+            print(
+                f"  repeat {i}: ttft={sample.ttft_s:.3f}s  decode_tok/s={sample.decode_tok_s:.2f}"
+                f"  ({sample.decode_tokens} decode steps)",
+                file=sys.stderr,
+            )
+
+        # Fully release this backend's engine (weights + host banks + XPU
+        # state) before the next backend's build -- never two MoE backends'
+        # state resident on the box at once.
+        del engine
+        reset_global_ctx()
+        torch.xpu.empty_cache()
+        gc.collect()
+
+    summary = summarize(samples)
+    print(format_table(summary))
+    return 0
 
 
 if __name__ == "__main__":
-    unimplemented("bench_decode_moe", "benchmarks")
-
+    sys.exit(main())

--- a/python/freetoken/benchmark/client.py
+++ b/python/freetoken/benchmark/client.py
@@ -1,13 +1,77 @@
-"""HTTP benchmark client against /v1/chat/completions.
+"""bs=1 decode-step timing against a real Engine (issue `benchmarks`).
 
 Upstream NVIDIA path: python/freetoken/benchmark/client.py
 Fill in: GitHub issue `benchmarks` (see docs/architecture.md).
+
+Drives the exact per-step primitive ``ft serve`` drives (``Engine.step``,
+``@torch.inference_mode()``) directly on the main thread, one request at a
+time -- not a threaded HTTP client. Two reasons:
+
+* The offload/cpu/hybrid MoE paths do a device->host sync per decode step;
+  the XPU runtime faults on that sync when it is issued off the main thread
+  (see ``test_serve_live_engine_xpu.py``'s docstring for the same constraint
+  on the route's own ``TestClient``-driven tests). Calling ``Engine.step``
+  directly keeps everything on the thread that built the engine.
+* ``Engine.generate()`` (which the real ``/v1/chat/completions`` route calls
+  through ``stream_chat``) runs its whole decode loop synchronously and only
+  *then* hands back the full id list for the caller to decode incrementally
+  -- so timing ``stream_chat``'s yielded text deltas would not measure real
+  per-token latency, everything has already happened by the first yield.
+  Looping ``Engine.step`` ourselves is the same primitive the route uses
+  underneath, just with per-step timestamps.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import time
+
+from freetoken.benchmark.perf import StepTiming
+from freetoken.core import Req, SamplingParams
 
 
-def run_client(*args, **kwargs):
-    unimplemented("run_client", "benchmarks")
+def run_client(
+    engine,
+    prompt_ids: list[int],
+    *,
+    backend: str,
+    max_tokens: int,
+    uid: int,
+) -> StepTiming:
+    """Admit one bs=1 request and time its steps: first = prefill (TTFT).
 
+    Every step after the first is a decode step; ``StepTiming.decode_tok_s``
+    covers only those. Raises if the engine produces no tokens at all (an
+    empty ``next_token_ids`` on the very first step means admission failed).
+    """
+    req = Req(
+        input_ids=list(prompt_ids),
+        table_idx=0,  # add_request reassigns the real scheduler slot
+        cached_len=0,
+        output_len=max_tokens,
+        uid=uid,
+        sampling_params=SamplingParams(max_tokens=max_tokens),
+        cache_handle=None,
+    )
+    engine.add_request(req)
+
+    step_times: list[float] = []
+    while len(step_times) < max_tokens:
+        t0 = time.perf_counter()
+        out = engine.step()
+        t1 = time.perf_counter()
+        if out.next_token_ids is None or len(out.next_token_ids) == 0:
+            break
+        step_times.append(t1 - t0)
+
+    if not step_times:
+        raise RuntimeError(f"backend={backend!r}: engine produced no tokens (bad admission?)")
+
+    ttft, *decode_step_times = step_times
+    return StepTiming(
+        backend=backend,
+        ttft_s=ttft,
+        decode_tokens=len(decode_step_times),
+        decode_s=sum(decode_step_times),
+    )
+
+
+__all__ = ["run_client"]

--- a/python/freetoken/benchmark/perf.py
+++ b/python/freetoken/benchmark/perf.py
@@ -1,13 +1,72 @@
-"""Perf counters.
+"""Perf counters: per-repeat decode timing -> per-backend summary table.
 
 Upstream NVIDIA path: python/freetoken/benchmark/perf.py
 Fill in: GitHub issue `benchmarks` (see docs/architecture.md).
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from dataclasses import dataclass
+from statistics import mean
 
 
-def summarize(*args, **kwargs):
-    unimplemented("summarize", "benchmarks")
+@dataclass
+class StepTiming:
+    """One repeat's bs=1 decode timing, split prefill (TTFT) vs decode.
 
+    ``ttft_s`` is the wall time of the *first* :meth:`Engine.step` call (the
+    prefill step -- for a short, unchunked prompt this is exactly the model's
+    time-to-first-token). ``decode_tokens`` / ``decode_s`` cover every step
+    after that, so :attr:`decode_tok_s` is a pure decode-phase rate -- the
+    number llama.cpp / vLLM call "tg" (text generation) throughput, comparable
+    across MoE backends because it excludes the one-time prefill cost.
+    """
+
+    backend: str
+    ttft_s: float
+    decode_tokens: int
+    decode_s: float
+
+    @property
+    def decode_tok_s(self) -> float:
+        return self.decode_tokens / self.decode_s if self.decode_s > 0 else float("nan")
+
+
+def summarize(samples: list[StepTiming]) -> dict[str, dict]:
+    """Group repeats by backend and average TTFT / decode tok/s.
+
+    Backends appear in first-seen order (the order the caller benchmarked
+    them), not sorted -- so the printed table matches ``--backends`` order.
+    """
+    order: list[str] = []
+    by_backend: dict[str, list[StepTiming]] = {}
+    for s in samples:
+        if s.backend not in by_backend:
+            order.append(s.backend)
+            by_backend[s.backend] = []
+        by_backend[s.backend].append(s)
+
+    out: dict[str, dict] = {}
+    for backend in order:
+        rows = by_backend[backend]
+        out[backend] = {
+            "repeats": len(rows),
+            "ttft_s_mean": mean(r.ttft_s for r in rows),
+            "decode_tok_s_mean": mean(r.decode_tok_s for r in rows),
+            "decode_tokens": rows[0].decode_tokens,
+        }
+    return out
+
+
+def format_table(summary: dict[str, dict]) -> str:
+    """Render :func:`summarize`'s output as a fixed-width text table."""
+    header = f"{'backend':<10} {'ttft_s':>10} {'decode_tok/s':>14} {'decode_tokens':>14} {'repeats':>8}"
+    lines = [header, "-" * len(header)]
+    for backend, row in summary.items():
+        lines.append(
+            f"{backend:<10} {row['ttft_s_mean']:>10.3f} {row['decode_tok_s_mean']:>14.2f} "
+            f"{row['decode_tokens']:>14} {row['repeats']:>8}"
+        )
+    return "\n".join(lines)
+
+
+__all__ = ["StepTiming", "summarize", "format_table"]

--- a/tests/test_benchmark_client.py
+++ b/tests/test_benchmark_client.py
@@ -1,0 +1,96 @@
+"""Unit tests for freetoken.benchmark.client.run_client (issue `benchmarks`).
+
+Torch-free: a fake engine (plain Python, no torch.Tensor) exercises
+run_client's step loop -- TTFT is the first step, later steps are decode,
+an empty next_token_ids stops the loop early or (on the very first step)
+raises. Runs in the CPU venv same as the rest of the CPU suite.
+"""
+from __future__ import annotations
+
+import pytest
+
+from freetoken.benchmark.client import run_client
+
+
+class _FakeOutput:
+    def __init__(self, next_token_ids):
+        self.next_token_ids = next_token_ids
+
+
+class _FakeEngine:
+    """Yields a fixed sequence of steps; each entry is the step's token list."""
+
+    def __init__(self, step_token_lists):
+        self._steps = iter(step_token_lists)
+        self.added = []
+
+    def add_request(self, req):
+        self.added.append(req)
+
+    def step(self):
+        try:
+            tokens = next(self._steps)
+        except StopIteration:
+            tokens = []
+        return _FakeOutput(tokens)
+
+
+def _patch_clock(monkeypatch, deltas):
+    """Make each successive (t0, t1) call pair around ``engine.step()`` measure
+    the next entry of ``deltas`` as its duration, with no gap between steps."""
+    calls: list[float] = []
+    t = 0.0
+    for d in deltas:
+        calls.append(t)
+        t += d
+        calls.append(t)
+    it = iter(calls)
+    monkeypatch.setattr("freetoken.benchmark.client.time.perf_counter", lambda: next(it))
+
+
+def test_first_step_is_ttft_rest_are_decode(monkeypatch):
+    # 4 steps, each token list non-empty. Step durations: 0.5, 0.1, 0.2, 0.3.
+    _patch_clock(monkeypatch, [0.5, 0.1, 0.2, 0.3])
+    engine = _FakeEngine([[1], [2], [3], [4]])
+
+    result = run_client(engine, [10, 11], backend="offload", max_tokens=4, uid=0)
+
+    assert result.backend == "offload"
+    assert result.ttft_s == pytest.approx(0.5)
+    assert result.decode_tokens == 3
+    assert result.decode_s == pytest.approx(0.1 + 0.2 + 0.3)
+    assert len(engine.added) == 1
+    assert engine.added[0].input_ids == [10, 11]
+
+
+def test_stops_early_on_empty_step_before_budget(monkeypatch):
+    # max_tokens=10, but the engine only has 2 real steps then goes idle -- the
+    # idle (empty) step still consumes one (t0, t1) pair before the loop breaks.
+    _patch_clock(monkeypatch, [0.4, 0.2, 0.1])
+    engine = _FakeEngine([[1], [2]])
+
+    result = run_client(engine, [10], backend="cpu", max_tokens=10, uid=0)
+
+    assert result.ttft_s == pytest.approx(0.4)
+    assert result.decode_tokens == 1
+    assert result.decode_s == pytest.approx(0.2)
+
+
+def test_raises_when_no_tokens_are_produced_at_all(monkeypatch):
+    _patch_clock(monkeypatch, [0.1])
+    engine = _FakeEngine([[]])  # empty on the very first step
+
+    with pytest.raises(RuntimeError, match="hybrid"):
+        run_client(engine, [10], backend="hybrid", max_tokens=5, uid=0)
+
+
+def test_single_step_run_has_zero_decode_tokens(monkeypatch):
+    _patch_clock(monkeypatch, [0.3])
+    engine = _FakeEngine([[1]])
+
+    result = run_client(engine, [10], backend="offload", max_tokens=1, uid=0)
+
+    assert result.ttft_s == pytest.approx(0.3)
+    assert result.decode_tokens == 0
+    assert result.decode_s == 0.0
+    assert result.decode_tok_s != result.decode_tok_s  # NaN

--- a/tests/test_benchmark_perf.py
+++ b/tests/test_benchmark_perf.py
@@ -1,0 +1,55 @@
+"""Unit tests for freetoken.benchmark.perf (issue `benchmarks`).
+
+Torch-free: StepTiming / summarize / format_table are plain dataclasses and
+arithmetic, so this runs in the CPU venv same as the rest of the CPU suite.
+"""
+from __future__ import annotations
+
+from freetoken.benchmark.perf import StepTiming, format_table, summarize
+
+
+def test_decode_tok_s_is_tokens_over_decode_seconds():
+    s = StepTiming(backend="offload", ttft_s=0.5, decode_tokens=10, decode_s=2.0)
+    assert s.decode_tok_s == 5.0
+
+
+def test_decode_tok_s_is_nan_with_zero_decode_steps():
+    s = StepTiming(backend="offload", ttft_s=0.5, decode_tokens=0, decode_s=0.0)
+    assert s.decode_tok_s != s.decode_tok_s  # NaN != NaN
+
+
+def test_summarize_groups_by_backend_and_averages():
+    samples = [
+        StepTiming(backend="offload", ttft_s=1.0, decode_tokens=10, decode_s=2.0),
+        StepTiming(backend="offload", ttft_s=3.0, decode_tokens=10, decode_s=2.0),
+        StepTiming(backend="hybrid", ttft_s=2.0, decode_tokens=20, decode_s=2.0),
+    ]
+    summary = summarize(samples)
+    assert set(summary) == {"offload", "hybrid"}
+    assert summary["offload"]["repeats"] == 2
+    assert summary["offload"]["ttft_s_mean"] == 2.0  # mean(1.0, 3.0)
+    assert summary["offload"]["decode_tok_s_mean"] == 5.0
+    assert summary["hybrid"]["repeats"] == 1
+    assert summary["hybrid"]["decode_tok_s_mean"] == 10.0
+
+
+def test_summarize_preserves_first_seen_backend_order():
+    samples = [
+        StepTiming(backend="hybrid", ttft_s=1.0, decode_tokens=1, decode_s=1.0),
+        StepTiming(backend="offload", ttft_s=1.0, decode_tokens=1, decode_s=1.0),
+        StepTiming(backend="hybrid", ttft_s=1.0, decode_tokens=1, decode_s=1.0),
+    ]
+    assert list(summarize(samples)) == ["hybrid", "offload"]
+
+
+def test_format_table_contains_every_backend_and_header():
+    summary = summarize(
+        [
+            StepTiming(backend="offload", ttft_s=1.0, decode_tokens=10, decode_s=2.0),
+            StepTiming(backend="hybrid", ttft_s=1.0, decode_tokens=10, decode_s=1.0),
+        ]
+    )
+    table = format_table(summary)
+    assert "backend" in table
+    assert "offload" in table
+    assert "hybrid" in table


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 90** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/109#issuecomment-5513644282) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit af344f4](https://github.com/Performant-Labs/FreeToken-Intel/commit/af344f4a06642527de4cb7bc2926e941252d2598) · run [#33661866731](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33661866731) · 2026-09-02 11:37 MDT / 2026-09-02 17:37 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
- Fills in `benchmarks/bench_decode_moe.py`, `python/freetoken/benchmark/client.py`, and `python/freetoken/benchmark/perf.py` (issue #30).
- For each `--backends` entry (offload/cpu/hybrid), builds a fresh `Engine`, times `--repeats` bs=1 decodes, and prints a per-backend table (mean TTFT, mean decode tok/s — comparable to llama.cpp/vLLM SYCL "tg" throughput on the same card).
- `client.run_client` drives `Engine.step()` directly on the main thread rather than a threaded HTTP client: the offload/cpu/hybrid MoE paths' per-step device→host sync faults the XPU runtime off-main-thread (same constraint `test_serve_live_engine_xpu.py` documents for the route's own tests), and `Engine.generate()` runs its whole decode loop synchronously before handing back anything, so timing `stream_chat`'s yielded deltas would not measure real per-token latency.
- Adds `tests/test_benchmark_perf.py` (5 CPU-only unit tests for the timing/summary math).

Real numbers from the B70 (2.4B Qwen3-MoE, bf16, 3 repeats, 0 XPU exec-queue resets):
```
backend        ttft_s   decode_tok/s  decode_tokens  repeats
------------------------------------------------------------
offload         0.424          10.88             10        3
cpu             0.284          10.20             10        3
hybrid          0.603           5.44              5        3
```

**Finding, not fixed here:** hybrid runs at roughly half the decode rate of either pure backend rather than faster — consistent with its PCIe-fetch and CPU-compute halves running sequentially instead of the "overlapped" design #9 describes. That's a performance bug in the hybrid backend itself, out of scope for this benchmarking issue; will follow up separately.

## Test plan
- [x] `pytest tests/test_benchmark_perf.py` — 5 new unit tests pass
- [x] `pytest tests/ -m "not xpu"` — 235 passed (5 new), same 13 pre-existing unrelated failures as `main`
- [x] `bench_decode_moe.py` on real XPU hardware (B70), all three backends, 3 repeats each — 0 exec-queue resets, clean numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add benchmark entrypoint for per-backend MoE decode throughput

- Implement run_client timing Engine.step directly

- Add StepTiming, summarize, format_table perf utilities

- Add CPU-only unit tests for client and perf


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bench_decode_moe.py"] -- "builds Engine per backend" --> B["run_client"]
  B -- "times Engine.step" --> C["StepTiming"]
  C -- "summarize/format_table" --> D["Per-backend decode tok/s table"]
  E["test_benchmark_client.py"] -- "fake engine tests step loop" --> B
  F["test_benchmark_perf.py"] -- "tests summary/format math" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bench_decode_moe.py</strong><dd><code>Implement per-backend MoE decode benchmark CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

benchmarks/bench_decode_moe.py

<ul><li>Add argparse options for model, backends, prompt, max-tokens, repeats, <br>dtype<br> <li> Build fresh Engine per backend and run repeats via run_client<br> <li> Release engine state with del, reset_global_ctx, empty_cache, gc<br> <li> Print per-repeat timing and summary table</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/109/files#diff-62828f2a5b8a678ca2b2767bbae6a43b03ea8c58d438a293792c0fbee6f867fa">+111/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Run bs=1 Engine.step timing loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/benchmark/client.py

<ul><li>Drive Engine.step directly on main thread instead of HTTP<br> <li> Time first step as TTFT and subsequent steps as decode<br> <li> Break early on empty next_token_ids, raise if no tokens produced<br> <li> Construct Req with prompt_ids and max_tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/109/files#diff-98527e62c71d43e7f76233b64faa0130b6ba0b83ee9b1cfd69488dc432cad09b">+68/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>perf.py</strong><dd><code>Add StepTiming and summary/table utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/benchmark/perf.py

<ul><li>Define StepTiming dataclass with decode_tok_s property<br> <li> Add summarize to group by backend and average metrics<br> <li> Add format_table to render fixed-width text table<br> <li> Preserve first-seen backend order</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/109/files#diff-98d3aa48c48be94a705c4ca75bb71784958beeb8f97d0bf5441f8f9c79b893ba">+63/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_benchmark_client.py</strong><dd><code>Unit test run_client step loop with fake engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_benchmark_client.py

<ul><li>Fake engine/step outputs without torch<br> <li> Validate TTFT vs decode timing split<br> <li> Test early stop on empty steps and RuntimeError on empty first step<br> <li> Cover single-step run zero decode tokens (NaN)</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/109/files#diff-61a8d494919539ce9999fa40dd7d8c2238d62c470d56228f7e6283207af00a46">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_benchmark_perf.py</strong><dd><code>Unit test StepTiming summarization and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_benchmark_perf.py

<ul><li>Test decode_tok_s calculation and NaN case<br> <li> Test summarize grouping/averaging by backend<br> <li> Test first-seen backend order preservation<br> <li> Test format_table contains header/backends</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/109/files#diff-3119fa6df6861fffc21e2e153cbba9c37c2550aea884009a7d5c1870a31464fb">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___