### PR TITLE
fix(attention): sycl backend misclassifies the first decode step as prefill

### DIFF
--- a/python/freetoken/attention/sycl.py
+++ b/python/freetoken/attention/sycl.py
@@ -241,10 +241,25 @@ class SyclAttentionBackend(BaseAttnBackend):
         # and grows every step, so it is 1 only on a degenerate first decode).
         # The per-request new-token count comes from ``batch.extend_lens`` (the
         # engine's authoritative vector: prompt_len in prefill, 1 in decode).
+        # Per-request phase: ``batch.phase`` (the scheduler's authoritative,
+        # always-correct flag -- every other backend in this codebase trusts it
+        # uniformly, e.g. TritonAttentionBackend / _forward_offload). The
+        # previous per-request re-derivation (``req.device_len !=
+        # len(req.input_ids)``) miscompares equal on the FIRST decode step
+        # following a full prompt prefill: the engine's post-step bookkeeping
+        # appends the sampled token to input_ids on a prefill step (input_ids
+        # grows to prompt_len+1) and bumps device_len to prompt_len+1 in the
+        # same step, so the two coincidentally match going into the very next
+        # step and that step is misclassified as ANOTHER prefill (kv_len=1
+        # instead of the real history length) -- corrupting decode attention
+        # from the second generated token onward. Confirmed by tracing the
+        # real per-step tables: this file's own docstrings elsewhere in this
+        # module warn against exactly this class of shape-based phase check.
+        is_decode_batch = batch.phase == "decode"
         dec_idx: list[int] = []
         pre_idx: list[int] = []
         for b, req in enumerate(batch.reqs):
-            (dec_idx if req.device_len != len(req.input_ids) else pre_idx).append(b)
+            (dec_idx if is_decode_batch else pre_idx).append(b)
         bs_dec, bs_pre = len(dec_idx), len(pre_idx)
 
         # ``positions`` / ``out_loc`` are token-indexed: one entry per *new* token,
@@ -373,10 +388,11 @@ class SyclAttentionBackend(BaseAttnBackend):
         # order, so find this request's row and make a 1-row USM view of it.
         req = next((r for r in batch.reqs if table_idx is None or r.table_idx == table_idx), batch.reqs[0])
         b = batch.reqs.index(req)
-        # Same phase signal as _build_metadata / the engine's step(): a request
-        # is in decode once a token has been generated (device_len grew past the
-        # prompt length). NOT ``extend_len == 1`` (that grows every step).
-        is_decode = req.device_len != len(req.input_ids)
+        # Same phase signal as _build_metadata: batch.phase (see that method's
+        # docstring for why the previous per-request device_len/input_ids
+        # comparison was wrong -- it miscompared equal on the first decode step
+        # after a full prefill).
+        is_decode = batch.phase == "decode"
         table = metadata.decode if is_decode else metadata.prefill
         if table is None:
             # No rows of this phase were built (should not happen when the
@@ -387,10 +403,10 @@ class SyclAttentionBackend(BaseAttnBackend):
         # exactly the dec_idx / pre_idx order _build_metadata used. The kernel's
         # bs=1 launch reads rows [0, 0+K), so point it at this request's row by
         # passing a 1-row USM slice at the phase-list index (a torch slice of an
-        # XPU tensor stays USM-backed: same storage, a row offset). Count the
-        # matching-phase requests up to and including this one (b) to get the
-        # phase-list index.
-        phase_idx = sum(1 for j in range(b + 1) if (batch.reqs[j].device_len != len(batch.reqs[j].input_ids)) == is_decode) - 1
+        # XPU tensor stays USM-backed: same storage, a row offset). Every
+        # request in the batch shares the same phase (batch.phase is uniform),
+        # so the phase-list index is just this request's position in the batch.
+        phase_idx = b
         one_row = table[phase_idx : phase_idx + 1]
         # q is head-major [qh, ext, d]; the kernel wants token-major [ext, qh, d].
         q_tok = q.transpose(0, 1).contiguous()


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 80** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit b399a41](https://github.com/Performant-Labs/FreeToken-Intel/commit/b399a413b9552eb1fa384fec1fccf3aa86b6e3e5) · run [#33684659420](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33684659420) · 2026-09-02 15:26 MDT / 2026-09-02 21:26 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Found via instrumented tracing of the real per-step metadata tables while investigating #114/#115's remaining `test_sycl_backend_matches_reference_random_weights_on_xpu` failure.

`SyclAttentionBackend._build_metadata` and `.forward()` both re-derived per-request phase with `req.device_len != len(req.input_ids)` instead of trusting `batch.phase` (the scheduler's authoritative flag every other backend in this codebase uses uniformly — `TritonAttentionBackend`, `_forward_offload`, etc).

That check coincidentally evaluates equal on exactly the **first decode step following a full prompt prefill**: a prefill step's post-processing appends the sampled token to `input_ids` and bumps `device_len` to the same value in the same step, so going into the very next step `device_len == len(input_ids)` — misclassifying that step as ANOTHER prefill (`kv_len=1`) instead of a decode attending the real history (`kv_len=prompt_len+1`). Traced on a 3-token prompt: step 2 built `kv_len=1` instead of the correct `kv_len=4`, corrupting every decode step from the second generated token onward. This is the exact "degenerate first decode" shape-based phase-detection pitfall this codebase's own comments warn against elsewhere (`engine.py`, `models/qwen3_moe`) — `sycl.py` hadn't been updated to match.

**Fix:** use `batch.phase == "decode"` uniformly. Verified via re-trace: the fixed first-decode step now correctly reads `kv_len=4 qpos=3`.

**Does not fully close** `test_sycl_backend_matches_reference_random_weights_on_xpu`: tokens still diverge, including token 1 (from the prefill step, untouched by this fix) — consistent with the test's own documented risk of a near-tie greedy argmax flip from SYCL-vs-torch floating-point accumulation order differences, not a further logic bug. Left failing rather than declared fixed.

## Test plan
- [x] Instrumented before/after trace confirming the metadata table is now structurally correct
- [x] `tests/test_attention_sycl.py` — 5/6 pass (same as before this fix; the remaining failure is the float-noise issue above, not a regression)
- [x] `pytest tests/ -m "not xpu"` — 241 passed, same 11 pre-existing unrelated failures
- [x] Real XPU hardware, 0 new exec-queue resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix


___

### **Description**
- Use `batch.phase == "decode"` instead of per-request `device_len != len(input_ids)` phase checks.

- Fix first decode step misclassified as prefill.

- Simplify `phase_idx` to request batch position.

- Expand comments warning about shape-based phase detection.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scheduler batch.phase decode flag"] -- "authoritative phase signal" --> B["_build_metadata splits dec_idx/pre_idx"]
  A -- "same signal" --> C["forward selects decode or prefill table"]
  B -- "correct first decode kv_len" --> D["Fixes first decode misclassification"]
  C -- "phase_idx equals batch position" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sycl.py</strong><dd><code>SYCL attention phase detection fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/attention/sycl.py

<ul><li>Replace per-request phase derivation with <code>batch.phase == "decode"</code> in <br><code>_build_metadata</code>.<br> <li> Update <code>forward</code> table selection to use the same <code>batch.phase</code> signal.<br> <li> Change <code>phase_idx</code> calculation from counting matching-phase requests to <br>batch position <code>b</code>.<br> <li> Expand comments explaining why the previous <code>device_len != </code><br><code>len(input_ids)</code> check misclassifies the first decode step after <br>prefill.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/116/files#diff-2964e92209720555499ebe6f84f02da86955ea251c1d8701540e8351d3a1f27e">+25/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___