### PR TITLE
feat(kernel): block-FP8 dequantize/quantize primitives (issue #10)

### DIFF
--- a/python/freetoken/kernel/triton/fp8_block_linear.py
+++ b/python/freetoken/kernel/triton/fp8_block_linear.py
@@ -71,14 +71,24 @@ def dequantize_block_fp8(
             f"weight_scale_inv shape {tuple(weight_scale_inv.shape)} does not match "
             f"the expected {expected_scale_shape} for weight_fp8 shape {(N, K)} at block={block}"
         )
-    # Upsample the per-block scale table to per-element via repeat_interleave (each
-    # block's single scale broadcasts to every element in that block), then multiply
-    # in fp32 for precision before casting to the caller's dtype. Trim to (N, K) in
-    # case N/K are not exact multiples of block (the repeat overshoots by the pad).
+    # Reshape into [n_blocks_row, block, n_blocks_col, block] and multiply by the
+    # per-block scale via broadcasting (scale[:, None, :, None]) rather than
+    # repeat_interleave-ing it up to a full [N, K] tensor first -- for a large
+    # checkpoint matrix (DeepSeek-V3 scale) that extra materialized fp32 scale
+    # tensor is a real, avoidable multi-hundred-MB temporary (PR-Agent review,
+    # PR #125). Pad up to a block multiple first (mirrors quantize_block_fp8),
+    # then trim back to (N, K) after.
+    n_blocks_row, n_blocks_col = expected_scale_shape
+    pad_n = n_blocks_row * block - N
+    pad_k = n_blocks_col * block - K
+    w = weight_fp8.to(torch.float32)
+    if pad_n or pad_k:
+        w = torch.nn.functional.pad(w, (0, pad_k, 0, pad_n))
+    blocks = w.reshape(n_blocks_row, block, n_blocks_col, block)
     scale = weight_scale_inv.to(torch.float32)
-    scale = scale.repeat_interleave(block, dim=0)[:N]
-    scale = scale.repeat_interleave(block, dim=1)[:, :K]
-    return (weight_fp8.to(torch.float32) * scale).to(out_dtype)
+    out = blocks * scale[:, None, :, None]
+    out = out.reshape(n_blocks_row * block, n_blocks_col * block)[:N, :K]
+    return out.to(out_dtype)
 
 
 def quantize_block_fp8(

--- a/python/freetoken/kernel/triton/fp8_block_linear.py
+++ b/python/freetoken/kernel/triton/fp8_block_linear.py
@@ -1,13 +1,137 @@
-"""Triton-Intel kernel: fp8_block_linear.
+"""DeepSeek-V3-style 128x128 block-FP8 weights: quantize / dequantize (issue `quant-xpu`).
 
 Upstream NVIDIA path: python/freetoken/kernel/triton/fp8_block_linear.py
-Fill in: GitHub issue `quant-xpu` (see docs/architecture.md).
+
+Upstream's version is a full native-FP8-tensor-core Triton GEMM (dynamic
+per-token activation quant + a custom ``tl.dot`` kernel that runs in real
+fp8 when the platform supports it, falling back to a bf16-emulated dot
+otherwise -- see its own ``e4m3_native_cx()`` capability check). Porting
+that whole kernel to Intel's Triton-XPU backend is real, separate work
+(unverified whether ``triton_xpu`` even exposes an fp8 ``tl.dot`` today) --
+not attempted here.
+
+This is the **dequant-on-load** half instead, which issue `quant-xpu`'s own
+accept criteria explicitly allows ("Document which dtypes are native vs
+dequant-on-load"): a checkpoint's fp8 weight + per-block scale round-trips
+through this module to a plain bf16 (or fp32) tensor, then flows through
+this port's EXISTING, already-correct/tested bf16 fused / offload MoE and
+dense-linear code paths unchanged. No custom kernel, no hardware fp8
+tensor-core dependency -- just the storage-format convention, matched
+exactly to upstream (and to sglang's / vLLM's ``w8a8_block_fp8`` weight
+layout, which real FP8-quantized checkpoints on HuggingFace already use):
+
+    weight_bf16[i, j] = weight_fp8[i, j] * weight_scale_inv[i // block, j // block]
+
+``weight`` is ``[N, K]`` fp8-e4m3 (``torch.float8_e4m3fn``); ``weight_scale_inv``
+is ``[ceil(N/block), ceil(K/block)]`` (bf16 or fp32 in the checkpoint; computed
+here in fp32 for the intermediate multiply and cast back to the caller's
+``out_dtype``). ``block`` defaults to 128, DeepSeek-V3 / sglang / vLLM's
+convention (also what a real checkpoint's ``quantization_config
+.weight_block_size`` would name -- read from there, not hardcoded, once
+loader-side integration lands as a follow-up).
+
+VRAM benefit even without a native fp8 GEMM: the checkpoint's on-disk /
+host-resident footprint is the fp8 tensor (half the bytes of bf16) plus a
+tiny per-block scale table -- dequantizing to bf16 happens only once, at
+load time (or lazily per forward, for a backend that wants to keep the fp8
+bytes resident and pay the dequant cost repeatedly to save VRAM -- not what
+this first cut does; :func:`dequantize_block_fp8` is called once here).
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import torch
+
+FP8 = torch.float8_e4m3fn
+_BLOCK = 128
 
 
-def fp8_block_linear(*args, **kwargs):
-    unimplemented("fp8_block_linear", "quant-xpu")
+def dequantize_block_fp8(
+    weight_fp8: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    *,
+    block: int = _BLOCK,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Reconstruct a dense ``[N, K]`` tensor from block-quantized fp8 + scales.
 
+    ``weight_fp8`` is ``[N, K]`` (any fp8 dtype torch supports, typically
+    ``torch.float8_e4m3fn``); ``weight_scale_inv`` is ``[ceil(N/block),
+    ceil(K/block)]``. ``N`` / ``K`` need not be exact multiples of ``block``
+    (the last row/col block of scales covers the remainder).
+    """
+    if weight_fp8.ndim != 2:
+        raise ValueError(f"weight_fp8 must be 2-D [N, K], got shape {tuple(weight_fp8.shape)}")
+    N, K = weight_fp8.shape
+    expected_scale_shape = (
+        (N + block - 1) // block,
+        (K + block - 1) // block,
+    )
+    if tuple(weight_scale_inv.shape) != expected_scale_shape:
+        raise ValueError(
+            f"weight_scale_inv shape {tuple(weight_scale_inv.shape)} does not match "
+            f"the expected {expected_scale_shape} for weight_fp8 shape {(N, K)} at block={block}"
+        )
+    # Upsample the per-block scale table to per-element via repeat_interleave (each
+    # block's single scale broadcasts to every element in that block), then multiply
+    # in fp32 for precision before casting to the caller's dtype. Trim to (N, K) in
+    # case N/K are not exact multiples of block (the repeat overshoots by the pad).
+    scale = weight_scale_inv.to(torch.float32)
+    scale = scale.repeat_interleave(block, dim=0)[:N]
+    scale = scale.repeat_interleave(block, dim=1)[:, :K]
+    return (weight_fp8.to(torch.float32) * scale).to(out_dtype)
+
+
+def quantize_block_fp8(
+    weight: torch.Tensor,
+    *,
+    block: int = _BLOCK,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a dense ``[N, K]`` tensor to block-fp8 + per-block scale.
+
+    The inverse of :func:`dequantize_block_fp8` (used to build fabricated fp8
+    test checkpoints, and by any future checkpoint-conversion tool -- ``ft
+    checkpoint`` / issue ``ftw-checkpoint``, #11 -- that quantizes an existing
+    bf16 checkpoint rather than only reading an already-quantized one).
+    Per-block scale is ``max(abs(block)) / fp8_max`` (symmetric, matching
+    upstream's dynamic activation quant formula), clamped away from zero so an
+    all-zero block does not divide by zero.
+    """
+    if weight.ndim != 2:
+        raise ValueError(f"weight must be 2-D [N, K], got shape {tuple(weight.shape)}")
+    N, K = weight.shape
+    fp8_max = torch.finfo(FP8).max
+    n_blocks_row = (N + block - 1) // block
+    n_blocks_col = (K + block - 1) // block
+    pad_n = n_blocks_row * block - N
+    pad_k = n_blocks_col * block - K
+    w = weight.to(torch.float32)
+    if pad_n or pad_k:
+        w = torch.nn.functional.pad(w, (0, pad_k, 0, pad_n))
+    blocks = w.reshape(n_blocks_row, block, n_blocks_col, block)
+    amax = blocks.abs().amax(dim=(1, 3)).clamp_min(1e-12)  # [n_blocks_row, n_blocks_col]
+    scale = amax / fp8_max
+    quantized = (blocks / scale[:, None, :, None]).clamp(-fp8_max, fp8_max)
+    quantized = quantized.reshape(n_blocks_row * block, n_blocks_col * block)[:N, :K].to(FP8)
+    return quantized, scale
+
+
+def fp8_block_linear(
+    x: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    *,
+    block: int = _BLOCK,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x @ dequantize_block_fp8(weight_fp8, weight_scale_inv).T (+ bias)``.
+
+    The dequant-on-forward drop-in for a quantized ``nn.Linear``-shaped
+    weight (``[out_features, in_features]``, the checkpoint's native
+    layout): dequantizes once per call and runs the existing bf16 matmul.
+    For a weight used repeatedly across many forward calls (the common
+    case), the caller should dequantize ONCE at load time instead (via
+    :func:`dequantize_block_fp8` directly) and cache the bf16 result --
+    this per-call convenience wrapper pays the dequant cost every call.
+    """
+    w = dequantize_block_fp8(weight_fp8, weight_scale_inv, block=block, out_dtype=x.dtype)
+    return torch.nn.functional.linear(x, w, bias)

--- a/tests/test_fp8_block_quant.py
+++ b/tests/test_fp8_block_quant.py
@@ -1,0 +1,86 @@
+"""Correctness tests for block-FP8 quantize/dequantize (issue quant-xpu, #10).
+
+These are the storage-format primitives, not a kernel -- pure torch, no
+triton, no XPU dependency (fp8 tensor creation/cast works identically on CPU
+and XPU per direct probe on this box). Runs in the CPU venv.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.fp8_block_linear import (
+    dequantize_block_fp8,
+    fp8_block_linear,
+    quantize_block_fp8,
+)
+
+
+def test_round_trip_matches_original_within_fp8_precision():
+    torch.manual_seed(0)
+    w = torch.randn(256, 256) * 0.5
+    q, scale = quantize_block_fp8(w, block=128)
+    assert q.dtype == torch.float8_e4m3fn
+    assert scale.shape == (2, 2)
+
+    back = dequantize_block_fp8(q, scale, block=128, out_dtype=torch.float32)
+    # fp8-e4m3 has ~2 decimal digits of precision; a generous but real bound.
+    torch.testing.assert_close(back, w, rtol=0.1, atol=0.05)
+
+
+def test_non_multiple_of_block_shape_round_trips():
+    """N/K need not be exact multiples of block (the last block covers the
+    remainder) -- a real checkpoint's dims are not guaranteed 128-aligned."""
+    torch.manual_seed(1)
+    w = torch.randn(200, 130) * 0.3
+    q, scale = quantize_block_fp8(w, block=128)
+    assert q.shape == (200, 130)
+    assert scale.shape == (2, 2)  # ceil(200/128)=2, ceil(130/128)=2
+
+    back = dequantize_block_fp8(q, scale, block=128, out_dtype=torch.float32)
+    assert back.shape == w.shape
+    torch.testing.assert_close(back, w, rtol=0.1, atol=0.05)
+
+
+def test_dequantize_rejects_mismatched_scale_shape():
+    w = torch.randn(256, 256)
+    q, scale = quantize_block_fp8(w, block=128)
+    bad_scale = scale[:1]  # wrong shape
+    with pytest.raises(ValueError, match="does not match"):
+        dequantize_block_fp8(q, bad_scale, block=128)
+
+
+def _relative_error(out: torch.Tensor, ref: torch.Tensor) -> float:
+    return ((out - ref).norm() / ref.norm().clamp_min(1e-12)).item()
+
+
+def test_fp8_block_linear_matches_fp32_reference_matmul():
+    """A matmul SUMS quantization error over K, and any block containing one
+    large-magnitude weight sets that block's whole scale -- costing precision
+    for the block's smaller elements. That is expected, real block-fp8 lossy
+    behavior (the same tradeoff real production fp8 checkpoints accept), not
+    a correctness bug, so this checks the aggregate (whole-tensor relative
+    L2 error) rather than every individual output element."""
+    torch.manual_seed(2)
+    x = torch.randn(4, 256)
+    w = torch.randn(64, 256) * 0.5  # [out_features, in_features]
+    q, scale = quantize_block_fp8(w, block=128)
+
+    out = fp8_block_linear(x, q, scale, block=128)
+    ref = torch.nn.functional.linear(x, w)
+    err = _relative_error(out, ref)
+    assert err < 0.05, f"fp8-quantized matmul relative L2 error too large: {err:.4f}"
+
+
+def test_fp8_block_linear_with_bias():
+    torch.manual_seed(3)
+    x = torch.randn(2, 128)
+    w = torch.randn(16, 128) * 0.5
+    bias = torch.randn(16)
+    q, scale = quantize_block_fp8(w, block=128)
+
+    out = fp8_block_linear(x, q, scale, block=128, bias=bias)
+    ref = torch.nn.functional.linear(x, w, bias)
+    err = _relative_error(out - bias, ref - bias)  # isolate the matmul term
+    assert err < 0.05, f"fp8-quantized matmul (with bias) relative L2 error too large: {err:.4f}"


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 96** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 0c4640a](https://github.com/Performant-Labs/FreeToken-Intel/commit/0c4640abfdd10128999b3f0ab40ff4a6cd47f57a) · run [#33694058742](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33694058742) · 2026-09-02 17:19 MDT / 2026-09-02 23:19 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Starts issue quant-xpu (#10): DeepSeek-V3-style 128x128 block-FP8 weight storage (`weight_bf16[i,j] = weight_fp8[i,j] * weight_scale_inv[i//128, j//128]`), matching upstream's own convention (and sglang's/vLLM's `w8a8_block_fp8` layout real HF checkpoints already use).

**Scoped deliberately** to the dequant-on-load half of the issue's own accept criteria ("Document which dtypes are native vs dequant-on-load"): upstream's `fp8_block_linear.py` is a full native-FP8-tensor-core Triton GEMM with its own hardware-capability detection — porting that whole kernel to Intel's Triton-XPU backend is real, separate work (unverified whether `triton_xpu` even exposes an fp8 `tl.dot` today, and there's no local FP8-quantized checkpoint to validate a full loader-integration + real-model round trip against right now).

This delivers the well-specified, independently-testable half: `dequantize_block_fp8`/`quantize_block_fp8` (pure torch, no custom kernel) plus `fp8_block_linear` (a dequant-on-forward drop-in). Once dequantized, weights flow through this port's existing, already-correct bf16 fused/offload code paths unchanged — the VRAM benefit is the checkpoint's on-disk/host-resident footprint (half the bytes of bf16), not compute speed, for this first cut.

## Test plan
- [x] `tests/test_fp8_block_quant.py` (new, 5 tests) — round-trip quantize→dequantize matches original within fp8-e4m3's real precision bound (including non-128-aligned shapes); `fp8_block_linear`'s matmul matches an fp32 reference within a whole-tensor relative-L2-error bound (a matmul sums quantization error over K — real, expected block-fp8 lossy behavior, not a bug)
- [x] Verified directly on real XPU hardware (relative error ~2.7% for a 256×256 weight), 0 exec-queue resets
- [x] `pytest tests/ -m "not xpu"` — 251 passed (5 new), same 11 pre-existing unrelated failures

**Not done, and explicitly noted rather than overclaimed:** MXFP4 (the issue's other allowed format), loader-side integration, native fp8-tensor-core compute. Real, separable follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add pure-torch block-FP8 quantization/dequantization helpers

- Implement dequant-on-forward `fp8_block_linear` linear replacement

- Avoid full-size scale materialization via broadcasting

- Add five CPU tests covering shapes and errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  impl["python/freetoken/kernel/triton/fp8_block_linear.py"] -- "adds dequantize_block_fp8" --> deq["Broadcast dequant to out_dtype"]
  impl -- "adds quantize_block_fp8" --> quant["Symmetric block quantization to fp8"]
  impl -- "adds fp8_block_linear" --> lin["Dequant-on-forward nn.Linear"]
  tests["tests/test_fp8_block_quant.py"] -- "5 correctness tests" --> deq
  tests -- "round-trip and matmul checks" --> quant
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fp8_block_linear.py</strong><dd><code>Implement block-FP8 quantize/dequantize and linear drop-in</code></dd></summary>
<hr>

python/freetoken/kernel/triton/fp8_block_linear.py

<ul><li>Replaces <code>unimplemented</code> stub with pure-torch <code>dequantize_block_fp8</code>, <br><code>quantize_block_fp8</code>, and <code>fp8_block_linear</code>.<br> <li> Uses reshape/broadcast in dequant to avoid full-size scale <br>materialization.<br> <li> Pads non-block-aligned shapes and trims outputs.<br> <li> Adds documentation for the DeepSeek-V3 block-FP8 storage convention.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/125/files#diff-ff4f68373a56a54df7fd232bb2c6271c2dba2627c1c8c22e4c95ef80e886b6f6">+139/-5</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_fp8_block_quant.py</strong><dd><code>Add block-FP8 quant correctness tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_fp8_block_quant.py

<ul><li>Adds five CPU tests for round-trip fp8 precision, <br>non-multiple-of-block shapes, scale shape validation, matmul relative <br>error, and bias.<br> <li> Uses <code>torch.testing.assert_close</code> and custom relative L2 error.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/125/files#diff-075dad4d88eebb86b1f3a215372fd5f0c3cb14bbf1fbb9f17f24da07349016ca">+86/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___