### PR TITLE
feat(attention): SYCL kernel submits on the caller's stream, enabling graph capture (issue #119)

### DIFF
--- a/python/freetoken/attention/sycl.py
+++ b/python/freetoken/attention/sycl.py
@@ -38,7 +38,10 @@ _KERNEL_SRC = pathlib.Path(__file__).parent.parent / "kernel" / "csrc" / "sycl" 
 
 # (const float* q, const float* kc, const float* vc, const int* table,
 #  int bs, int K, int qh, int kv, int d, float sm_scale, int sliding_window,
-#  float* out)
+#  float* out, void* queue_handle)
+# queue_handle (issue attn-sycl-graph-capture, #119): the caller's active SYCL
+# queue (torch.xpu.Stream.sycl_queue), or NULL to fall back to a fresh
+# default-device queue -- see attention.cpp's decode_attention docstring.
 _FN_TYPES = [
     ctypes.c_void_p,
     ctypes.c_void_p,
@@ -51,6 +54,7 @@ _FN_TYPES = [
     ctypes.c_int,
     ctypes.c_float,
     ctypes.c_int,
+    ctypes.c_void_p,
     ctypes.c_void_p,
 ]
 
@@ -121,9 +125,16 @@ class SyclAttentionBackend(BaseAttnBackend):
         self.capture = None
         self.capture_bs: list[int] = []
         self.max_graph_bs = 0
-        # No graph capture in this backend: the reference engine does not drive
-        # capture/replay, and a SYCL nd_range launch is not a graph node.
-        # The fields exist so BaseAttnBackend.reset_capture() stays safe.
+        # Issue attn-sycl-graph-capture (#119): forward() now submits the
+        # kernel on the CALLER's active SYCL queue (torch's current XPU
+        # stream) rather than one this backend creates itself, so
+        # torch.xpu.graph() can actually see and record the launch. While
+        # _capturing is armed, forward() also skips the pre/post
+        # torch.xpu.synchronize() calls it otherwise does for host-visible
+        # correctness -- a host sync during capture is a hard error (the
+        # error this issue exists to fix: "wait cannot be called for a queue
+        # which is recording to a command graph").
+        self._capturing = False
         self._decode = None
         self._prefill = None
         self._kv_num_slots = self._resolve_num_slots(config)
@@ -207,7 +218,11 @@ class SyclAttentionBackend(BaseAttnBackend):
         self.max_graph_bs = max(bs_list) if bs_list else 0
 
     def prepare_for_capture(self, batch) -> None:
-        return None
+        self._capturing = True
+
+    def reset_capture(self) -> None:
+        super().reset_capture()
+        self._capturing = False
 
     def prepare_for_replay(self, batch) -> None:
         # Nothing to rebind: forward() rebuilds the tables from the live batch.
@@ -412,7 +427,18 @@ class SyclAttentionBackend(BaseAttnBackend):
         q_tok = q.transpose(0, 1).contiguous()
         out = torch.zeros((ext, qh, d), device=q.device, dtype=torch.float32)
 
-        torch.xpu.synchronize()
+        # The caller's active SYCL queue (torch's current XPU stream), passed
+        # through so the kernel submits onto it instead of a queue this
+        # backend creates itself (issue attn-sycl-graph-capture, #119) -- the
+        # SYCL/XPU analog of upstream's CUDA kernels taking the caller's
+        # cudaStream_t. Making that queue's work visible to torch.xpu.graph()
+        # is what lets capture see this kernel launch at all.
+        queue_handle = ctypes.c_void_p(torch.xpu.current_stream().sycl_queue)
+        # A host sync during capture is a hard error (see __init__'s
+        # docstring); ordinary (non-capturing) callers still get the same
+        # host-visible-before-return guarantee these always provided.
+        if not self._capturing:
+            torch.xpu.synchronize()
         if is_decode:
             self._decode(
                 self._ptr(q_tok),
@@ -427,6 +453,7 @@ class SyclAttentionBackend(BaseAttnBackend):
                 ctypes.c_float(sm_scale),
                 window,
                 self._ptr(out),
+                queue_handle,
             )
         else:
             self._prefill(
@@ -442,8 +469,10 @@ class SyclAttentionBackend(BaseAttnBackend):
                 ctypes.c_float(sm_scale),
                 window,
                 self._ptr(out),
+                queue_handle,
             )
-        torch.xpu.synchronize()
+        if not self._capturing:
+            torch.xpu.synchronize()
         # The kernel wrote token-major [ext, qh, d]; the model wants head-major
         # [qh, ext, d] (it does o_proj on out.transpose(1, 2)).
         return out.transpose(0, 1).contiguous()

--- a/python/freetoken/kernel/csrc/sycl/attention.cpp
+++ b/python/freetoken/kernel/csrc/sycl/attention.cpp
@@ -116,13 +116,12 @@ void probe_usm_inputs(const sycl::queue& q_dev, Ptrs... ptrs) {
 // compiles correctly. See the `s = ...` line in the loop below.
 void decode_attention_impl(const float* q, const float* k_cache, const float* v_cache,
                             const int* table, int bs, int K, int qh, int kv, int d, float sm_scale,
-                            int sliding_window, float* out) {
+                            int sliding_window, float* out, sycl::queue& q_dev) {
   if (bs == 0) {
     return;
   }
   const int g = qh / kv;  // query heads per kv head (GQA group size)
   const int stride = 3;
-  sycl::queue q_dev;  // default device: the B70 when present, else a CPU device
   // Rule 1 (never a host/fake SYCL): every pointer the kernel touches must be a
   // USM (device) pointer -- a torch XPU tensor's data. A plain host pointer
   // cannot be read or written by the B70 kernel (see the memory-model note
@@ -216,7 +215,17 @@ void decode_attention_impl(const float* q, const float* k_cache, const float* v_
           }
         });
   });
-  q_dev.wait();
+  // No q_dev.wait() here (issue attn-sycl-graph-capture, #119): this queue is
+  // now the CALLER's active stream (torch's current XPU stream), not a
+  // private one this function owns -- a blocking wait on a stream that may
+  // be recording to a command graph is a hard capture error, the same class
+  // of problem the removed pre-call torch.xpu.synchronize() was (see
+  // sycl.py). Ordering for the eager (non-capturing) caller is the caller's
+  // job now: it submits this kernel on its own stream and is responsible for
+  // synchronizing before reading `out` on the host, exactly as it already
+  // does for every other op on that stream (this mirrors upstream's own CUDA
+  // kernels, which take the caller's cudaStream_t and never wait() inside
+  // the kernel either -- see kernel/csrc/include/freetoken/utils.cuh).
 }
 
 // GQA prefill / extend attention: one work-item per (request, kv-head group).
@@ -228,13 +237,12 @@ void decode_attention_impl(const float* q, const float* k_cache, const float* v_
 // out     [num_qo, qh, d]  USM (written in place)
 void prefill_attention_impl(const float* q, const float* k_cache, const float* v_cache,
                             const int* table, int bs, int K, int qh, int kv, int d, float sm_scale,
-                            int sliding_window, float* out) {
+                            int sliding_window, float* out, sycl::queue& q_dev) {
   if (bs == 0) {
     return;
   }
   const int g = qh / kv;
   const int stride = 5;  // slot, kv_len, qpos0, ext, cum_ext
-  sycl::queue q_dev;
   probe_usm_inputs(q_dev, q, k_cache, v_cache, table, out);  // Rule 1 USM guard.
 
   // Metadata (slot / kv_len / qpos0 / ext / cum_ext) is read straight from the
@@ -315,23 +323,47 @@ void prefill_attention_impl(const float* q, const float* k_cache, const float* v
           }
         });
   });
-  q_dev.wait();
+  // No q_dev.wait() -- see decode_attention_impl's comment above.
 }
 
 }  // namespace
 
 extern "C" {
 
+// queue_handle (issue attn-sycl-graph-capture, #119): the caller's active
+// SYCL queue, as an opaque pointer -- torch's XPU stream, cast from
+// torch.xpu.Stream.sycl_queue on the Python side (the direct SYCL/XPU analog
+// of the cudaStream_t upstream's own CUDA kernels take from the caller
+// rather than creating their own; see kernel/csrc/include/freetoken/utils.cuh).
+// Submitting on the queue torch.xpu.graph() is actually recording is what
+// makes this kernel's work visible to graph capture at all -- a queue this
+// function created itself, as it used to, is invisible to it regardless of
+// shape. NULL falls back to a freshly constructed default-device queue (the
+// old behavior, for any caller that does not have a stream handle to pass).
 void decode_attention(const float* q, const float* k_cache, const float* v_cache, const int* table,
                        int bs, int K, int qh, int kv, int d, float sm_scale, int sliding_window,
-                       float* out) {
-  decode_attention_impl(q, k_cache, v_cache, table, bs, K, qh, kv, d, sm_scale, sliding_window, out);
+                       float* out, void* queue_handle) {
+  if (queue_handle != nullptr) {
+    sycl::queue& q_dev = *reinterpret_cast<sycl::queue*>(queue_handle);
+    decode_attention_impl(q, k_cache, v_cache, table, bs, K, qh, kv, d, sm_scale, sliding_window, out, q_dev);
+  } else {
+    sycl::queue q_dev;  // default device: the B70 when present, else a CPU device
+    decode_attention_impl(q, k_cache, v_cache, table, bs, K, qh, kv, d, sm_scale, sliding_window, out, q_dev);
+    q_dev.wait();  // no caller stream to order against -- block here instead
+  }
 }
 
 void prefill_attention(const float* q, const float* k_cache, const float* v_cache, const int* table,
                         int bs, int K, int qh, int kv, int d, float sm_scale, int sliding_window,
-                        float* out) {
-  prefill_attention_impl(q, k_cache, v_cache, table, bs, K, qh, kv, d, sm_scale, sliding_window, out);
+                        float* out, void* queue_handle) {
+  if (queue_handle != nullptr) {
+    sycl::queue& q_dev = *reinterpret_cast<sycl::queue*>(queue_handle);
+    prefill_attention_impl(q, k_cache, v_cache, table, bs, K, qh, kv, d, sm_scale, sliding_window, out, q_dev);
+  } else {
+    sycl::queue q_dev;
+    prefill_attention_impl(q, k_cache, v_cache, table, bs, K, qh, kv, d, sm_scale, sliding_window, out, q_dev);
+    q_dev.wait();
+  }
 }
 
 }  // extern "C"

--- a/tests/test_attention_sycl_capture_xpu.py
+++ b/tests/test_attention_sycl_capture_xpu.py
@@ -1,0 +1,94 @@
+"""XPU tests: SyclAttentionBackend is graph-capturable (issue attn-sycl-graph-capture, #119).
+
+A follow-up to engine-graph (#15): the SYCL kernel used to open its own
+``sycl::queue`` internally and call ``torch.xpu.synchronize()`` before every
+launch, so ``torch.xpu.graph()`` could neither see the kernel's work nor
+tolerate the sync (a hard capture error: "wait cannot be called for a queue
+which is recording to a command graph"). Fixed by threading the caller's
+active SYCL queue (``torch.xpu.current_stream().sycl_queue``) through to the
+kernel -- the SYCL/XPU analog of upstream's own CUDA kernels taking the
+caller's ``cudaStream_t`` -- and skipping the host syncs while a capture is
+armed (``prepare_for_capture``).
+
+``xpu``-marked: deselected on a torch-free / no-XPU box (see ``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.engine.graph import XpuGraphRunner
+
+from tests.test_attention_sycl import _write_tiny_checkpoint, _engine_config, _add_prompt
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+
+@XPU
+@pytest.mark.xpu
+def test_sycl_attention_forward_is_graph_capturable(tmp_path):
+    """A real SyclAttentionBackend.forward() call, captured and replayed,
+    reproduces eager exactly -- the queue this used to create itself made
+    torch.xpu.graph() unable to see (or capture) the kernel's work at all;
+    this is the fix, verified against the real kernel end to end."""
+    from freetoken.core import reset_global_ctx
+    from freetoken.engine.engine import Engine
+
+    reset_global_ctx()
+    model_path = _write_tiny_checkpoint(tmp_path, random=True)
+    engine = Engine(_engine_config(model_path, device="xpu", attention_backend="sycl", dummy_weight=False))
+    _add_prompt(engine, output_len=5, prompt_ids=[1, 2, 3])
+
+    # Drive to a stable decode state (prefill + a couple of decode steps).
+    for _ in range(3):
+        engine.step()
+
+    batch = engine.scheduler.schedule()
+    assert batch is not None and batch.phase == "decode"
+    req = batch.reqs[0]
+    pos = req.device_len - 1
+    dev = engine.device
+
+    batch.input_ids = torch.tensor([int(req.input_ids[-1])], dtype=torch.int64, device=dev)
+    batch.positions = torch.tensor([pos], dtype=torch.int64, device=dev)
+    batch.out_loc = torch.tensor([pos], dtype=torch.int64, device=dev)
+    batch.extend_lens = torch.tensor([1], dtype=torch.int64, device=dev)
+    table_idx = req.table_idx
+
+    try:
+        with engine.ctx.forward_batch(batch):
+            engine.attn_backend.prepare_metadata(batch)
+            engine.attn_backend.prepare_for_capture(batch)
+            assert engine.attn_backend._capturing is True
+
+            layer0 = engine.model.layers[0]
+            attn = layer0.self_attn
+            static_hidden = torch.randn(1, engine.model.config.hidden_size, device=dev, dtype=torch.float32)
+            static_normed = layer0.input_layernorm(static_hidden)
+
+            eager_out = attn(static_normed, batch.positions, table_idx, engine.ctx, batch).clone()
+            torch.xpu.synchronize()
+
+            static_out_buf = torch.empty_like(eager_out)
+
+            def _fn():
+                o = attn(static_normed, batch.positions, table_idx, engine.ctx, batch)
+                static_out_buf.copy_(o)
+
+            runner = XpuGraphRunner(warmup_iters=3)
+            runner.capture(_fn)  # must not raise -- this is the fix under test
+
+            runner.replay()
+            torch.xpu.synchronize()
+            diff = (static_out_buf - eager_out).abs().max().item()
+            assert diff < 1e-4, f"captured/replayed SYCL attention diverged from eager: {diff}"
+
+            # A second replay (idempotent, same fixed inputs) must still match.
+            runner.replay()
+            torch.xpu.synchronize()
+            diff2 = (static_out_buf - eager_out).abs().max().item()
+            assert diff2 < 1e-4
+    finally:
+        engine.attn_backend.reset_capture()
+        reset_global_ctx()


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 92** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit baf5a9b](https://github.com/Performant-Labs/FreeToken-Intel/commit/baf5a9b714aa073a9dc73ea194d3918a25f584c9) · run [#33689665961](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33689665961) · 2026-09-02 16:22 MDT / 2026-09-02 22:22 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
`decode_attention`/`prefill_attention` used to open their own `sycl::queue` internally and call `torch.xpu.synchronize()` before every launch — so `torch.xpu.graph()` could neither see the kernel's work nor tolerate the sync (a hard capture error, confirmed while building #15/#117).

**Fix**, mirroring upstream's own CUDA kernels (which take the caller's `cudaStream_t` rather than creating their own — see `kernel/csrc/include/freetoken/utils.cuh`'s `LaunchKernel`):

- `attention.cpp`: `decode_attention_impl`/`prefill_attention_impl` take a `sycl::queue&` instead of constructing one. The `extern "C"` entry points gained a `void* queue_handle` param — non-NULL reinterpret_casts to the caller's queue and uses it directly; NULL falls back to the old behavior (fresh local queue + blocking wait) for safety. Removed the unconditional `q_dev.wait()` at the end of both kernels.
- `sycl.py`: `forward()` passes `ctypes.c_void_p(torch.xpu.current_stream().sycl_queue)` as the new kernel argument, and skips the pre/post `torch.xpu.synchronize()` calls while a capture is armed (`prepare_for_capture`, previously a no-op).

**Verified end to end** (`tests/test_attention_sycl_capture_xpu.py`): a real `SyclAttentionBackend.forward()` call, captured via `XpuGraphRunner` and replayed, reproduces eager **bit-exact** (max abs diff 0.0). Before this fix the same capture attempt failed outright with the "recording to a command graph" error.

This was the one change this session where getting the pointer interop wrong (reinterpreting torch's stream handle as a `sycl::queue*`) could have hung the GPU rather than just failed cleanly — tested in isolation with a tight timeout before running the broader suite. Real B70 hardware throughout, 0 exec-queue resets at any point.

`tests/test_attention_sycl.py`: 5/6 still pass (same as before — the sixth, a float-noise token divergence under random weights documented in #116, is unaffected either way).

## Test plan
- [x] Kernel compiles cleanly (`icpx -fsycl -c`, zero GPU risk check first)
- [x] Isolated first real kernel launch through the new interop, tight timeout, dmesg checked immediately — clean
- [x] `tests/test_attention_sycl_capture_xpu.py` (new) — real SYCL attention forward captured + replayed, bit-exact vs eager
- [x] `tests/test_attention_sycl.py` — 5/6 pass, same as before (no regression)
- [x] All directly-relevant XPU tests run together (SYCL, SYCL capture, triton capture, fused MoE, hybrid e2e, engine graph runner) — 14/15 pass, same known pre-existing failure
- [x] `pytest tests/ -m "not xpu"` — 243 passed, same 11 pre-existing unrelated failures
- [x] 0 exec-queue resets throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Pass caller XPU stream queue to attention kernels

- Remove internal queue waits enabling graph capture

- Skip host syncs during capture, keep for eager

- Add XPU test verifying replayed output matches eager


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["torch.xpu.current_stream().sycl_queue"] -- "queue_handle" --> B["extern C decode/prefill attention"]
  B -- "non-NULL" --> C["Submit on caller SYCL queue"]
  B -- "NULL" --> D["Fallback local queue + wait"]
  C -- "no internal wait / skip host sync" --> E["XPU graph capture records kernel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sycl.py</strong><dd><code>Pass caller XPU stream queue and manage capture sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/attention/sycl.py

<ul><li>Add <code>void* queue_handle</code> to <code>_FN_TYPES</code><br> <li> Pass caller's active SYCL queue to kernel calls<br> <li> Set <code>_capturing</code> in <code>prepare_for_capture</code>, reset in <code>reset_capture</code><br> <li> Skip pre/post <code>torch.xpu.synchronize()</code> while capturing</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/121/files#diff-2964e92209720555499ebe6f84f02da86955ea251c1d8701540e8351d3a1f27e">+36/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>attention.cpp</strong><dd><code>Thread caller SYCL queue through attention kernels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/kernel/csrc/sycl/attention.cpp

<ul><li>Accept caller <code>sycl::queue&</code> in decode/prefill impls<br> <li> Remove unconditional <code>q_dev.wait()</code> from impls<br> <li> Add <code>void* queue_handle</code> to extern C entry points<br> <li> Use caller queue when non-null, fallback local queue plus wait <br>otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/121/files#diff-e76a4eff8e98c5c00e77b60a930dfcbe90e2101a016906a93d613e004dc1fddb">+42/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_attention_sycl_capture_xpu.py</strong><dd><code>Add graph capture test for SYCL attention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_attention_sycl_capture_xpu.py

<ul><li>Add XPU test capturing <code>SyclAttentionBackend.forward()</code> via <br><code>XpuGraphRunner</code><br> <li> Verify captured/replayed output matches eager within 1e-4<br> <li> Assert capture state is armed by <code>prepare_for_capture</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/121/files#diff-d3772e11059cf26dfceb0fee3e70a2385c091d0cef0c12ae03902251406ea41b">+94/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___