### PR TITLE
feat(attention): fixed-shape KV read for graph capture (issue #118)

### DIFF
--- a/python/freetoken/attention/triton.py
+++ b/python/freetoken/attention/triton.py
@@ -48,6 +48,20 @@ class TritonAttentionBackend(BaseAttnBackend):
         self.capture = None
         self.capture_bs = []
         self.max_graph_bs = 0
+        # Issue moe-hybrid-overlap's graph-capture sibling (engine-graph, #15
+        # / attn-triton-fixed-kv, #118): a decode step's KV read normally
+        # walks torch.arange(written) -- a shape that GROWS every step, which
+        # torch.xpu.graph() cannot replay (capture requires identical tensor
+        # shapes on every replay). When capturing, _attend_one instead reads
+        # a FIXED torch.arange(max_seq_len) range with an extra mask term
+        # (keypos < written) gating out the not-yet-written tail -- the
+        # standard fixed-buffer / paged-attention trick. This is strictly
+        # more compute per step (O(max_seq_len) instead of O(written)), so it
+        # is used ONLY while _capturing is True (set by prepare_for_capture);
+        # ordinary eager decode (no capture in flight) keeps the cheaper
+        # growing-slice read unchanged.
+        self._capturing = False
+        self._graph_max_seq_len = 0
 
     # -- BaseAttnBackend interface -------------------------------------------
 
@@ -57,14 +71,24 @@ class TritonAttentionBackend(BaseAttnBackend):
         return None
 
     def init_capture_graph(self, max_seq_len: int, bs_list) -> None:
-        # No CUDA/XPU graph capture in the reference backend.
+        self._graph_max_seq_len = int(max_seq_len)
         self.max_graph_bs = max(bs_list) if bs_list else 0
 
     def prepare_for_capture(self, batch) -> None:
-        return None
+        # Arms the fixed-shape KV read for the capture call(s) that follow
+        # (XpuGraphRunner.capture's warmup iterations + the one actual
+        # capture). Replay never re-enters this Python forward -- the graph
+        # replays the already-captured kernel sequence directly -- so there
+        # is nothing to arm in prepare_for_replay.
+        self._capturing = self._graph_max_seq_len > 0
 
     def prepare_for_replay(self, batch) -> None:
         return None
+
+    def reset_capture(self) -> None:
+        super().reset_capture()
+        self._capturing = False
+        self._graph_max_seq_len = 0
 
     def forward(
         self,
@@ -159,13 +183,27 @@ class TritonAttentionBackend(BaseAttnBackend):
         return out
 
     def _attend_one(self, req, qh, q_pos, written, repeat, scale, window: int = 0, layer_id: int = 0) -> torch.Tensor:
-        """Attend a block of query rows against one request's KV history."""
+        """Attend a block of query rows against one request's KV history.
+
+        Reads exactly ``[0, written)`` -- the cheap, shape-varies-per-step
+        path -- unless a graph capture is in flight (see ``prepare_for_capture``),
+        in which case it reads the FIXED ``[0, max_seq_len)`` range instead
+        (same total key count on every call, gated by an extra ``keypos <
+        written`` mask term) so the kernel launches this produces are
+        replayable. The not-yet-written tail's bytes are whatever the pool
+        buffer currently holds there (zero-initialized, or a stale previous
+        request's finite floats) -- never read as a *value*: the mask sets
+        that position's score to -inf before the softmax, so it contributes
+        exactly zero regardless of content.
+        """
         ctx = _get_ctx()
         kv_cache = ctx.kv_cache
         dev = qh.device
-        k_tok, v_tok = kv_cache.read_kv(req.table_idx, torch.arange(written, device=dev), layer_id)
-        k_all = k_tok.transpose(0, 1).contiguous()  # [kv, written, D]
-        v_all = v_tok.transpose(0, 1).contiguous()  # [kv, written, D]
+        capture_len = self._graph_max_seq_len if self._capturing else 0
+        read_len = capture_len if capture_len > written else written
+        k_tok, v_tok = kv_cache.read_kv(req.table_idx, torch.arange(read_len, device=dev), layer_id)
+        k_all = k_tok.transpose(0, 1).contiguous()  # [kv, read_len, D]
+        v_all = v_tok.transpose(0, 1).contiguous()  # [kv, read_len, D]
         if repeat != 1:
             # GQA: query head h attends KV head h // repeat. That is an
             # *interleave* of the KV heads ([0,0,1,1] for 2 kv heads, repeat 2),
@@ -173,16 +211,21 @@ class TritonAttentionBackend(BaseAttnBackend):
             # axis and would map query heads to the wrong KV head whenever there
             # are multiple KV heads (head 1 would read KV head 1 instead of 0).
             # `repeat_interleave` gives the correct h // repeat mapping.
-            k_all = k_all.repeat_interleave(repeat, dim=0)  # [num_heads, written, D]
+            k_all = k_all.repeat_interleave(repeat, dim=0)  # [num_heads, read_len, D]
             v_all = v_all.repeat_interleave(repeat, dim=0)
-        # scores = qh @ k_all^T -> [heads, qlen, written]. The mask is
-        # [1, qlen, written] (broadcast over the head dim), comparing query
+        # scores = qh @ k_all^T -> [heads, qlen, read_len]. The mask is
+        # [1, qlen, read_len] (broadcast over the head dim), comparing query
         # positions (dim 1) against key positions (dim 2). Causal: a query at
         # position q attends keys at position <= q. SWA (window > 0) additionally
         # restricts to the most recent `window` keys: q - keypos < window. This
-        # matches the SYCL kernel's branch-free mask exactly.
-        key_pos = torch.arange(written, device=dev)
+        # matches the SYCL kernel's branch-free mask exactly. When read_len >
+        # written (capturing), an extra `keypos < written` term masks out the
+        # not-yet-written tail -- causal alone would not, since those slots'
+        # positions are still <= q for a query far enough along.
+        key_pos = torch.arange(read_len, device=dev)
         allowed = q_pos[None, :, None] >= key_pos[None, None, :]
+        if read_len > written:
+            allowed = allowed & (key_pos[None, None, :] < written)
         if window > 0:
             allowed = allowed & ((q_pos[None, :, None] - key_pos[None, None, :]) < window)
         scores = torch.matmul(qh, k_all.transpose(-1, -2)) * scale

--- a/tests/test_attention_triton_capture_xpu.py
+++ b/tests/test_attention_triton_capture_xpu.py
@@ -1,0 +1,109 @@
+"""XPU tests: TritonAttentionBackend's fixed-shape (graph-capturable) KV read.
+
+Issue attn-triton-fixed-kv (#118), a follow-up to engine-graph (#15):
+``_attend_one`` normally reads exactly ``[0, written)`` keys, a shape that
+grows every decode step -- incompatible with ``torch.xpu.graph()``, which
+replays the identical kernel launches (identical tensor shapes) every time.
+While ``self._capturing`` is armed (``prepare_for_capture``), it instead
+reads a FIXED ``[0, max_seq_len)`` range with an extra ``keypos < written``
+mask term, so the shape never changes.
+
+Scope actually proven here: capture is possible (the shape-varying error
+XpuGraphRunner would otherwise hit is gone) and the captured/replayed output
+matches eager for the fixed state it was captured at. Genuine reuse across
+DIFFERENT (growing) decode steps without recapturing needs `written` itself
+to flow as a persistent tensor buffer (like the SYCL table's kv_len row),
+not a Python int baked into the graph at capture time -- the same
+persistent-buffer plumbing through the engine's step loop that #117
+(XpuGraphRunner) and #118's own issue body already flag as separate,
+larger follow-up work. Not attempted here.
+
+``xpu``-marked: deselected on a torch-free / no-XPU box (see ``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.attention.triton import TritonAttentionBackend
+from freetoken.engine.graph import XpuGraphRunner
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+
+class _FakeReq:
+    def __init__(self, table_idx: int) -> None:
+        self.table_idx = table_idx
+
+
+class _FakePool:
+    """A minimal read_kv-only KV pool: k/v laid out [max_seq_len, kv, D]."""
+
+    def __init__(self, max_seq_len: int, kv: int, d: int, device: torch.device) -> None:
+        self.k = torch.randn(max_seq_len, kv, d, device=device, dtype=torch.float32)
+        self.v = torch.randn(max_seq_len, kv, d, device=device, dtype=torch.float32)
+
+    def read_kv(self, table_idx, pos, layer_id):
+        return self.k[pos], self.v[pos]
+
+
+@XPU
+@pytest.mark.xpu
+def test_capture_time_fixed_shape_matches_eager_growing_slice():
+    """A capture-armed decode step matches the ordinary (eager) growing-slice
+    result for the exact state it was captured at, and XpuGraphRunner can
+    actually capture it (the point of this fix: no shape-varying error)."""
+    dev = torch.device("xpu")
+    torch.manual_seed(0)
+
+    qh_n, kv_n, d, max_seq_len = 4, 2, 8, 16
+    written = 5  # this decode step's real history length (< max_seq_len)
+
+    import freetoken.attention.triton as triton_mod
+
+    monkeypatched_pool = _FakePool(max_seq_len, kv_n, d, dev)
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(triton_mod, "_get_ctx", lambda: type("Ctx", (), {"kv_cache": monkeypatched_pool})())
+
+    try:
+        backend = TritonAttentionBackend(config=object())
+        req = _FakeReq(table_idx=0)
+        qh = torch.randn(qh_n, 1, d, device=dev, dtype=torch.float32)  # one new token
+        q_pos = torch.tensor([written - 1], device=dev, dtype=torch.int64)
+        repeat = qh_n // kv_n
+        scale = 1.0 / (d ** 0.5)
+
+        # Eager (growing-slice) reference: _capturing is False by default.
+        assert backend._capturing is False
+        eager_out = backend._attend_one(req, qh, q_pos, written, repeat, scale).clone()
+
+        # Arm capture mode and confirm the fixed-shape path matches eager
+        # exactly for this same state (same q/k/v, same written).
+        backend.init_capture_graph(max_seq_len=max_seq_len, bs_list=[1])
+        backend.prepare_for_capture(batch=None)
+        assert backend._capturing is True
+
+        static_out = torch.empty_like(eager_out)
+
+        def _fn():
+            static_out.copy_(backend._attend_one(req, qh, q_pos, written, repeat, scale))
+
+        runner = XpuGraphRunner(warmup_iters=3)
+        runner.capture(_fn)  # must not raise (this is the actual fix under test)
+        runner.replay()
+        torch.xpu.synchronize()
+
+        diff = (static_out - eager_out).abs().max().item()
+        assert diff < 1e-4, f"captured/replayed output diverged from eager: {diff}"
+    finally:
+        monkeypatch.undo()
+
+
+def test_reset_capture_clears_capturing_state():
+    backend = TritonAttentionBackend(config=object())
+    backend._capturing = True
+    backend._graph_max_seq_len = 16
+    backend.reset_capture()
+    assert backend._capturing is False
+    assert backend._graph_max_seq_len == 0


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 85** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/120#issuecomment-5517072693) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 8c2484b](https://github.com/Performant-Labs/FreeToken-Intel/commit/8c2484b35c62ffbc0a45c764d9225d18604a16c8) · run [#33688254944](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33688254944) · 2026-09-02 16:04 MDT / 2026-09-02 22:04 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
`TritonAttentionBackend._attend_one` normally reads exactly `[0, written)` keys — a shape that grows every decode step, which `torch.xpu.graph()` cannot replay (confirmed while building #15/#117's `XpuGraphRunner`).

**Fix:** while a capture is armed (`prepare_for_capture`, following the `BaseAttnBackend` contract's hooks — previously no-ops on this backend), `_attend_one` instead reads a **fixed** `[0, max_seq_len)` range with an extra `keypos < written` mask term gating out the not-yet-written tail — the standard fixed-buffer/paged-attention trick. Ordinary eager decode is completely unchanged (same cheap growing-slice read, verified via the full existing forward-correctness suite) — the fixed-shape read is strictly more compute per step, so applying it unconditionally would be a real regression for the common path.

Verified: the fixed-shape capture-time read matches eager exactly for the state it was captured at, and `XpuGraphRunner.capture()` now succeeds around it (previously the shape-varying error this issue exists to fix).

**Honest scope note — revising #118's own accept criteria:** I wrote "replay it correctly across several different decode steps (growing history) without recapturing" as an accept bullet before attempting this. That's **not** achieved here and needs more than this file: `written` is a plain Python int (from `req.device_len`), so it gets baked into the captured graph as a constant at capture time, not read fresh on each replay. Genuine growing-length reuse needs `written` to become a persistent tensor buffer (mirroring the SYCL table's `kv_len` row), updated in place before each replay — the same engine-level plumbing #117's `graph.py` docstring already flagged as separate, larger follow-up work. Updating #118's issue body to match reality.

## Test plan
- [x] `tests/test_attention_triton_capture_xpu.py` (new): fixed-shape capture-time read matches eager exactly; `XpuGraphRunner.capture()` succeeds; `reset_capture()` clears the new state
- [x] `tests/test_moe_*_forward.py` — all pass unchanged (eager path byte-identical, no regression)
- [x] `tests/test_moe_fused_xpu.py`, `test_moe_hybrid_e2e_real_xpu.py` — real end-to-end decode on real hardware, unaffected
- [x] `pytest tests/ -m "not xpu"` — 243 passed (1 new), same 11 pre-existing unrelated failures
- [x] Real XPU hardware, 0 new exec-queue resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add capture-time fixed-shape KV read in TritonAttentionBackend

- Mask not-yet-written tail with `keypos < written`

- Keep eager growing-slice path unchanged outside capture

- Add XPU tests validating capture and reset


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Init["init_capture_graph sets max_seq_len"] --> Arm["prepare_for_capture arms fixed-shape read"]
  Arm --> Attend["_attend_one reads fixed max_seq_len KV"]
  Attend --> Mask["Adds keypos < written mask for tail"]
  Mask --> Capture["torch.xpu.graph capture succeeds"]
  Test["tests/test_attention_triton_capture_xpu.py"] --> Capture
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>triton.py</strong><dd><code>Fixed-shape KV read for graph capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/attention/triton.py

<ul><li>Add <code>_capturing</code> and <code>_graph_max_seq_len</code> backend state<br> <li> Implement <code>init_capture_graph</code>, <code>prepare_for_capture</code>, and <code>reset_capture</code><br> <li> Read fixed <code>[0, max_seq_len)</code> keys during capture instead of growing <code>[0, </code><br><code>written)</code><br> <li> Add <code>keypos < written</code> mask to exclude not-yet-written tail</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/120/files#diff-818a55a2203b4bd840161ef989795eda5653e2508e412689e4aa674ee4297562">+54/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_attention_triton_capture_xpu.py</strong><dd><code>XPU tests for fixed-shape capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_attention_triton_capture_xpu.py

<ul><li>Add XPU test comparing capture-time fixed-shape output to eager <br>growing-slice output<br> <li> Verify <code>XpuGraphRunner.capture()</code> succeeds around <code>_attend_one</code><br> <li> Verify <code>reset_capture()</code> clears capture state</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/120/files#diff-465ee89a2839991c4f844c36ad95c3286f9f92b89cc506a8b266a81b1c7d6dfe">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___