### PR TITLE
fix(moe): overlap hybrid's CPU and PCIe halves instead of running them sequentially (#110)

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1157,51 +1157,95 @@ class _Qwen35MoE:
         n_fetch = max(1, min(n - 1, n_fetch))
         seen_sorted = sorted(seen)
         cpu_experts = set(seen_sorted[: n - n_fetch])  # (1 - f) share -> CPU
-        # The CPU half computes its share from the pinned host banks.
-        cpu_top_w = torch.ones(expert_ids_cpu.shape, dtype=top_w.dtype, device=flat.device)
+
+        # The two halves run CONCURRENTLY (issue moe-hybrid-overlap): the
+        # host-CPU half's pure-CPU matmuls (no XPU tensor touched) run on a
+        # persistent single-worker background thread while the XPU half's
+        # PCIe fetch + gather runs on *this* (main) thread -- the same regime
+        # benchbw._bench_overlap measures. A decode step then costs
+        # max(cpu_half, pcie_half), not their sum, matching the q* fetch
+        # fraction's bandwidth-matched assumption. The pool is reused across
+        # every layer / every step (cached on the model) rather than spawning
+        # a fresh thread per call: thread-creation overhead alone was large
+        # enough relative to a small model's per-expert matmul cost to erase
+        # most of the overlap's benefit when measured with a fresh Thread
+        # each time.
+        #
+        # The device<->host transfers (flat -> CPU in, the CPU result -> device
+        # out) must stay on this thread: the XPU runtime faults that sync when
+        # issued off the thread that built the engine (see
+        # test_serve_live_engine_xpu.py's docstring for the same constraint).
+        # So the CPU half's input is prepared here before the submit, and its
+        # output is moved back to the device here after the result is
+        # collected.
+        x_cpu = flat.to("cpu", non_blocking=True)
+
+        future = self._hybrid_cpu_pool(model).submit(
+            self._cpu_subset_math, x_cpu, expert_ids_cpu, ctx, cpu_experts
+        )
+
         out = self._forward_offload_core(
             flat, top_idx, top_w, ctx, batch,
             exclude=cpu_experts,
         )
-        # The host-CPU half computes its (disjoint) share.
-        out += self._forward_cpu_subset(flat, top_idx, cpu_top_w, ctx, batch, cpu_experts)
+
+        cpu_out = future.result()
+        # The host-CPU half's (disjoint) share, so the per-row sum matches the
+        # sequential version exactly regardless of which half finishes first.
+        out += cpu_out.to(flat.device, non_blocking=True)
         return out
 
-    def _forward_cpu_subset(self, flat, top_idx, cpu_top_w, ctx, batch, cpu_experts):
-        """The host-CPU half of the hybrid split: compute *only* the routed
-        experts in ``cpu_experts`` on the CPU (from the pinned host banks) and
-        return their per-row contribution. A row that routes to an expert *not*
-        in the CPU set contributes nothing (that row is served by the XPU half).
+    @staticmethod
+    def _hybrid_cpu_pool(model):
+        """A single-worker thread pool for the hybrid CPU half, cached on the
+        model so it survives across decode steps / layers instead of paying
+        thread-creation cost on every call (see ``_forward_hybrid``)."""
+        pool = getattr(model, "_moe_hybrid_cpu_pool", None)
+        if pool is None:
+            from concurrent.futures import ThreadPoolExecutor
+
+            pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="moe-hybrid-cpu")
+            model._moe_hybrid_cpu_pool = pool
+        return pool
+
+    def _cpu_subset_math(self, x_cpu, expert_ids_cpu, ctx, cpu_experts):
+        """Pure-CPU math for the hybrid split's host-CPU half.
+
+        Computes *only* the routed experts in ``cpu_experts`` (from the pinned
+        host banks) and returns their per-row contribution, on the CPU -- so
+        this is safe to run on a background thread (no XPU tensor is read or
+        written anywhere in this method; the device<->host transfers around it
+        are the caller's job, on the main thread). A row that routes to an
+        expert not in ``cpu_experts`` contributes nothing (that row is served
+        by the XPU half).
 
         Accumulation is expert-major then top-k-column (matching
         ``_forward_cpu`` / the in-VRAM reference), so the per-row result the
         hybrid path sums is numerically identical to what the pure CPU backend
-        would produce for that subset.
+        would produce for that subset. The upstream per-row weight for this
+        half (``cpu_top_w`` in the pre-overlap code) was always identically
+        1.0 -- applying it was a no-op multiply -- so it is omitted here
+        rather than reintroduced as a real weight.
         """
         model = ctx.model
         moe_idx = model.moe_layer_id[self.layer_id]
         sources = model.moe_cache.bank_sources
         gate_up = sources["gate_up"][moe_idx]
         down = sources["down"][moe_idx]
-        dev = flat.device
-        expert_ids = top_idx.to("cpu")
-        B, k = expert_ids.shape
+        B, k = expert_ids_cpu.shape
         num_experts = self.num_experts
-        out = torch.zeros_like(flat)
+        out = torch.zeros_like(x_cpu)
         for e in range(num_experts):
             if e not in cpu_experts:
                 continue
             for j in range(k):
-                sel = expert_ids[:, j] == e
+                sel = expert_ids_cpu[:, j] == e
                 if not bool(sel.any()):
                     continue
                 idx = torch.nonzero(sel, as_tuple=False).view(-1)
-                idx_dev = idx.to(dev)
-                x_cpu = flat.index_select(0, idx_dev).to("cpu")
-                y = self._expert_compute_cpu(gate_up, down, e, x_cpu)
-                y_dev = y.to(dev)
-                w = cpu_top_w.index_select(0, idx_dev)[:, j, None]
-                out.index_add_(0, idx_dev, w * y_dev)
+                x_sel = x_cpu.index_select(0, idx)
+                y = self._expert_compute_cpu(gate_up, down, e, x_sel)
+                out.index_add_(0, idx, y)
         return out
 
     @staticmethod

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -672,21 +672,71 @@ class _Qwen3MoE(nn.Module):
         n_fetch = max(1, min(n - 1, n_fetch))
         seen_sorted = sorted(seen)
         cpu_experts = set(seen_sorted[: n - n_fetch])  # (1 - f) share -> CPU
+        # The two halves run CONCURRENTLY (issue moe-hybrid-overlap): the
+        # host-CPU half's pure-CPU matmuls (no XPU tensor touched) run on a
+        # persistent single-worker background thread while the XPU half's
+        # PCIe fetch + gather runs on *this* (main) thread -- the same
+        # regime benchbw._bench_overlap measures. A decode step then costs
+        # max(cpu_half, pcie_half), not their sum, matching the q* fetch
+        # fraction's bandwidth-matched assumption. The pool is reused across
+        # every layer / every step (cached on the model) rather than
+        # spawning a fresh thread per call: this model has ~28 MoE layers per
+        # decode step, and thread-creation overhead alone was large enough
+        # relative to this tiny model's per-expert matmul cost to erase most
+        # of the overlap's benefit when measured with a fresh Thread each time.
+        #
+        # The device<->host transfers (flat -> CPU in, the CPU result -> device
+        # out) must stay on this thread: the XPU runtime faults that sync when
+        # issued off the thread that built the engine (see
+        # test_serve_live_engine_xpu.py's docstring for the same constraint).
+        # So the CPU half's *input* is prepared here before the submit, and
+        # its *output* is moved back to the device here after the result is
+        # collected -- the background worker itself never touches an XPU
+        # tensor.
+        x_cpu = flat.to("cpu", non_blocking=True).float()
+        top_idx_cpu = top_idx.to("cpu")
+        top_w_cpu = top_w.to("cpu")
+
+        future = self._hybrid_cpu_pool(model).submit(
+            self._cpu_subset_math, x_cpu, top_idx_cpu, top_w_cpu, model, cpu_experts
+        )
+
         # The XPU half fetches and computes every routed expert except the CPU
         # set; its per-(expert, column) accumulation is expert-major, matching the
         # pure offload path (and the in-VRAM reference), so the rows it serves are
         # byte-identical to what offload would produce.
         out = self._forward_offload(flat, top_idx, top_w, model, batch, exclude=cpu_experts)
-        # The host-CPU half computes its (disjoint) share from the pinned banks,
-        # also in expert-major order, so the per-row sum matches offload exactly.
-        out += self._forward_cpu_subset(flat, top_idx, top_w, model, batch, cpu_experts)
+
+        cpu_out = future.result()
+        # The host-CPU half's (disjoint) share, also in expert-major order, so
+        # the per-row sum matches offload exactly regardless of which half
+        # happened to finish first.
+        out += cpu_out.to(flat.device, non_blocking=True).to(flat.dtype)
         return out
 
-    def _forward_cpu_subset(self, flat, top_idx, top_w, model, batch, cpu_experts) -> torch.Tensor:
-        """The host-CPU half of the hybrid split: compute *only* the routed
-        experts in ``cpu_experts`` on the CPU (from the pinned host banks) and
-        return their per-row contribution. A row that routes to an expert *not*
-        in the CPU set contributes nothing (that row is served by the XPU half).
+    @staticmethod
+    def _hybrid_cpu_pool(model) -> "ThreadPoolExecutor":
+        """A single-worker thread pool for the hybrid CPU half, cached on the
+        model so it survives across decode steps / layers instead of paying
+        thread-creation cost on every call (see ``_forward_hybrid``)."""
+        pool = getattr(model, "_moe_hybrid_cpu_pool", None)
+        if pool is None:
+            from concurrent.futures import ThreadPoolExecutor
+
+            pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="moe-hybrid-cpu")
+            model._moe_hybrid_cpu_pool = pool
+        return pool
+
+    def _cpu_subset_math(self, x_cpu, top_idx_cpu, top_w_cpu, model, cpu_experts) -> torch.Tensor:
+        """Pure-CPU math for the hybrid split's host-CPU half.
+
+        Computes *only* the routed experts in ``cpu_experts`` (from the pinned
+        host banks) and returns their per-row contribution, on the CPU, in
+        ``x_cpu``'s dtype/device -- so this is safe to run on a background
+        thread (no XPU tensor is read or written anywhere in this method; the
+        device<->host transfers around it are the caller's job, on the main
+        thread). A row that routes to an expert not in ``cpu_experts``
+        contributes nothing (that row is served by the XPU half).
 
         Accumulation is expert-major then top-k-column (matching
         ``_forward_cpu`` / the in-VRAM reference), so the per-row result the
@@ -694,7 +744,7 @@ class _Qwen3MoE(nn.Module):
         would produce for that subset.
         """
         if not cpu_experts:
-            return torch.zeros_like(flat)
+            return torch.zeros_like(x_cpu)
         # Host banks for this MoE layer (the pinned loader-built banks; the same
         # source the XPU slot pool streams from -- ADR 0002). No PCIe round-trip:
         # the source of truth is already on the host.
@@ -702,23 +752,7 @@ class _Qwen3MoE(nn.Module):
         sources = model.moe_cache.bank_sources
         gate_up = sources["gate_up"][moe_idx]
         down = sources["down"][moe_idx]
-        executor = getattr(model, "_moe_cpu_executor", None)
-        if executor is None:
-            from freetoken.moe.cpu_executor import CpuMoeExecutor
-
-            threads = int(getattr(model.config, "moe_cpu_threads", 0) or 0)
-            executor = CpuMoeExecutor(
-                num_experts=int(model.config.num_experts),
-                intermediate=int(model.config.moe_intermediate_size),
-                threads=threads,
-            )
-            model._moe_cpu_executor = executor
-        # Compute the subset on the host (CPU dtype, CPU math) and ship only the
-        # result back to the device.
-        x_cpu = flat.to("cpu", non_blocking=True).float()
         out = torch.zeros(x_cpu.shape, dtype=x_cpu.dtype, device="cpu")
-        top_idx_cpu = top_idx.to("cpu")
-        top_w_cpu = top_w.to("cpu")
         for e in range(int(model.config.num_experts)):
             if e not in cpu_experts:
                 continue
@@ -739,7 +773,7 @@ class _Qwen3MoE(nn.Module):
                 up = x_sel @ gu_e[I : 2 * I].t()
                 y = (F.silu(gate) * up) @ down[e].float().t()
                 out.index_add_(0, rows, y * w_sel[:, None])
-        return out.to(flat.device, non_blocking=True).to(flat.dtype)
+        return out
 
     def _forward_cpu(self, flat, top_idx, top_w, model, batch) -> torch.Tensor:
         """Run the routed experts on the host (issue #8, ADR 0002).


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 85** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 0b6a8fd](https://github.com/Performant-Labs/FreeToken-Intel/commit/0b6a8fd478c3847b8e46cf66a9357c913a8f913c) · run [#33664868977](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33664868977) · 2026-09-02 12:09 MDT / 2026-09-02 18:09 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
- `_forward_hybrid` ran `_forward_offload()` then `_forward_cpu_subset()` strictly sequentially, paying for both halves' wall time added together instead of `max(cpu, pcie)` — despite #9's own design (and `ft bench bw`'s `_bench_overlap` measurement) assuming the two halves run concurrently. Found while benchmarking #30.
- Fix: the CPU half's pure-CPU matmuls (no XPU tensor touched) now run on a persistent single-worker thread pool (cached on the model, to avoid per-layer thread-creation overhead across ~28 MoE layers/step) while the XPU half's PCIe fetch + gather runs on the main thread. Device↔host transfers stay on the main thread (the XPU runtime faults that sync off the thread that built the engine). Applied to both `qwen3_moe` and `qwen3_5_moe`.
- Correctness unchanged — only *when* the two halves run changed, never the math or accumulation order. All hybrid/offload/cpu forward-correctness tests pass byte-identical.

Real B70 measurement (2.4B Qwen3-MoE, bf16, 3 repeats, load-settled system):
```
before: hybrid ~5.4 tok/s vs offload/cpu ~10.4-10.5 (roughly half)
after:  hybrid ~6.4 tok/s vs offload/cpu ~10.0-10.1 (a real ~18% gain)
```

**Honest note on scope:** this does not fully close the gap to `max(offload, cpu)` — see the commit message for a controlled A/B I ran on a second attempt (batching `OffloadMoeCache.copy_missing()`'s per-row loop), which turned out to be a regression on this small model and was reverted. The remaining gap looks like genuine Python GIL contention from the offload path's other per-step Python bookkeeping, which is a bigger restructuring than this issue's scope and deserves its own follow-up once measurable on a model where the win is unambiguous.

## Test plan
- [x] `tests/test_moe_hybrid_forward.py`, `test_moe_offload_forward.py`, `test_moe_cpu_forward.py` — pass, byte-identical output
- [x] `pytest tests/ -m "not xpu"` — 239 passed, same 13 pre-existing unrelated failures as `main`
- [x] `tests/test_moe_hybrid_e2e_real_xpu.py` on real XPU hardware — passes, 0 exec-queue resets
- [x] `bench_decode_moe.py` before/after on real XPU hardware, controlled for system load (an unrelated CPU-bound process was stopped and load averages confirmed settled before each comparative run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Overlap hybrid MoE CPU and PCIe halves concurrently

- Offload pure-CPU expert math to a persistent single-worker thread pool

- Keep device↔host transfers on the main thread

- Apply the same overlap pattern to qwen3_moe and qwen3_5_moe


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_forward_hybrid"] --> B["Prepare x_cpu and expert metadata"]
  B --> C["Submit CPU subset math to cached ThreadPoolExecutor"]
  A --> D["Run XPU offload fetch and gather on main thread"]
  C --> E["future.result()"]
  D --> E
  E --> F["Add CPU contribution to XPU output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Overlap CPU subset math with offload fetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li><code>_forward_hybrid</code> now copies input to CPU, submits pure-CPU expert math <br>to a cached single-worker pool, runs offload on the main thread, then <br>adds the CPU result.<br> <li> Replaces <code>_forward_cpu_subset</code> with <code>_cpu_subset_math</code>, which performs <br>CPU-only expert math and avoids all XPU tensor access.<br> <li> Adds <code>_hybrid_cpu_pool</code> to reuse one <code>ThreadPoolExecutor</code> cached on the <br>model.<br> <li> Removes the no-op <code>cpu_top_w</code> weight application from the CPU subset <br>path.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/111/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+65/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Overlap CPU subset math with offload fetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_moe/__init__.py

<ul><li><code>_forward_hybrid</code> now prepares CPU inputs, submits CPU expert math to a <br>cached persistent thread pool, runs offload on the main thread, and <br>adds the CPU result afterward.<br> <li> Replaces <code>_forward_cpu_subset</code> with <code>_cpu_subset_math</code>, returning a CPU <br>tensor and no longer using <code>CpuMoeExecutor</code>.<br> <li> Adds <code>_hybrid_cpu_pool</code> to reuse a model-cached <code>ThreadPoolExecutor</code>.<br> <li> Preserves float32 CPU math convention while moving device transfers to <br>the caller.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/111/files#diff-7df44a0f5eb5c411dc8b6f5d672093944a031ba3e91e79a23781674f3ceb1a3e">+60/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___