### PR TITLE
fix(moe): vectorize _resync_slot_for_id, unlocking real offload-cache sizing (#112)

### DIFF
--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -227,14 +227,24 @@ class OffloadMoeCache:
         Deriving ``slot_for_id`` from ``id_of_slot`` after each mutation makes
         the desync impossible: a slot is counted as layer L's expert e only if
         ``id_of_slot[slot] == L*E + e``.
+
+        Vectorized (issue moe-offload-gil / #112): the original per-slot
+        Python loop called ``.item()`` once per slot -- each one a
+        device->host sync on XPU -- so this scaled with ``cache_size`` badly
+        enough that growing the cache to fix thrashing (the actual point of
+        #112) just moved the bottleneck here instead. This is pure small
+        index bookkeeping (not weight-sized data), so batching it into a
+        handful of tensor ops has none of ``copy_missing``'s "extra
+        intermediate buffer" pitfall -- there's no large data to double-move.
         """
         E = self.num_experts
-        S = self.cache_size
-        self.slot_for_id.fill_(-1)
-        for slot in range(S):
-            id_ = int(self.id_of_slot[slot].item())
-            if id_ >= 0:
-                self.slot_for_id[id_ // E, id_ % E] = slot
+        ids_cpu = self.id_of_slot.to("cpu", dtype=torch.int64)
+        valid = ids_cpu >= 0
+        slots = valid.nonzero(as_tuple=True)[0]
+        ids_valid = ids_cpu[slots]
+        resynced = torch.full((self.num_layers, self.num_experts), -1, dtype=torch.int32)
+        resynced[ids_valid // E, ids_valid % E] = slots.to(torch.int32)
+        self.slot_for_id.copy_(resynced.to(self.device, non_blocking=True))
 
     def reset(self) -> None:
         """Clear all slot mappings, usage, the step counter, and the stats."""


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 92** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/113#issuecomment-5515097945) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 81d0406](https://github.com/Performant-Labs/FreeToken-Intel/commit/81d0406d8a1c4938586d46bf3417dd1187c38ed6) · run [#33672840373](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33672840373) · 2026-09-02 13:24 MDT / 2026-09-02 19:24 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Profiling issue #112's hybrid/offload gap found the real dominant cost was `OffloadMoeCache.copy_missing()`'s per-row loop (49% of decode step time) — genuine LRU thrashing, not GIL bookkeeping as originally guessed. The natural fix (batching `copy_missing`) was tried and confirmed a regression via isolated `cProfile` on a quiet system (unpinned intermediate buffer moves more data, not less) — reverted, not in this PR.

Growing `cache_size` to fix the actual thrashing was blocked by a **second** bottleneck: `_resync_slot_for_id` did one `.item()` call per cache slot — each a device→host sync on XPU — so it scaled badly enough that a bigger cache just moved the bottleneck instead of fixing anything.

**Fix:** vectorize `_resync_slot_for_id` into a handful of tensor ops instead of a per-slot Python loop. Unlike `copy_missing`'s batching attempt, this is pure small index bookkeeping (not weight-sized data), so there's no "extra intermediate buffer" pitfall.

Shared by both `qwen3_moe` and `qwen3_5_moe` via the common `OffloadMoeCache`. Also unlocks issue #16's existing VRAM-budget auto-planner (`moe_cache_auto`) — before this fix, a bigger auto-planned cache would have hit the same O(cache_size) resync cost and made things *worse*; after, it picks `cache_size=1501` on this small model and reaches **34.9 tok/s** (vs 10.2 before either fix) with zero thrashing. No change to the conservative non-auto default — that stays right for models where full residency is impossible (the 35B hero).

Real B70 measurement (2.4B Qwen3-MoE, bf16, default `cache_size=32` — the unconditionally-shipped path):
```
offload: ~10.3 -> ~12.1 tok/s (+17%)
cpu:     ~10.3 -> ~11.6 tok/s (within noise; never touches OffloadMoeCache — no-regression check)
hybrid:  ~6.4  -> ~6.2 tok/s (within noise)
```

## Test plan
- [x] `tests/test_moe_offload_cache.py`, `test_moe_offload_forward.py`, `test_moe_hybrid_forward.py`, `test_moe_cpu_forward.py` — pass, byte-identical output
- [x] `pytest tests/ -m "not xpu"` — 239 passed, same 13 pre-existing unrelated failures as `main`
- [x] `tests/test_moe_hybrid_e2e_real_xpu.py` on real XPU hardware — passes, 0 exec-queue resets
- [x] `bench_decode_moe.py` before/after on real hardware, quiet system, `cProfile`-based cache-size sweep confirming both the thrashing hypothesis and this fix's effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement


___

### **Description**
- Replace per-slot resync loop with vectorized tensor ops

- Eliminate O(cache_size) device-to-host syncs on XPU

- Enable larger `moe_cache_auto` cache sizes without resync bottleneck

- Shared by `qwen3_moe` and `qwen3_5_moe` via `OffloadMoeCache`


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["id_of_slot tensor"] -- "bulk copy to CPU" --> B["CPU int64 ids"]
    B -- "mask valid ids" --> C["valid slot indices"]
    C -- "compute expert row and column" --> D["resynced mapping"]
    D -- "copy back to device" --> E["slot_for_id"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>offload_cache.py</strong><dd><code>Vectorize resync slot lookup using tensor ops</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/moe/offload_cache.py

<ul><li>Replace per-slot Python <code>.item()</code> loop with vectorized tensor operations<br> <li> Copy <code>id_of_slot</code> to CPU once and mask valid ids<br> <li> Build resynced <code>slot_for_id</code> mapping using slot indices and expert <br>rows/cols<br> <li> Copy the resynced mapping back to the device with <code>copy_</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/113/files#diff-2b28912e9e23e80a09b8bbfbfe7a0ceba4db2a916f9ba2fc974704f1f455702d">+16/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___