### PR TITLE
feat(engine): XpuGraphRunner capture/replay primitive (issue #15)

### DIFF
--- a/python/freetoken/engine/graph.py
+++ b/python/freetoken/engine/graph.py
@@ -2,19 +2,123 @@
 
 Upstream NVIDIA path: python/freetoken/engine/graph.py
 Fill in: GitHub issue `engine-graph` (see docs/architecture.md).
+
+``torch.xpu`` on this box (torch 2.13.0+xpu) exposes the same graph-capture
+API CUDA does (``torch.xpu.XPUGraph`` / ``torch.xpu.graph`` / a warmup-on-a-
+side-stream-then-capture sequence) -- verified with a minimal standalone
+capture+replay of an ``nn.Linear`` forward, bit-exact against eager.
+
+:class:`XpuGraphRunner` is a thin, model-agnostic wrapper around that API: it
+captures whatever ``fn`` does into a graph and replays it. It does **not**
+itself know anything about the engine, the model, or attention -- the caller
+is responsible for making sure every tensor ``fn`` reads or writes has a
+*fixed address* across capture and every replay (the same discipline CUDA
+graphs require): pass data in via tensors you already hold a persistent
+reference to and mutate in place (``.copy_()``), never ones ``fn`` allocates
+fresh each call.
+
+**Neither attention backend is actually graph-capturable today** (issue
+``engine-graph`` / #15), for two distinct reasons found while wiring this up:
+
+* ``TritonAttentionBackend`` (the pure-torch reference) reads a KV history of
+  length ``req.device_len``, which *grows every decode step* -- a fresh
+  ``torch.arange(written)`` each call. Graph capture replays the exact same
+  kernel launches against the exact same tensor shapes every time, so a
+  growing shape breaks it outright. Fixing this means rewriting the attention
+  math to attend over a fixed-size ``max_seq_len`` buffer with a mask instead
+  of a growing slice (the same design real paged-attention kernels use, and
+  what upstream's own ``engine/graph.py`` assumes its attention backend
+  already does) -- an algorithmic change, not a plumbing one.
+
+* ``SyclAttentionBackend`` calls its compiled kernel through raw ``ctypes``
+  (see ``attention/sycl.py``), and the C++ side (``attention.cpp``) opens its
+  **own** ``sycl::queue`` internally rather than submitting onto torch's
+  currently-recording stream -- so ``torch.xpu.graph()`` cannot see that work
+  at all, capturable or not. ``forward()`` also calls ``torch.xpu.synchronize()``
+  immediately before the kernel call (needed today so the USM inputs are
+  ready), and a host sync during capture is a hard error under
+  ``torch.xpu.graph()`` (confirmed directly: ``RuntimeError: wait cannot be
+  called for a queue which is recording to a command graph``). Fixing this
+  needs the kernel to accept and submit onto torch's active queue/stream, and
+  the synchronize to be removed or made capture-safe -- C++/SYCL kernel
+  surgery, not a Python change.
+
+Both are real architectural gaps, not just missing plumbing, and each is its
+own follow-up. What *is* proven correct and ready to build on: the
+capture/replay mechanism itself. ``torch.xpu.graph`` / ``torch.xpu.XPUGraph``
+work exactly like their CUDA counterparts on this box (torch 2.13.0+xpu,
+verified with a minimal ``nn.Linear`` capture+replay, bit-exact against
+eager -- see ``tests/test_engine_graph_xpu.py``), and additionally, a decode
+step's per-request ``batch.extend_lens`` is read with a Python-level
+``int(extend_lens[i])`` inside the model's decoder-layer loop -- a host sync
+that would *also* block capture at the whole-model level even once an
+attention backend supports it, and needs to be resolved (or worked around
+per-request) before a whole ``model.forward()`` can be captured end to end.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+from freetoken.utils import init_logger
+
+logger = init_logger(__name__)
 
 
 class XpuGraphRunner:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    """Capture a sequence of XPU kernel launches once; replay without
+    repeating the Python-level dispatch that produced them.
 
-    def capture(self, *args, **kwargs):
-        unimplemented("XpuGraphRunner.capture", "engine-graph")
+    Not thread-safe and not reentrant: one runner captures one graph. Build a
+    new runner (or call :meth:`capture` again) to capture a different ``fn``.
+    """
 
-    def replay(self, *args, **kwargs):
-        unimplemented("XpuGraphRunner.replay", "engine-graph")
+    def __init__(self, warmup_iters: int = 3) -> None:
+        self.warmup_iters = warmup_iters
+        self._graph = None
 
+    @property
+    def is_captured(self) -> bool:
+        return self._graph is not None
+
+    def capture(self, fn):
+        """Warm up ``fn`` on a side stream, then capture one call of it.
+
+        ``fn`` takes no arguments and should read/write only tensors the
+        caller already holds fixed-address references to (see module
+        docstring). Returns whatever ``fn()`` returns from the *capture*
+        call -- useful for a quick sanity check, but not a live view of
+        replay's output: read the static buffer(s) ``fn`` wrote into after
+        calling :meth:`replay`, not this return value.
+
+        Raises ``RuntimeError`` if no XPU is available -- graph capture is
+        meaningless without one, and callers should catch this and fall back
+        to eager execution (the issue's own accept criterion: "document if
+        graphs are unsupported on a given driver").
+        """
+        import torch
+
+        if not (hasattr(torch, "xpu") and torch.xpu.is_available()):
+            raise RuntimeError(
+                "XPU graph capture requires a torch XPU device; use eager execution instead"
+            )
+
+        # Warmup on a side stream (required before capture: it lets any
+        # lazy one-time allocations / kernel JIT happen off the capture
+        # stream, matching torch.cuda.graph's own documented sequence).
+        side_stream = torch.xpu.Stream()
+        side_stream.wait_stream(torch.xpu.current_stream())
+        with torch.xpu.stream(side_stream):
+            for _ in range(self.warmup_iters):
+                fn()
+        torch.xpu.current_stream().wait_stream(side_stream)
+        torch.xpu.synchronize()
+
+        self._graph = torch.xpu.XPUGraph()
+        with torch.xpu.graph(self._graph):
+            result = fn()
+        torch.xpu.synchronize()
+        return result
+
+    def replay(self) -> None:
+        """Replay the captured graph. Raises if :meth:`capture` was never called."""
+        if self._graph is None:
+            raise RuntimeError("XpuGraphRunner.replay() called before capture()")
+        self._graph.replay()

--- a/tests/test_engine_graph_xpu.py
+++ b/tests/test_engine_graph_xpu.py
@@ -1,0 +1,100 @@
+"""XPU tests: XpuGraphRunner's capture/replay mechanism (issue `engine-graph`, #15).
+
+These test the capture/replay *primitive* in isolation (a plain nn.Linear
+forward against static tensors) -- not attention or the model, which are not
+yet graph-capturable (see graph.py's module docstring for the two distinct
+reasons why, found while wiring this up). That is the honest scope this
+issue closes today: the mechanism is proven correct and available on this
+box; wiring it into either attention backend or the model is real follow-up
+work, tracked separately.
+
+``xpu``-marked: deselected on a torch-free / no-XPU box (see ``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.engine.graph import XpuGraphRunner
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+
+@XPU
+@pytest.mark.xpu
+def test_capture_replay_matches_eager():
+    """A captured nn.Linear forward, replayed, matches eager exactly."""
+    dev = torch.device("xpu")
+    torch.manual_seed(0)
+    lin = torch.nn.Linear(64, 64).to(dev)
+
+    static_in = torch.randn(4, 64, device=dev)
+    static_out = torch.empty(4, 64, device=dev)
+
+    def _fn():
+        static_out.copy_(lin(static_in))
+
+    runner = XpuGraphRunner(warmup_iters=3)
+    assert not runner.is_captured
+    runner.capture(_fn)
+    assert runner.is_captured
+
+    with torch.no_grad():
+        expected = lin(static_in)
+
+    runner.replay()
+    torch.xpu.synchronize()
+    assert torch.equal(static_out, expected), "replay must match eager bit-exact for identical inputs"
+
+
+@XPU
+@pytest.mark.xpu
+def test_replay_reflects_updated_static_input():
+    """Replay reads the CURRENT contents of the static input tensor.
+
+    This is the property multi-step reuse depends on: capture once, then
+    mutate the static buffer in place and replay again -- the graph must
+    read the new values, not the ones frozen at capture time.
+    """
+    dev = torch.device("xpu")
+    torch.manual_seed(1)
+    lin = torch.nn.Linear(32, 32).to(dev)
+
+    static_in = torch.randn(2, 32, device=dev)
+    static_out = torch.empty(2, 32, device=dev)
+
+    def _fn():
+        static_out.copy_(lin(static_in))
+
+    runner = XpuGraphRunner(warmup_iters=3)
+    runner.capture(_fn)
+
+    new_in = torch.randn(2, 32, device=dev)
+    with torch.no_grad():
+        expected = lin(new_in)
+
+    static_in.copy_(new_in)
+    runner.replay()
+    torch.xpu.synchronize()
+    assert torch.equal(static_out, expected)
+
+
+@XPU
+@pytest.mark.xpu
+def test_replay_before_capture_raises():
+    runner = XpuGraphRunner()
+    with pytest.raises(RuntimeError, match="capture"):
+        runner.replay()
+
+
+def test_capture_without_xpu_raises_not_crashes(monkeypatch):
+    """Off an XPU box, capture() must raise a clear RuntimeError (the issue's
+    own accept criterion: document unsupported drivers, eager fallback),
+    never crash or hang."""
+    import freetoken.engine.graph as graph_mod
+
+    monkeypatch.setattr(torch, "xpu", type("_NoXpu", (), {"is_available": staticmethod(lambda: False)})())
+    runner = graph_mod.XpuGraphRunner()
+    with pytest.raises(RuntimeError, match="XPU"):
+        runner.capture(lambda: None)


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 87** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/117#issuecomment-5516876336) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit e5609f7](https://github.com/Performant-Labs/FreeToken-Intel/commit/e5609f7bffb82c153c83569d38fa41e1e7fc8c4c) · run [#33686517121](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33686517121) · 2026-09-02 15:45 MDT / 2026-09-02 21:45 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Fills in `engine/graph.py`'s `XpuGraphRunner`: a thin, model-agnostic wrapper around `torch.xpu.graph`/`torch.xpu.XPUGraph` (verified present and working on this box, torch 2.13.0+xpu — capture+replay of an `nn.Linear` forward is bit-exact against eager).

**Honest scope: neither attention backend in this port is actually graph-capturable today**, for two distinct reasons found while wiring this up (both documented in `graph.py`'s module docstring):

- `TritonAttentionBackend` (pure-torch reference) reads a KV history whose length grows every decode step — a fresh `torch.arange(written)` each call. Graph capture requires identical tensor shapes on every replay. Needs an algorithmic rewrite to a fixed-size masked KV buffer (real paged-attention design).
- `SyclAttentionBackend` calls its kernel through raw `ctypes` into C++ that opens its **own** `sycl::queue` internally rather than submitting onto torch's currently-recording stream, so `torch.xpu.graph` can't see that work at all. Its `forward()` also calls `torch.xpu.synchronize()` right before the kernel call — a hard error under capture (confirmed directly: `RuntimeError: wait cannot be called for a queue which is recording to a command graph`). Needs C++/SYCL kernel surgery.

A third, model-level blocker: the decoder-layer loop reads `int(batch.extend_lens[i])` per request — a host sync that would also block capturing a whole `model.forward()` once an attention backend supports it.

**What IS proven and shipped:** the capture/replay mechanism itself (`tests/test_engine_graph_xpu.py`) — bit-exact replay, correctly reads updated static-buffer values across repeated replays (the property real multi-step reuse depends on), raises a clear `RuntimeError` off an XPU box rather than crashing (the issue's "document unsupported, eager fallback" accept criterion).

**Not closing #15**: its literal accept criterion ("captured decode replay matches eager decode numerically on a tiny model") isn't met here — that needs one of the two backend fixes above first. Filing both as separate follow-ups; this PR is the foundation they'd build on.

## Test plan
- [x] `tests/test_engine_graph_xpu.py` (new) — 4 tests: capture+replay bit-exact, replay reflects updated static input, replay-before-capture raises, no-XPU raises cleanly
- [x] `pytest tests/ -m "not xpu"` — 242 passed (1 new), same 11 pre-existing unrelated failures
- [x] Real XPU hardware, 0 new exec-queue resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `XpuGraphRunner` capture/replay via `torch.xpu.XPUGraph`

- Document graph-capture blockers in attention and model loops

- Add XPU tests for bit-exact and static-input replay


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["XpuGraphRunner"] --> B["capture(fn): warmup side stream + XPUGraph"]
  B --> C["XPU graph captures fn"]
  C --> D["replay(): graph replay"]
  B --> E["No XPU raises RuntimeError"]
  D --> F["Tests verify bit-exact and updated input"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graph.py</strong><dd><code>Implement XPU graph capture/replay runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/engine/graph.py

<ul><li>Replace <code>unimplemented</code> stubs with real <code>XpuGraphRunner</code> implementation<br> <li> Add XPU availability check raising <code>RuntimeError</code> when unavailable<br> <li> Perform warmup on side stream before <code>torch.xpu.XPUGraph</code> capture<br> <li> Document attention backend and host-sync graph-capture blockers</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/117/files#diff-3d7c1b0f5fe15b87ca7a6a57ec0f38fa5e9c75cd9aec3dffc1c2ae8498d62764">+111/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_engine_graph_xpu.py</strong><dd><code>Add XPU graph runner tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_engine_graph_xpu.py

<ul><li>Add XPU test for bit-exact <code>nn.Linear</code> capture/replay vs eager<br> <li> Test replay reads updated static input buffer across replays<br> <li> Test replay before capture and no-XPU behavior raise cleanly</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/117/files#diff-92da00a0e6e212f2f28fa14a2c97b4b37bf12c038e682a0407448fb7f77f9241">+100/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___