### PR TITLE
fix(attention): export SyclAttentionBackend lazily, defer constructor's config read

### DIFF
--- a/python/freetoken/attention/__init__.py
+++ b/python/freetoken/attention/__init__.py
@@ -116,4 +116,21 @@ __all__ = [
     "create_attention_backend",
     "SUPPORTED_ATTENTION_BACKENDS",
     "validate_attn_backend",
+    "SyclAttentionBackend",
+    "SyclMetadata",
 ]
+__all_lazy__ = {"SyclAttentionBackend", "SyclMetadata"}
+
+
+def __getattr__(name):
+    # PEP 562: lazy re-export so this package stays torch-free at import time
+    # (sycl.py imports torch at module scope -- see create_sycl_backend above).
+    if name in __all_lazy__:
+        from . import sycl
+
+        return getattr(sycl, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(__all__) | set(globals()))

--- a/python/freetoken/attention/sycl.py
+++ b/python/freetoken/attention/sycl.py
@@ -137,6 +137,14 @@ class SyclAttentionBackend(BaseAttnBackend):
         backend, so read it from there; fall back to deriving it from the engine
         config the way the pool is sized (``num_page_override`` or
         ``max_running_req * max_seq_len``).
+
+        Both lookups are best-effort: the constructor must stay lazy-safe (see
+        ``_ensure_loaded``'s docstring) even when ``config`` is a minimal / mock
+        object with none of the expected fields (a real ``EngineConfig`` always
+        has them; only a deliberately-bare object, as the "constructor is safe"
+        test uses, does not). 0 here just means "not yet known" -- real usage
+        always has a real config or an attached pool by the time a kernel
+        actually runs, in ``_ensure_loaded`` / the forward methods below.
         """
         try:
             pool = getattr(_get_ctx(), "kv_cache", None)
@@ -144,8 +152,11 @@ class SyclAttentionBackend(BaseAttnBackend):
                 return int(pool.num_slots)
         except Exception:
             pass
-        num_pages = config.num_page_override or (config.max_running_req * config.max_seq_len)
-        return int(num_pages) * int(config.page_size)
+        try:
+            num_pages = config.num_page_override or (config.max_running_req * config.max_seq_len)
+            return int(num_pages) * int(config.page_size)
+        except AttributeError:
+            return 0
 
     def _ensure_loaded(self) -> None:
         """Compile (or load from the AOT cache) attention.cpp and bind entry points.


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 90** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 137fd81](https://github.com/Performant-Labs/FreeToken-Intel/commit/137fd811967d7df5aefa9ca2e7f2c475a0144504) · run [#33683727693](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33683727693) · 2026-09-02 15:13 MDT / 2026-09-02 21:13 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Found starting issue #15 (engine-graph): the SYCL kernel toolchain (icpx, oneAPI 2026.1) is fully installed on this box — `tests/test_attention_sycl.py` was failing all session not because the kernel is broken, but because invoking pytest without first sourcing `setvars-xpu.sh` in the same shell call left `icpx` off `PATH`. With the environment correctly sourced, 3 of 6 tests already passed outright.

Two of the remaining three were real, independent bugs:

- `freetoken.attention/__init__.py` never re-exported `SyclAttentionBackend`/`SyclMetadata`. Fixed via the same lazy `__getattr__` (PEP 562) pattern `freetoken.engine`/`freetoken.models` already use, keeping the package torch-free at import time.
- `SyclAttentionBackend.__init__` eagerly read `config.num_page_override`/etc with no guard, violating `_ensure_loaded`'s own documented "constructor is safe (lazy)" contract. Fixed: the fallback derivation is now try/except-guarded like the pool-lookup branch above it.

Both independently verified: `pytest -m "not xpu"` now shows **11** pre-existing failures instead of 13 (both fixed tests are CPU-safe), and **5 of 6** `test_attention_sycl.py` tests pass on real hardware (up from 1).

**Not fixed here:** the sixth test (`test_sycl_backend_matches_reference_random_weights_on_xpu`, a real numeric divergence under non-trivial weights). Investigated separately — both `decode_attention` and `prefill_attention` kernels were verified byte-correct against the reference math in isolation (direct kernel calls with controlled Q/K/V and an identity slot table match to float32 rounding noise, for growing decode kv_len and a 3-token causal prefill). So the bug isn't the kernel's attention math — it's somewhere in how the real engine's per-step metadata (page table/kv_len/qpos) threads through `_build_metadata` across a live multi-step decode. Needs its own follow-up.

## Test plan
- [x] `tests/test_attention_sycl.py` — 5/6 pass on real XPU hardware (up from 1)
- [x] `pytest tests/ -m "not xpu"` — 241 passed, 11 pre-existing unrelated failures (down from 13)
- [x] Direct kernel-vs-reference math verification for both decode and prefill paths (see commit message)
- [x] Real XPU hardware throughout, 0 new exec-queue resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix


___

### **Description**
- Add lazy `SyclAttentionBackend` and `SyclMetadata` exports.

- Guard `_resolve_num_slots` fallback config reads.

- Preserve torch-free package import via PEP 562.

- Return 0 slots when config fields are missing.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["attention/__init__.py"] -- "adds __all_lazy__ and __getattr__" --> B["Lazy re-export of SyclAttentionBackend and SyclMetadata"]
    C["SyclAttentionBackend._resolve_num_slots"] -- "try/except AttributeError" --> D["Returns 0 for bare or mock config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Lazy SYCL attention class re-export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/attention/__init__.py

<ul><li>Adds <code>SyclAttentionBackend</code> and <code>SyclMetadata</code> to <code>__all__</code>.<br> <li> Introduces <code>__all_lazy__</code> and PEP 562 <code>__getattr__</code> to import from <code>.sycl</code> <br>lazily.<br> <li> Adds <code>__dir__</code> to include lazy attributes.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/115/files#diff-9aab77f5f638c8dd1aa451d1b536d581086e0d8c719a12c5f16ea49fec3af64a">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sycl.py</strong><dd><code>Guard constructor config fallback reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/attention/sycl.py

<ul><li>Wraps fallback config derivation in <code>_resolve_num_slots</code> with <code>try/except </code><br><code>AttributeError</code>.<br> <li> Returns 0 when config lacks expected attributes, preserving lazy-safe <br>constructor.<br> <li> Expands docstring to document best-effort lookups.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/115/files#diff-2964e92209720555499ebe6f84f02da86955ea251c1d8701540e8351d3a1f27e">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___