### PR TITLE
fix(checkpoint): ft checkpoint CLI crashed on prog= kwarg from cli.py

### DIFF
--- a/python/freetoken/checkpoint/__main__.py
+++ b/python/freetoken/checkpoint/__main__.py
@@ -13,15 +13,22 @@ import sys
 from .convert import convert_checkpoint, convert_summary
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="ft checkpoint")
+def main(argv: list[str] | None = None, prog: str = "ft checkpoint") -> int:
+    parser = argparse.ArgumentParser(prog=prog)
     sub = parser.add_subparsers(dest="command", required=True)
 
     convert_p = sub.add_parser("convert", help="Convert a safetensors checkpoint to FTW")
     convert_p.add_argument("model_path", help="Source checkpoint directory (HF safetensors)")
     convert_p.add_argument("output_path", help="Destination FTW directory")
 
-    args = parser.parse_args(argv)
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    # argparse prints to stdout/stderr and raises SystemExit on both --help
+    # (0) and usage errors (2); honor whatever it chose rather than letting
+    # it propagate past this function (matches server/launch.py's pattern).
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code if exc.code is not None else 0)
     if args.command == "convert":
         convert_checkpoint(args.model_path, args.output_path)
         summary = convert_summary(args.output_path)

--- a/python/freetoken/checkpoint/convert.py
+++ b/python/freetoken/checkpoint/convert.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 import os
 import shutil
 
-import torch
-
 from .ftw import FtwArchive
+
+# torch is imported lazily inside convert_checkpoint(), not at module level:
+# this module is on the `ft checkpoint` CLI's import path
+# (checkpoint/__main__.py -> convert.py), which must stay importable
+# (`ft checkpoint --help`) in a torch-free environment -- the CPU CLI-smoke
+# lane runs exactly that (caught in PR #127).
 
 
 class _CountingIterator:
@@ -60,6 +64,8 @@ def convert_checkpoint(model_path: str, output_path: str) -> str:
     Every tensor is carried over unchanged (dtype, shape, values) -- this
     repacks the storage format, it does not requantize or reshape anything.
     """
+    import torch
+
     from freetoken.models.weight import iter_safetensors
 
     os.makedirs(output_path, exist_ok=True)

--- a/python/freetoken/checkpoint/ftw.py
+++ b/python/freetoken/checkpoint/ftw.py
@@ -33,9 +33,16 @@ import json
 import mmap
 import os
 import warnings
-from typing import Dict, Iterator, Tuple
+from typing import TYPE_CHECKING, Dict, Iterator, Tuple
 
-import torch
+if TYPE_CHECKING:
+    import torch
+
+# torch is imported lazily inside each function/method that needs it, not at
+# module level: this module is on the `ft checkpoint` CLI's import path
+# (checkpoint/__main__.py -> convert.py -> ftw.py), which must stay
+# importable (e.g. `ft checkpoint --help`) in a torch-free environment --
+# the CPU CLI-smoke lane runs exactly that (caught in PR #127).
 
 INDEX_NAME = "ftw_index.json"
 WEIGHTS_NAME = "ftw_weights.bin"
@@ -51,6 +58,8 @@ def _dtype_to_str(dtype: torch.dtype) -> str:
 
 
 def _dtype_from_str(name: str) -> torch.dtype:
+    import torch
+
     dtype = getattr(torch, name, None)
     if not isinstance(dtype, torch.dtype):
         raise ValueError(f"unknown FTW tensor dtype {name!r}")
@@ -74,6 +83,8 @@ class FtwArchive:
         can be large enough for that intermediate dict alone to exhaust host
         RAM during offline conversion.
         """
+        import torch
+
         os.makedirs(self.path, exist_ok=True)
         items = tensors.items() if isinstance(tensors, dict) else tensors
         index: Dict[str, dict] = {}
@@ -111,6 +122,8 @@ class FtwArchive:
         tensors well past that point (e.g. building the model's state dict),
         so a raw view would go stale.
         """
+        import torch
+
         index = self.read_index()
         weights_path = os.path.join(self.path, WEIGHTS_NAME)
         with open(weights_path, "rb") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,3 +17,28 @@ def test_unknown_command_exits_two():
 
 def test_no_args_exits_two():
     assert main([]) == 2
+
+
+def test_checkpoint_help_exits_zero():
+    # Regression: `_run_checkpoint` calls `checkpoint.__main__.main(argv,
+    # prog=...)` -- a prior version of that main() did not accept `prog` and
+    # raised TypeError for every `ft checkpoint` invocation, `--help`
+    # included (caught during shell-daemon (#27) follow-up work, PR #127).
+    assert main(["checkpoint", "--help"]) == 0
+
+
+def test_checkpoint_convert_round_trips_through_the_top_level_cli(tmp_path, capsys):
+    import json
+
+    torch = __import__("pytest").importorskip("torch")
+    from safetensors.torch import save_file
+
+    src = tmp_path / "src_ckpt"
+    src.mkdir()
+    save_file({"w": torch.randn(4, 4).contiguous()}, str(src / "model.safetensors"))
+    (src / "config.json").write_text(json.dumps({"architectures": ["Foo"]}))
+    dst = tmp_path / "dst_ckpt"
+
+    assert main(["checkpoint", "convert", str(src), str(dst)]) == 0
+    assert (dst / "ftw_index.json").is_file()
+    assert "Wrote FTW archive" in capsys.readouterr().out


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 92** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 95bec1a](https://github.com/Performant-Labs/FreeToken-Intel/commit/95bec1a3497cbe184c9c34f50861f8ed7fd1624c) · run [#33696445437](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33696445437) · 2026-09-02 17:47 MDT / 2026-09-02 23:47 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Found while starting shell-daemon (#27) follow-up work: `ft checkpoint` (the real top-level CLI entry point, e.g. `ft checkpoint --help`) crashed with `TypeError: main() got an unexpected keyword argument 'prog'`. `cli.py`'s `_run_checkpoint` calls `checkpoint.__main__.main(argv, prog="ft checkpoint")`, but that `main()` (landed in #126) didn't accept `prog`. My own manual verification for #126 invoked the module directly (`python -m freetoken.checkpoint convert ...`), which bypasses `cli.py` entirely and never hit this -- it shipped unnoticed.

`main()` now accepts `prog` (passed through to argparse) and catches argparse's `SystemExit` instead of letting it propagate raw (matches `server/launch.py`'s existing pattern for the same problem).

## Test plan
- [x] `tests/test_cli.py` (2 new cases): `ft checkpoint --help` exits 0; a full `ft checkpoint convert` round trip through the top-level CLI -- either would have caught this
- [x] `pytest tests/ -m "not xpu"`: 259 passed (+2), same 11 pre-existing unrelated failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `ft checkpoint --help` crash from unexpected `prog`

- Handle argparse `SystemExit` without raw propagation

- Make `convert.py` and `ftw.py` torch imports lazy

- Add top-level CLI checkpoint regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["checkpoint __main__.py main"] -- "accepts prog, catches SystemExit" --> C["ft checkpoint CLI works"]
  B["convert.py and ftw.py"] -- "lazy torch imports" --> C
  D["tests/test_cli.py"] -- "regression tests for help and convert" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__main__.py</strong><dd><code>Make checkpoint main accept prog and handle exits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/checkpoint/__main__.py

<ul><li><code>main</code> accepts new <code>prog</code> argument and passes it to <br><code>argparse.ArgumentParser</code>.<br> <li> Normalizes <code>argv=None</code> to <code>sys.argv[1:]</code> before parsing.<br> <li> Catches argparse <code>SystemExit</code> and returns its exit code instead of <br>propagating.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/127/files#diff-d4668814f3f829faf69004c87584034bf3b47d92224deef31051abf66f767cb7">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convert.py</strong><dd><code>Defer torch import in checkpoint conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/checkpoint/convert.py

<ul><li>Removes module-level <code>import torch</code>.<br> <li> Adds lazy <code>import torch</code> inside <code>convert_checkpoint</code> to keep CLI import <br>torch-free.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/127/files#diff-7d7762297cac1ac2e56922efc0c091df00641d78c11768c80877531bed5eb3a2">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ftw.py</strong><dd><code>Lazy torch imports in FTW archive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/checkpoint/ftw.py

<ul><li>Replaces module-level <code>import torch</code> with <code>TYPE_CHECKING</code> import.<br> <li> Adds lazy <code>import torch</code> in <code>_dtype_from_str</code>, <code>FtwArchive.write</code>, and <br><code>FtwArchive.read</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/127/files#diff-7ab503b63b3a519ec0bbca11f8118d39af13a518ee86939819469e9bab934da2">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cli.py</strong><dd><code>Add CLI regression tests for checkpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_cli.py

<ul><li>Adds regression test for <code>main(["checkpoint", "--help"]) == 0</code>.<br> <li> Adds full top-level CLI checkpoint convert round-trip test using a <br>temporary safetensors checkpoint.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/127/files#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032e">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___