### PR TITLE
fix(models): fused in-VRAM MoE forward crashes on real XPU hardware

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1058,13 +1058,26 @@ class _Qwen35MoE:
         return executor.forward(flat, top_idx, top_w, gate_up, down)
 
     def _forward_inram(self, flat, top_idx, top_w):
+        # Indices are built on the HOST, not with device-side boolean-mask
+        # indexing (`flat[sel]`) or `torch.nonzero` on an XPU tensor: on this
+        # torch/XPU build, `nonzero()` (which boolean-mask indexing calls
+        # internally) silently returns an EMPTY result for an XPU bool tensor
+        # regardless of its actual content (`sel.sum()` / `sel.tolist()` are
+        # correct; `sel.nonzero()` / `flat[sel]` are not) -- a real
+        # correctness bug, not just the "implicit D2H sync" performance
+        # concern the offload path already routes around this same way (see
+        # qwen3_moe's in-VRAM forward for the same fix).
         out = torch.zeros_like(flat)
+        top_idx_cpu = top_idx.to("cpu")
         for e in range(self.num_experts):
             for slot in range(self.top_k):
-                sel = top_idx[:, slot] == e
-                if not sel.any():
+                sel_cpu = top_idx_cpu[:, slot] == e
+                if not bool(sel_cpu.any()):
                     continue
-                out[sel] += top_w[sel, slot, None] * self.experts[e](flat[sel])
+                idx = sel_cpu.nonzero(as_tuple=True)[0].to(flat.device)
+                w = top_w.index_select(0, idx)[:, slot, None]
+                y = self.experts[e](flat.index_select(0, idx))
+                out.index_add_(0, idx, w * y)
         return out
 
     def _forward_offload(self, flat, top_idx, top_w, ctx, batch):

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -492,12 +492,29 @@ class _Qwen3MoE(nn.Module):
 
         out = torch.zeros_like(flat)
         # Per-expert gather: route each expert's tokens in one matmul each.
+        #
+        # The routing mask is built and resolved to row indices on the HOST,
+        # not with device-side boolean-mask indexing (`flat[sel]`) or
+        # `torch.nonzero` on an XPU tensor: on this torch/XPU build,
+        # `nonzero()` (which boolean-mask indexing calls internally) silently
+        # returns an EMPTY result for an XPU bool tensor regardless of its
+        # actual content (`sel.sum()` / `sel.tolist()` are correct; `sel
+        # .nonzero()` / `flat[sel]` are not) -- a real correctness bug, not
+        # just the "implicit D2H sync" performance concern the offload /
+        # hybrid / cpu backends already route around this same way. Building
+        # the indices on the host and gathering with `index_select` /
+        # `index_add_` sidesteps it entirely (and keeps this path
+        # graph-capture-friendly: no data-dependent output shape).
+        top_idx_cpu = top_idx.to("cpu")
         for e in range(self.num_experts):
             for slot in range(self.top_k):
-                sel = (top_idx[:, slot] == e)
-                if not sel.any():
+                sel_cpu = top_idx_cpu[:, slot] == e
+                if not bool(sel_cpu.any()):
                     continue
-                out[sel] += top_w[sel, slot, None] * self.experts[e](flat[sel])
+                idx = sel_cpu.nonzero(as_tuple=True)[0].to(flat.device)
+                w = top_w.index_select(0, idx)[:, slot, None]
+                y = self.experts[e](flat.index_select(0, idx))
+                out.index_add_(0, idx, w * y)
         return out.view(in_shape)
 
     def _forward_offload(self, flat, top_idx, top_w, model, batch, *, exclude: set | None = None) -> torch.Tensor:

--- a/tests/test_moe_fused_xpu.py
+++ b/tests/test_moe_fused_xpu.py
@@ -1,0 +1,108 @@
+"""XPU regression test: the in-VRAM ("fused") MoE forward on real XPU hardware.
+
+``test_moe_offload_forward.py``'s in-VRAM *reference* runs on CPU only
+(``DEVICE = torch.device("cpu")``) -- it exists to validate the *offload*
+path, not the in-VRAM path itself, so it never exercised ``_Qwen3MoE.forward``'s
+resident-experts branch on an XPU tensor. That branch used device-side
+boolean-mask indexing (``flat[sel]`` / ``out[sel] +=``, backed by
+``torch.nonzero``) which silently returns an EMPTY result on this torch/XPU
+build for a multi-token step (multiple experts routing different tokens) --
+``sel.sum()`` / ``sel.tolist()`` show the mask is correct, but the indexed
+gather/scatter through ``nonzero()`` is not, and the forward raises inside the
+expert matmul (``numel: integer multiplication overflow``) once the *bogus*
+empty selection reaches a downstream shape check. A prefill (multiple new
+tokens in one step) exercises this; a bs=1 decode-only run does not, which is
+why the existing (CPU-only) coverage never caught it. Fixed by resolving the
+routing indices on the host, the same way the offload/hybrid/cpu backends
+already do.
+
+``xpu``-marked: deselected on a torch-free / no-XPU box (see ``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.models.loader import load_model
+
+from tests.test_moe_offload_forward import TINY_CONFIG, offload_ckpt  # noqa: F401
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _engine_config(model_path: str, device: torch.device) -> EngineConfig:
+    return EngineConfig(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=device,
+        attention_backend="auto",
+        moe_backend="fused",
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+        num_page_override=64,
+    )
+
+
+# 9 tokens (> num_experts * top_k), prefilled in one step: reliably reproduced
+# the device-side nonzero() bug in manual repro (empty result for a multi-True
+# boolean mask on XPU), unlike a 3-4 token prompt, where the bug is
+# intermittent -- it depends on *which* positions are True, not just how many.
+_PROMPT_IDS = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def _add_prompt(engine: Engine, output_len: int) -> None:
+    engine.add_request(
+        Req(
+            input_ids=list(_PROMPT_IDS),
+            table_idx=0,
+            cached_len=0,
+            output_len=output_len,
+            uid=0,
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+            cache_handle=None,
+        )
+    )
+
+
+@XPU
+def test_fused_inram_forward_matches_cpu_reference_on_xpu(offload_ckpt):
+    """A multi-token prefill through the in-VRAM path on real XPU hardware.
+
+    The 9-token prompt is prefilled in one step, so multiple experts route
+    different tokens in the same forward call -- the shape that reliably
+    exposed the device-side ``nonzero()`` bug (see module docstring). This
+    must not crash, and must reproduce the CPU in-VRAM reference's greedy
+    tokens exactly (same weights, same math, only the device differs).
+    """
+    dev = torch.device("xpu")
+
+    cpu_model, _ = load_model(offload_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="fused")
+    assert cpu_model.layers[0].mlp.experts is not None, "fused path must build resident experts"
+    cpu_engine = Engine(_engine_config(offload_ckpt, torch.device("cpu")))
+    _add_prompt(cpu_engine, output_len=6)
+    cpu_tokens = cpu_engine.generate()
+
+    xpu_model, _ = load_model(offload_ckpt, dev, dtype=torch.float32, moe_backend="fused")
+    assert xpu_model.layers[0].mlp.experts is not None
+    xpu_engine = Engine(_engine_config(offload_ckpt, dev))
+    _add_prompt(xpu_engine, output_len=6)
+    xpu_tokens = xpu_engine.generate()  # must not raise (the bug crashed here)
+
+    assert xpu_tokens == cpu_tokens, (
+        f"fused in-VRAM forward diverged between CPU and XPU: {xpu_tokens} != {cpu_tokens}"
+    )
+    assert len(xpu_tokens[0]) == 6
+    assert all(0 <= t < TINY_CONFIG["vocab_size"] for t in xpu_tokens[0])

--- a/tests/test_moe_fused_xpu.py
+++ b/tests/test_moe_fused_xpu.py
@@ -78,6 +78,7 @@ def _add_prompt(engine: Engine, output_len: int) -> None:
 
 
 @XPU
+@pytest.mark.xpu
 def test_fused_inram_forward_matches_cpu_reference_on_xpu(offload_ckpt):
     """A multi-token prefill through the in-VRAM path on real XPU hardware.
 


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit b03da0a](https://github.com/Performant-Labs/FreeToken-Intel/commit/b03da0af072debbb515195b7a9cfc5de3791578c) · run [#33679722620](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33679722620) · 2026-09-02 14:34 MDT / 2026-09-02 20:34 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Found while starting issue #15 (engine-graph): the "fused" (in-VRAM, no-offload) MoE backend — the one path with static shapes and no host-sync, the natural target for graph capture — had never been run end to end on real XPU hardware. It crashed on the first real multi-token prefill: `RuntimeError: numel: integer multiplication overflow`.

**Root cause:** `_Qwen3MoE.forward`'s in-VRAM branch used device-side boolean-mask indexing (`flat[sel]` / `out[sel] +=`, both backed by `torch.nonzero` internally). On this torch 2.13.0+xpu build, `nonzero()` on an XPU bool tensor silently returns an **empty** result for some index patterns while `sel.sum()` / `sel.tolist()` correctly show the mask's real content — confirmed with a minimal, 100%-reproducible standalone repro. This is a genuine PyTorch/XPU stack bug, not just the "implicit D2H sync" performance concern the offload/hybrid/cpu backends already route around this same way (their comments call that out explicitly) — it's silently *wrong*, not just slow.

**Fix:** resolve routing indices on the host (`.to("cpu")` then `nonzero()`, correct there) and gather/scatter with `index_select`/`index_add_`, mirroring the pattern `_forward_offload`/`_forward_hybrid`/`_forward_cpu` already use. Applied to both `qwen3_moe`'s `_Qwen3MoE.forward` and `qwen3_5_moe`'s `_forward_inram`.

**Bonus:** the fused backend is now not just correct but fast — **48.7 tok/s** on the 2.4B stand-in vs offload's ~12 tok/s (no PCIe streaming, no LRU thrashing, all experts resident). Worth a serving-policy look later (should `auto` prefer fused when a model actually fits?) — not addressed here.

## Test plan
- [x] `tests/test_moe_fused_xpu.py` (new, XPU-marked): drives the in-VRAM path through a real multi-token prefill on real hardware, compares against the CPU in-VRAM reference. Verified it fails with the exact original crash against pre-fix code, passes against the fix. (A 3-4 token prompt was *not* reliable — the underlying XPU bug is index-pattern-dependent, not purely count-dependent; a 9-token prompt reproduced it every time.)
- [x] `tests/test_moe_hybrid_forward.py`, `test_moe_offload_forward.py`, `test_moe_cpu_forward.py`, `test_moe_hybrid_e2e_real_xpu.py` — all pass, no regression
- [x] `pytest tests/ -m "not xpu"` — 240 passed (1 new), same 13 pre-existing unrelated failures as `main`
- [x] Real XPU hardware throughout, 0 new exec-queue resets from any test relevant to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix fused MoE routing on XPU using host-resolved indices

- Apply same fix to qwen3_moe and qwen3_5_moe

- Add XPU regression test for multi-token prefill


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["qwen3_moe in-VRAM forward"] --> B["Resolve routing indices on host"]
  C["qwen3_5_moe _forward_inram"] --> B
  B --> D["index_select / index_add_"]
  D --> E["Fused MoE expert output"]
  F["tests/test_moe_fused_xpu.py"] --> G["XPU regression test"]
  G --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Fix in-VRAM MoE routing on XPU</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_moe/__init__.py

<ul><li>Replace device-side boolean-mask indexing with host-resolved routing <br>indices.<br> <li> Move <code>top_idx</code> to CPU, compute <code>nonzero(as_tuple=True)[0]</code>, then move <br>indices back to the flat device.<br> <li> Use <code>index_select</code> for flat and weights, and <code>index_add_</code> for output <br>accumulation.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/114/files#diff-7df44a0f5eb5c411dc8b6f5d672093944a031ba3e91e79a23781674f3ceb1a3e">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Mirror host-index fix in qwen3_5_moe in-VRAM path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li>Apply the same host-resolved index fix to <code>_forward_inram</code>.<br> <li> Avoid device-side boolean-mask indexing and <code>torch.nonzero</code> on XPU.<br> <li> Preserve expert output accumulation with <code>index_add_</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/114/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_moe_fused_xpu.py</strong><dd><code>Add XPU regression test for fused MoE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_moe_fused_xpu.py

<ul><li>Add XPU-marked regression test for fused in-VRAM MoE prefill.<br> <li> Drive a 9-token multi-token prompt on real XPU hardware.<br> <li> Compare generated tokens against the CPU in-VRAM reference.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/114/files#diff-35e6556e31e54e97a62e33fd7d33d349de431b41f69978167dd763bc4cd95121">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___