### PR TITLE
feat(models): dense MoE routing while capturing -- closes issue #15 end to end

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -977,7 +977,7 @@ class _Qwen35MoE:
         elif self.use_offload:
             routed_out = self._forward_offload(flat, top_idx, top_w, ctx, batch)
         else:
-            routed_out = self._forward_inram(flat, top_idx, top_w)
+            routed_out = self._forward_inram(flat, top_idx, top_w, ctx)
         return (routed_out + shared_out).view(in_shape)
 
     def _is_cpu_layer(self, ctx) -> bool:
@@ -1057,7 +1057,7 @@ class _Qwen35MoE:
             model._moe_cpu_executor = executor
         return executor.forward(flat, top_idx, top_w, gate_up, down)
 
-    def _forward_inram(self, flat, top_idx, top_w):
+    def _forward_inram(self, flat, top_idx, top_w, ctx=None):
         # Indices are built on the HOST, not with device-side boolean-mask
         # indexing (`flat[sel]`) or `torch.nonzero` on an XPU tensor: on this
         # torch/XPU build, `nonzero()` (which boolean-mask indexing calls
@@ -1067,6 +1067,27 @@ class _Qwen35MoE:
         # correctness bug, not just the "implicit D2H sync" performance
         # concern the offload path already routes around this same way (see
         # qwen3_moe's in-VRAM forward for the same fix).
+        #
+        # EXCEPT while a graph capture is in flight (issue
+        # moe-fused-graph-capture, #123): the CPU round-trip below
+        # (`top_idx.to("cpu")`) is itself a device->host sync, a hard capture
+        # error. Route densely instead -- every expert on every token,
+        # weight-summed with a mask built from `==`/`torch.where` (plain
+        # elementwise ops: no `nonzero()`, no sync, so neither the broken
+        # on-device nonzero() nor the capture restriction applies). Strictly
+        # more compute, so opt-in via `_capturing` only (mirrors #118's
+        # fixed-KV-buffer attention, the same trade-compute-for-capturability
+        # shape).
+        model = getattr(ctx, "model", None)
+        if getattr(model, "_capturing", False):
+            out = torch.zeros_like(flat)
+            for e in range(self.num_experts):
+                w = torch.zeros(flat.shape[0], device=flat.device, dtype=flat.dtype)
+                for slot in range(self.top_k):
+                    w = torch.where(top_idx[:, slot] == e, top_w[:, slot], w)
+                out = out + w[:, None] * self.experts[e](flat)
+            return out
+
         out = torch.zeros_like(flat)
         top_idx_cpu = top_idx.to("cpu")
         for e in range(self.num_experts):

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -505,6 +505,28 @@ class _Qwen3MoE(nn.Module):
         # the indices on the host and gathering with `index_select` /
         # `index_add_` sidesteps it entirely (and keeps this path
         # graph-capture-friendly: no data-dependent output shape).
+        #
+        # EXCEPT: the CPU round-trip (`top_idx.to("cpu")`) is itself a
+        # device->host sync, which is a hard error while a graph capture is
+        # in flight (issue moe-fused-graph-capture, #123 -- found completing
+        # #15's XpuGraphRunner work: #118/#119/#122 fixed every other decode
+        # sync, this is the last one). While capturing, route with a dense
+        # mask instead: compute every expert for every token and weight-sum
+        # with a per-(token, expert) mask built from `==`/`torch.where`
+        # (plain elementwise ops -- no `nonzero()`, no host sync, so neither
+        # the broken-on-XPU-nonzero() bug nor the capture restriction
+        # applies). Strictly more compute than the gather above (every
+        # expert runs on every token, not just its routed rows), so this is
+        # opt-in via `_capturing` only -- the same trade-compute-for-
+        # capturability shape #118's fixed-KV-buffer attention already uses.
+        if getattr(model, "_capturing", False):
+            for e in range(self.num_experts):
+                w = torch.zeros(flat.shape[0], device=flat.device, dtype=flat.dtype)
+                for slot in range(self.top_k):
+                    w = torch.where(top_idx[:, slot] == e, top_w[:, slot], w)
+                out = out + w[:, None] * self.experts[e](flat)
+            return out.view(in_shape)
+
         top_idx_cpu = top_idx.to("cpu")
         for e in range(self.num_experts):
             for slot in range(self.top_k):

--- a/tests/test_engine_whole_model_capture_xpu.py
+++ b/tests/test_engine_whole_model_capture_xpu.py
@@ -1,0 +1,104 @@
+"""XPU test: a whole decode-step model.forward() is graph-capturable.
+
+The final piece of issue engine-graph (#15)'s own literal accept criterion
+("captured decode replay matches eager decode numerically on a tiny model"):
+#117 built XpuGraphRunner, #118/#119 made both attention backends
+individually capturable, #122 removed the decoder-layer loop's per-request
+extend_lens sync, and #123 gave the fused MoE path a dense (mask-based, no
+nonzero(), no host sync) routing while capturing. This test is the
+end-to-end proof all four combine correctly: a real decode-step
+model.forward() (SYCL attention + fused/in-VRAM MoE, the one MoE backend
+that's graph-capturable at all -- offload/cpu/hybrid stay fundamentally
+dynamic, see graph.py) is captured once and replayed, matching eager
+bit-exact.
+
+``xpu``-marked: deselected on a torch-free / no-XPU box (see ``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.engine.graph import XpuGraphRunner
+
+from tests.test_attention_sycl import _write_tiny_checkpoint, _add_prompt
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+
+@XPU
+@pytest.mark.xpu
+def test_whole_decode_step_model_forward_is_graph_capturable(tmp_path):
+    from freetoken.core import reset_global_ctx
+    from freetoken.distributed import DistributedInfo
+    from freetoken.engine.config import EngineConfig
+    from freetoken.engine.engine import Engine
+
+    dev = torch.device("xpu")
+    reset_global_ctx()
+    model_path = _write_tiny_checkpoint(tmp_path, random=True)
+    config = EngineConfig(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=dev,
+        attention_backend="sycl",
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+        use_dummy_weight=False,
+        moe_backend="fused",  # the only graph-capturable MoE path
+    )
+    engine = Engine(config)
+    _add_prompt(engine, output_len=5, prompt_ids=[1, 2, 3])
+
+    # Drive to a stable decode state (prefill + a couple of decode steps).
+    for _ in range(3):
+        engine.step()
+
+    batch = engine.scheduler.schedule()
+    assert batch is not None and batch.phase == "decode"
+    req = batch.reqs[0]
+    pos = req.device_len - 1
+
+    static_input_ids = torch.tensor([int(req.input_ids[-1])], dtype=torch.int64, device=dev)
+    static_positions = torch.tensor([pos], dtype=torch.int64, device=dev)
+    static_out_loc = torch.tensor([pos], dtype=torch.int64, device=dev)
+    batch.input_ids = static_input_ids
+    batch.positions = static_positions
+    batch.out_loc = static_out_loc
+    batch.extend_lens = torch.tensor([1], dtype=torch.int64, device=dev)
+
+    try:
+        with engine.ctx.forward_batch(batch):
+            engine.attn_backend.prepare_metadata(batch)
+            engine.attn_backend.prepare_for_capture(batch)
+            engine.model._capturing = True
+
+            eager_logits = engine.model(static_input_ids, static_positions, static_out_loc).clone()
+            torch.xpu.synchronize()
+
+            static_logits_buf = torch.empty_like(eager_logits)
+
+            def _fn():
+                logits = engine.model(static_input_ids, static_positions, static_out_loc)
+                static_logits_buf.copy_(logits)
+
+            runner = XpuGraphRunner(warmup_iters=3)
+            runner.capture(_fn)  # must not raise -- this is the point of #15/#123
+
+            runner.replay()
+            torch.xpu.synchronize()
+            diff = (static_logits_buf - eager_logits).abs().max().item()
+            assert diff < 1e-4, f"whole-model captured/replayed logits diverged from eager: {diff}"
+
+            # A second replay (idempotent, same fixed inputs) must still match.
+            runner.replay()
+            torch.xpu.synchronize()
+            diff2 = (static_logits_buf - eager_logits).abs().max().item()
+            assert diff2 < 1e-4
+    finally:
+        engine.attn_backend.reset_capture()
+        engine.model._capturing = False
+        reset_global_ctx()

--- a/tests/test_engine_whole_model_capture_xpu.py
+++ b/tests/test_engine_whole_model_capture_xpu.py
@@ -73,11 +73,20 @@ def test_whole_decode_step_model_forward_is_graph_capturable(tmp_path):
     try:
         with engine.ctx.forward_batch(batch):
             engine.attn_backend.prepare_metadata(batch)
-            engine.attn_backend.prepare_for_capture(batch)
-            engine.model._capturing = True
 
+            # The TRUE eager baseline: ordinary decode, _capturing still
+            # False, so this exercises the exact same gather-based MoE
+            # routing and per-step-sync attention path real (non-captured)
+            # serving uses -- not the dense/fixed-shape capture variants.
+            # (PR-Agent flagged an earlier version of this test for arming
+            # _capturing before computing this baseline, which would only
+            # have proven the captured path self-consistent, not that it
+            # matches real eager decode -- see PR #124's review.)
             eager_logits = engine.model(static_input_ids, static_positions, static_out_loc).clone()
             torch.xpu.synchronize()
+
+            engine.attn_backend.prepare_for_capture(batch)
+            engine.model._capturing = True
 
             static_logits_buf = torch.empty_like(eager_logits)
 

--- a/tests/test_moe_fused_dense_capture_routing.py
+++ b/tests/test_moe_fused_dense_capture_routing.py
@@ -1,0 +1,50 @@
+"""Dense (capture-mode) MoE routing matches the gather (eager) routing exactly.
+
+Issue moe-fused-graph-capture (#123): the fused in-VRAM MoE forward's eager
+routing does a CPU round-trip (`top_idx.to("cpu")`, needed to work around a
+broken on-device `nonzero()`, see #114) that is itself a device->host sync --
+incompatible with graph capture. While `model._capturing` is set, `_Qwen3MoE
+.forward` instead computes every expert for every token and weight-sums with
+a mask built from plain elementwise ops (`==` / `torch.where`, no
+`nonzero()`, no sync). This test proves that dense path is mathematically
+identical to the (already correctness-tested, see test_moe_fused_xpu.py)
+gather path it replaces while capturing -- CPU-only, no XPU needed, since the
+property under test (dense routing == gather routing) is device-independent.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.loader import load_model
+
+from tests.test_moe_offload_forward import offload_ckpt  # noqa: F401
+
+
+class _CapturingModel:
+    """Minimal stand-in for the model= arg _Qwen3MoE.forward reads _capturing off."""
+
+    def __init__(self, capturing: bool) -> None:
+        self._capturing = capturing
+
+
+def test_dense_routing_matches_gather_routing(offload_ckpt):
+    model, _ = load_model(offload_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="fused")
+    mlp = model.layers[0].mlp
+    torch.manual_seed(0)
+    flat = torch.randn(5, model.config.hidden_size)  # 5 tokens, bs > 1 so routing varies per row
+
+    out_gather = mlp.forward(flat, model=_CapturingModel(capturing=False))
+    out_dense = mlp.forward(flat, model=_CapturingModel(capturing=True))
+
+    # Not bit-exact: the dense path calls each expert on the FULL 5-token
+    # batch while the gather path calls it on a per-expert SUBSET (only the
+    # routed rows) -- different batch shapes can dispatch to different BLAS
+    # matmul blocking/vectorization, which is not bit-associative even for
+    # mathematically identical per-row sums (the same non-determinism the
+    # rest of this codebase already tolerates with allclose / greedy-token
+    # comparisons rather than exact tensor equality across different call
+    # shapes). The two routings select and weight the *same* experts per
+    # token, so they must agree closely, not bit-for-bit.
+    torch.testing.assert_close(out_gather, out_dense, rtol=1e-3, atol=1e-3)

--- a/tests/test_moe_qwen35_fused_dense_capture_routing.py
+++ b/tests/test_moe_qwen35_fused_dense_capture_routing.py
@@ -1,0 +1,80 @@
+"""qwen3_5_moe's dense (capture-mode) MoE routing matches gather (eager) routing.
+
+Same property as tests/test_moe_fused_dense_capture_routing.py (issue #123),
+for the qwen3_5_moe model family's `_Qwen35MoE._forward_inram`, which was not
+covered by that test (PR-Agent review on #124: the qwen3_moe test's
+`mlp.forward(flat, model=...)` call shape does not exist on qwen3_5_moe's
+`_forward_inram(flat, top_idx, top_w, ctx)`, so a regression there would not
+have been caught).
+
+Built directly (not through freetoken.models.loader.load_model): that loader
+path is currently broken for every qwen3_5 checkpoint by an unrelated
+pre-existing bug (`parse_config() got an unexpected keyword argument
+'model_path'`, tracked separately, not touched here) -- so this constructs
+the plain `_Qwen35Expert` / `_Qwen35MoE` classes directly (via the module's
+own lazy `_ensure_torch()` rebind, the same mechanism `load_model` uses) and
+calls `_forward_inram` as an unbound method against a minimal stand-in
+object exposing just the attributes it reads (`num_experts`, `top_k`,
+`experts`). CPU-only: the property under test is device-independent.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import freetoken.models.qwen3_5_moe as q35
+
+
+class _FakeMoE:
+    """Exposes exactly what _Qwen35MoE._forward_inram reads off self."""
+
+    def __init__(self, num_experts: int, top_k: int, experts) -> None:
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.experts = experts
+
+
+class _FakeCtx:
+    def __init__(self, model) -> None:
+        self.model = model
+
+
+class _FakeModel:
+    def __init__(self, capturing: bool) -> None:
+        self._capturing = capturing
+
+
+def test_qwen35_dense_routing_matches_gather_routing():
+    q35._ensure_torch()
+
+    hidden, inter, num_experts, top_k = 16, 8, 4, 2
+
+    class _Cfg:
+        hidden_size = hidden
+        moe_intermediate_size = inter
+
+    torch.manual_seed(0)
+    experts = [q35._Qwen35Expert(_Cfg(), torch.device("cpu"), torch.float32) for _ in range(num_experts)]
+    for e in experts:
+        for p in (e.gate_proj, e.up_proj, e.down_proj):
+            for param in p.parameters():
+                torch.nn.init.normal_(param, std=0.1)
+
+    fake_moe = _FakeMoE(num_experts=num_experts, top_k=top_k, experts=experts)
+
+    flat = torch.randn(5, hidden)  # 5 tokens
+    gate = torch.nn.Linear(hidden, num_experts, bias=False)
+    routing = gate(flat)
+    gate_log = torch.softmax(routing, dim=-1)
+    top_w, top_idx = torch.topk(gate_log, top_k, dim=-1)
+    top_w = (top_w / top_w.sum(dim=-1, keepdim=True)).to(flat.dtype)
+
+    out_gather = q35._Qwen35MoE._forward_inram(fake_moe, flat, top_idx, top_w, _FakeCtx(_FakeModel(False)))
+    out_dense = q35._Qwen35MoE._forward_inram(fake_moe, flat, top_idx, top_w, _FakeCtx(_FakeModel(True)))
+
+    # Not bit-exact -- same reason as the qwen3_moe version of this test:
+    # dense calls each expert on the full 5-token batch, gather calls it on
+    # a per-expert subset, and different batch shapes can dispatch to
+    # different (non-bit-associative) BLAS matmul blocking.
+    torch.testing.assert_close(out_gather, out_dense, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 90** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/124#issuecomment-5517489872) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit e6d2c57](https://github.com/Performant-Labs/FreeToken-Intel/commit/e6d2c57a8f6730d4e0896d7a11fbbd66df5f88a5) · run [#33692369879](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33692369879) · 2026-09-02 16:55 MDT / 2026-09-02 22:55 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
The last blocker found chasing issue #15's own literal accept criterion ("captured decode replay matches eager decode numerically on a tiny model"): with #117 (`XpuGraphRunner`), #118/#119 (both attention backends capturable), and #122 (the decoder loop's `extend_lens` sync) all landed, attempting a **real** whole decode-step `model.forward()` capture (SYCL attention + `moe_backend="fused"`) still failed:

```
RuntimeError: wait method cannot be used for an event associated with a command graph
```

...from `_Qwen3MoE.forward`'s `top_idx.to("cpu")` — issue #114's own correctness fix (routing indices computed on the CPU to work around a broken on-device `torch.nonzero()`). That CPU round-trip is itself a device→host sync, just as capture-incompatible as every other sync #118/#119/#122 already removed.

**Fix** (issue moe-fused-graph-capture, #123): while `model._capturing` is armed, route densely instead — compute every expert for every token and weight-sum with a per-(token, expert) mask built from `==`/`torch.where` (plain elementwise ops: no `nonzero()`, no host sync). Strictly more compute than the gather path, so opt-in via `_capturing` only — same trade-compute-for-capturability shape as #118. Ordinary eager decode is unchanged (same CPU-nonzero gather, verified against the full existing correctness suite). Applied to both `qwen3_moe` and `qwen3_5_moe`.

**Correctness:** `tests/test_moe_fused_dense_capture_routing.py` (CPU-only) proves dense and gather routing select and weight the same experts per token (`torch.testing.assert_close`, not bit-exact — the two paths call each expert on different batch shapes, which can dispatch to different BLAS matmul blocking; not bit-associative even for mathematically identical sums).

**End to end:** `tests/test_engine_whole_model_capture_xpu.py` captures a **real** decode-step `model.forward()` (SYCL attention + fused MoE, real XPU hardware) and replays it — matching eager **bit-exact** (max abs diff 0.0). This is #15's own accept criterion, finally met after #117/#118/#119/#122/#123 each removed one of the five blockers found chasing it.

## Test plan
- [x] `tests/test_moe_fused_dense_capture_routing.py` (new) — dense routing matches gather routing
- [x] `tests/test_engine_whole_model_capture_xpu.py` (new) — real whole-model decode-step capture, bit-exact replay
- [x] `pytest tests/ -m "not xpu"` — 245 passed (1 new), same 11 pre-existing unrelated failures
- [x] Full real-hardware regression (fused MoE, hybrid e2e, SYCL attention + capture, triton capture, engine graph runner, whole-model capture) — 15/16 pass, same known pre-existing float-noise failure
- [x] 0 exec-queue resets throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add dense capture-mode MoE routing for qwen3_moe and qwen3_5_moe.

- Replace CPU round-trip gather routing while `model._capturing` is active.

- Enable whole decode-step graph capture with SYCL attention and fused MoE.

- Add CPU dense-vs-gather tests and XPU end-to-end capture/replay test.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Fused MoE forward"] --> B["model._capturing?"]
  B -- "true" --> C["Dense mask routing"]
  B -- "false" --> D["CPU gather routing"]
  C --> E["No device-to-host sync"]
  E --> F["Whole decode-step graph capture"]
  F --> G["XPU replay matches eager"]
  C --> H["CPU dense-vs-gather tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add dense capture routing to Qwen3MoE forward</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_moe/__init__.py

<ul><li>Add <code>model._capturing</code> branch with per-expert <code>==</code>/<code>torch.where</code> masks.<br> <li> Compute every expert on all tokens, then weight-sum and return.<br> <li> Leave eager gather path with CPU <code>top_idx.to("cpu")</code> unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/124/files#diff-7df44a0f5eb5c411dc8b6f5d672093944a031ba3e91e79a23781674f3ceb1a3e">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add dense capture routing to Qwen35MoE inram forward</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li>Pass <code>ctx</code> into <code>_forward_inram</code> and make it optional.<br> <li> Add <code>_capturing</code> branch using dense mask weighted-sum over experts.<br> <li> Keep eager CPU round-trip gather path for non-capture mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/124/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_engine_whole_model_capture_xpu.py</strong><dd><code>Test whole decode-step XPU model graph capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_engine_whole_model_capture_xpu.py

<ul><li>Build tiny checkpoint with SYCL attention and fused MoE.<br> <li> Compute true eager logits before arming <code>_capturing</code>.<br> <li> Capture and replay <code>model.forward()</code> via <code>XpuGraphRunner</code>.<br> <li> Assert replayed logits match eager within <code>1e-4</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/124/files#diff-c819790fe9dda277a74f83da83cc3f27a845414bc177b22ad2e2bdc2adcea993">+113/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_moe_fused_dense_capture_routing.py</strong><dd><code>Test dense vs gather MoE routing for qwen3_moe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_moe_fused_dense_capture_routing.py

<ul><li>Load fused qwen3_moe and run <code>mlp.forward</code> with capturing false/true <br>stand-in.<br> <li> Assert dense and gather outputs are close, not bit-exact.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/124/files#diff-4508c5aff5d0e5f57680a7daeb678fa002eca737288461ac3640788081039a92">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_moe_qwen35_fused_dense_capture_routing.py</strong><dd><code>Test dense vs gather MoE routing for qwen3_5_moe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_moe_qwen35_fused_dense_capture_routing.py

<ul><li>Directly construct <code>_Qwen35Expert</code>/<code>_Qwen35MoE</code> via <code>_ensure_torch</code>.<br> <li> Call <code>_forward_inram</code> with fake capturing ctx false/true.<br> <li> Assert dense and gather outputs are close.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/124/files#diff-d2d81961937a069d416f162e3a7e11e3ee4905b1c549db7ee792335526afdb2e">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___