### PR TITLE
feat(shell,daemon,ctl): daemon supervisor, ft ctl, and a real-HTTP chat TUI (issue #27)

### DIFF
--- a/python/freetoken/control_cli.py
+++ b/python/freetoken/control_cli.py
@@ -19,22 +19,44 @@ from freetoken.daemon.client import DaemonClient, DaemonConnectionError, DEFAULT
 
 
 def _parse_args(argv: list[str], prog: str) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog=prog, description="Query and manage a running ft daemon.")
-    parser.add_argument(
+    # --daemon-url is registered on both the top-level parser AND (via this
+    # shared parent) each subparser: argparse only accepts a parent parser's
+    # own options *before* the subcommand name, so `ft ctl status
+    # --daemon-url <url>` -- the natural place to put it -- would otherwise
+    # fail with "unrecognized arguments" (PR-Agent review, PR #128); only
+    # `ft ctl --daemon-url <url> status` would have worked. Registering it on
+    # both accepts the flag in either position.
+    # Two separate parent parsers, not one reused: the subparser copy's
+    # default must be argparse.SUPPRESS, not the real default. If it also
+    # defaulted to DEFAULT_BASE_URL, `ft ctl --daemon-url X status` (flag
+    # given at the top level, not repeated after the subcommand) would parse
+    # the top level's --daemon-url correctly and then have the subparser's
+    # own re-parse immediately clobber it back to the default -- SUPPRESS
+    # means "leave the namespace's existing value alone if not given here".
+    top_level_daemon_url = argparse.ArgumentParser(add_help=False)
+    top_level_daemon_url.add_argument(
         "--daemon-url",
         default=DEFAULT_BASE_URL,
         help=f"daemon control-plane base URL (default: {DEFAULT_BASE_URL})",
     )
+    sub_daemon_url = argparse.ArgumentParser(add_help=False)
+    sub_daemon_url.add_argument("--daemon-url", default=argparse.SUPPRESS, help=argparse.SUPPRESS)
+
+    parser = argparse.ArgumentParser(
+        prog=prog, description="Query and manage a running ft daemon.", parents=[top_level_daemon_url]
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("status", help="Show whether ft serve is running, and its metadata")
+    sub.add_parser("status", parents=[sub_daemon_url], help="Show whether ft serve is running, and its metadata")
 
-    start_p = sub.add_parser("start", help="Start ft serve under the daemon's supervision")
+    start_p = sub.add_parser(
+        "start", parents=[sub_daemon_url], help="Start ft serve under the daemon's supervision"
+    )
     start_p.add_argument("model", help="model reference (HF repo id, FTW path, or registered name)")
     start_p.add_argument("--host", default="127.0.0.1")
     start_p.add_argument("--port", type=int, default=8080)
 
-    sub.add_parser("stop", help="Stop the supervised ft serve process")
+    sub.add_parser("stop", parents=[sub_daemon_url], help="Stop the supervised ft serve process")
 
     return parser.parse_args(argv)
 

--- a/python/freetoken/control_cli.py
+++ b/python/freetoken/control_cli.py
@@ -1,13 +1,68 @@
-"""ft ctl — inspect a running server.
+"""``ft ctl`` — inspect a running server.
 
 Upstream NVIDIA path: python/freetoken/control_cli.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
+
+Talks to the daemon's control-plane app (:mod:`freetoken.daemon.app`) via
+:class:`freetoken.daemon.client.DaemonClient` -- plain JSON-over-HTTP, no
+torch import anywhere on this path, so ``ft ctl`` never needs an XPU (or
+even a GPU-capable machine) to query/manage a server running elsewhere.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import argparse
+import json
+import sys
+from typing import TextIO
+
+from freetoken.daemon.client import DaemonClient, DaemonConnectionError, DEFAULT_BASE_URL
 
 
-def main(*args, **kwargs):
-    unimplemented("main", "shell-daemon")
+def _parse_args(argv: list[str], prog: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=prog, description="Query and manage a running ft daemon.")
+    parser.add_argument(
+        "--daemon-url",
+        default=DEFAULT_BASE_URL,
+        help=f"daemon control-plane base URL (default: {DEFAULT_BASE_URL})",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
 
+    sub.add_parser("status", help="Show whether ft serve is running, and its metadata")
+
+    start_p = sub.add_parser("start", help="Start ft serve under the daemon's supervision")
+    start_p.add_argument("model", help="model reference (HF repo id, FTW path, or registered name)")
+    start_p.add_argument("--host", default="127.0.0.1")
+    start_p.add_argument("--port", type=int, default=8080)
+
+    sub.add_parser("stop", help="Stop the supervised ft serve process")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None, prog: str = "ft ctl", out: TextIO | None = None) -> int:
+    stream = out if out is not None else sys.stdout
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    try:
+        args = _parse_args(argv, prog=prog)
+    except SystemExit as exc:
+        return int(exc.code if exc.code is not None else 0)
+
+    client = DaemonClient(args.daemon_url)
+    try:
+        if args.command == "status":
+            result = client.status()
+        elif args.command == "start":
+            result = client.start(args.model, host=args.host, port=args.port)
+        elif args.command == "stop":
+            result = client.stop()
+        else:  # pragma: no cover -- argparse's `required=True` rules this out
+            return 2
+    except DaemonConnectionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    stream.write(json.dumps(result, indent=2) + "\n")
+    return 0

--- a/python/freetoken/daemon/__init__.py
+++ b/python/freetoken/daemon/__init__.py
@@ -1,13 +1,56 @@
 """Persistent supervisor (torch-free). Upstream daemon package.
 
 Upstream NVIDIA path: python/freetoken/daemon/__init__.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
+
+``ft daemon`` runs the control-plane app (:mod:`freetoken.daemon.app`) that
+starts/stops/reports on one supervised ``ft serve`` child
+(:mod:`freetoken.daemon.serve_manager`). Entirely torch-free by itself --
+the daemon process never imports torch; only the ``ft serve`` *child* it
+spawns does, in its own process.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import argparse
+import os
+import sys
+
+from .app import create_app
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8500
 
 
-def main(*args, **kwargs):
-    unimplemented("main", "shell-daemon")
+def _parse_args(argv: list[str], prog: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Run the FreeToken-Intel daemon: a persistent supervisor for `ft serve`.",
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help=f"control-plane bind address (default: {DEFAULT_HOST})")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"control-plane bind port (default: {DEFAULT_PORT})")
+    return parser.parse_args(argv)
 
+
+def main(argv: list[str] | None = None, prog: str = "ft daemon") -> int:
+    """Entry point for ``ft daemon``. Returns a process exit code.
+
+    Serves the control-plane app with uvicorn until the process is stopped.
+    Mirrors ``server/api_server.py::run_api_server``'s test-harness guard:
+    under pytest (``PYTEST_CURRENT_TEST`` set) the app is built to confirm
+    wiring but never bound to a port -- uvicorn would otherwise block the
+    test runner. Test code that needs a live daemon drives ``create_app`` +
+    ``TestClient`` directly.
+    """
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    try:
+        args = _parse_args(argv, prog=prog)
+    except SystemExit as exc:
+        return int(exc.code if exc.code is not None else 0)
+
+    app = create_app()
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return 0
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    return 0

--- a/python/freetoken/daemon/__init__.py
+++ b/python/freetoken/daemon/__init__.py
@@ -12,6 +12,7 @@ spawns does, in its own process.
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import os
 import sys
 
@@ -19,6 +20,23 @@ from .app import create_app
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8500
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True if ``host`` only ever resolves to this machine (loopback).
+
+    Used to warn (not block -- an operator may have a real reason, e.g. an
+    already-firewalled network namespace) when ``--host`` opts the daemon's
+    control plane out of its documented trust model: no authentication
+    beyond the CSRF header on /start and /stop, safe only because the
+    default bind is loopback-only (PR-Agent review, PR #128).
+    """
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False  # a hostname (not an IP literal) -- can't vouch for it
 
 
 def _parse_args(argv: list[str], prog: str) -> argparse.Namespace:
@@ -46,6 +64,17 @@ def main(argv: list[str] | None = None, prog: str = "ft daemon") -> int:
         args = _parse_args(argv, prog=prog)
     except SystemExit as exc:
         return int(exc.code if exc.code is not None else 0)
+
+    if not _is_loopback_host(args.host):
+        print(
+            f"warning: ft daemon is binding to {args.host!r}, not loopback. "
+            "The control plane's only protection is a publicly-knowable CSRF "
+            "header, not real authentication -- anyone who can reach this "
+            "address can start/stop the supervised ft serve. Prefer a "
+            "loopback bind plus your own network-level access control "
+            "(firewall, SSH tunnel, VPN).",
+            file=sys.stderr,
+        )
 
     app = create_app()
     if os.environ.get("PYTEST_CURRENT_TEST"):

--- a/python/freetoken/daemon/app.py
+++ b/python/freetoken/daemon/app.py
@@ -1,13 +1,72 @@
 """Daemon HTTP control plane.
 
 Upstream NVIDIA path: python/freetoken/daemon/app.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
+
+A tiny FastAPI app -- ``/status`` (GET), ``/start`` / ``/stop`` (POST) --
+in front of one :class:`freetoken.daemon.serve_manager.ServeManager`. This
+is the daemon's own control channel, separate from the ``ft serve`` model
+server it supervises (which exposes the OpenAI/Anthropic routes on its own
+port once running -- see ``server/api_server.py``). Dependency-light like
+``server/openai_api.py`` (FastAPI + pydantic, no torch), so building/testing
+this app never touches torch either.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import sys
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .serve_manager import ServeManager
 
 
-def create_app(*args, **kwargs):
-    unimplemented("create_app", "shell-daemon")
+class StartRequest(BaseModel):
+    model: str
+    host: str = "127.0.0.1"
+    port: int = 8080
+    extra_args: list[str] = []
 
+
+def _serve_argv(req: StartRequest) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "freetoken.cli",
+        "serve",
+        req.model,
+        "--host",
+        req.host,
+        "--port",
+        str(req.port),
+        *req.extra_args,
+    ]
+
+
+def create_app(serve_manager: ServeManager | None = None) -> FastAPI:
+    """Build the daemon's control-plane app. ``serve_manager`` defaults to a
+    fresh :class:`ServeManager`; tests inject one to observe/stub start/stop."""
+    app = FastAPI(title="freetoken-daemon", description="ft daemon control plane")
+    app.state.serve_manager = serve_manager if serve_manager is not None else ServeManager()
+
+    @app.get("/status")
+    def status() -> dict:
+        return app.state.serve_manager.status()
+
+    @app.post("/start")
+    def start(req: StartRequest) -> dict:
+        try:
+            app.state.serve_manager.start(
+                _serve_argv(req),
+                meta={"model": req.model, "host": req.host, "port": req.port},
+            )
+        except RuntimeError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return app.state.serve_manager.status()
+
+    @app.post("/stop")
+    def stop() -> dict:
+        app.state.serve_manager.stop()
+        return app.state.serve_manager.status()
+
+    return app

--- a/python/freetoken/daemon/app.py
+++ b/python/freetoken/daemon/app.py
@@ -15,10 +15,31 @@ from __future__ import annotations
 
 import sys
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel
 
 from .serve_manager import ServeManager
+
+# CSRF guard for the mutating routes (PR-Agent review, PR #128): the daemon
+# binds loopback by default with no auth/TLS (explicitly out of scope), but
+# that alone left POST /stop (and /start) open to a plain cross-origin HTML
+# form submitted by any page the user's browser visits -- the browser would
+# happily deliver that request to 127.0.0.1 and kill the supervised `ft
+# serve`. A plain <form> (and a "simple" cross-origin fetch) cannot set a
+# custom header without triggering a CORS preflight, which this app never
+# answers with an Access-Control-Allow-* response -- so requiring this header
+# blocks that whole class of attack without needing real auth/session state.
+# freetoken.daemon.client.DaemonClient sets it on every request automatically.
+CSRF_HEADER_NAME = "x-freetoken-daemon"
+CSRF_HEADER_VALUE = "1"
+
+
+def _require_csrf_header(x_freetoken_daemon: str | None = Header(default=None)) -> None:
+    if x_freetoken_daemon != CSRF_HEADER_VALUE:
+        raise HTTPException(
+            status_code=403,
+            detail=f"missing/invalid {CSRF_HEADER_NAME!r} header (CSRF guard) -- use DaemonClient, which sets it automatically",
+        )
 
 
 class StartRequest(BaseModel):
@@ -53,7 +74,7 @@ def create_app(serve_manager: ServeManager | None = None) -> FastAPI:
     def status() -> dict:
         return app.state.serve_manager.status()
 
-    @app.post("/start")
+    @app.post("/start", dependencies=[Depends(_require_csrf_header)])
     def start(req: StartRequest) -> dict:
         try:
             app.state.serve_manager.start(
@@ -64,7 +85,7 @@ def create_app(serve_manager: ServeManager | None = None) -> FastAPI:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         return app.state.serve_manager.status()
 
-    @app.post("/stop")
+    @app.post("/stop", dependencies=[Depends(_require_csrf_header)])
     def stop() -> dict:
         app.state.serve_manager.stop()
         return app.state.serve_manager.status()

--- a/python/freetoken/daemon/client.py
+++ b/python/freetoken/daemon/client.py
@@ -1,17 +1,56 @@
 """Daemon client used by `ft ctl`.
 
 Upstream NVIDIA path: python/freetoken/daemon/client.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
+
+A plain-``urllib`` HTTP client for the daemon's control-plane app
+(:mod:`freetoken.daemon.app`) -- no new dependency (``requests``/``httpx``)
+just to talk to a local control socket, matching the project's existing
+"dependency-light" client-side philosophy (``server/openai_api.py``'s own
+docstring). This is also what a client-side ``ft ctl`` runs *without* an XPU
+in its own process -- it only ever does JSON-over-HTTP.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import json
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8500"
+
+
+class DaemonConnectionError(ConnectionError):
+    """The daemon at ``base_url`` could not be reached (not running, wrong
+    port, ...). Distinct from an HTTP error response (e.g. 409), which
+    means the daemon *is* reachable but rejected the request."""
 
 
 class DaemonClient:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    def __init__(self, base_url: str = DEFAULT_BASE_URL) -> None:
+        self.base_url = base_url.rstrip("/")
 
-    def status(self, *args, **kwargs):
-        unimplemented("DaemonClient.status", "shell-daemon")
+    def _request(self, method: str, path: str, body: dict | None = None) -> dict:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        headers = {"Content-Type": "application/json"} if data is not None else {}
+        req = urllib.request.Request(f"{self.base_url}{path}", data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"daemon returned {exc.code} for {method} {path}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise DaemonConnectionError(f"could not reach daemon at {self.base_url}: {exc.reason}") from exc
 
+    def status(self) -> dict:
+        return self._request("GET", "/status")
+
+    def start(self, model: str, *, host: str = "127.0.0.1", port: int = 8080, extra_args: list[str] | None = None) -> dict:
+        return self._request(
+            "POST",
+            "/start",
+            {"model": model, "host": host, "port": port, "extra_args": list(extra_args) if extra_args else []},
+        )
+
+    def stop(self) -> dict:
+        return self._request("POST", "/stop", {})

--- a/python/freetoken/daemon/client.py
+++ b/python/freetoken/daemon/client.py
@@ -16,6 +16,8 @@ import json
 import urllib.error
 import urllib.request
 
+from .app import CSRF_HEADER_NAME, CSRF_HEADER_VALUE
+
 DEFAULT_BASE_URL = "http://127.0.0.1:8500"
 
 
@@ -31,7 +33,9 @@ class DaemonClient:
 
     def _request(self, method: str, path: str, body: dict | None = None) -> dict:
         data = json.dumps(body).encode("utf-8") if body is not None else None
-        headers = {"Content-Type": "application/json"} if data is not None else {}
+        headers = {CSRF_HEADER_NAME: CSRF_HEADER_VALUE}
+        if data is not None:
+            headers["Content-Type"] = "application/json"
         req = urllib.request.Request(f"{self.base_url}{path}", data=data, method=method, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=5) as resp:

--- a/python/freetoken/daemon/serve_manager.py
+++ b/python/freetoken/daemon/serve_manager.py
@@ -15,14 +15,23 @@ a real checkpoint).
 from __future__ import annotations
 
 import subprocess
+import threading
 import time
 from typing import Optional
 
 
 class ServeManager:
-    """Starts, stops, and reports the status of one supervised child process."""
+    """Starts, stops, and reports the status of one supervised child process.
+
+    All mutation (and the check-then-act in ``start``/``stop``) happens
+    under one lock: FastAPI runs its synchronous route handlers in a
+    threadpool, so two concurrent ``/start`` calls (or a ``start`` racing a
+    ``stop``) would otherwise both observe "not running" and spawn two
+    children, leaking the first one's handle (PR-Agent review, PR #128).
+    """
 
     def __init__(self) -> None:
+        self._lock = threading.Lock()
         self._proc: Optional[subprocess.Popen] = None
         self._argv: list[str] = []
         self._started_at: Optional[float] = None
@@ -31,42 +40,49 @@ class ServeManager:
     def start(self, argv: list[str], *, meta: Optional[dict] = None) -> None:
         """Spawn ``argv`` as the supervised child. Raises ``RuntimeError`` if
         a child is already running (``stop()`` it first)."""
-        if self.is_running():
-            raise RuntimeError("a child process is already running; stop it first")
-        self._proc = subprocess.Popen(argv)
-        self._argv = list(argv)
-        self._started_at = time.monotonic()
-        self._meta = dict(meta) if meta else {}
+        with self._lock:
+            if self._is_running_locked():
+                raise RuntimeError("a child process is already running; stop it first")
+            self._proc = subprocess.Popen(argv)
+            self._argv = list(argv)
+            self._started_at = time.monotonic()
+            self._meta = dict(meta) if meta else {}
 
     def stop(self, timeout: float = 10.0) -> None:
         """Terminate the supervised child (SIGTERM, then SIGKILL after
         ``timeout`` seconds). A no-op if nothing is running."""
-        if self._proc is None:
-            return
-        if self._proc.poll() is None:
-            self._proc.terminate()
-            try:
-                self._proc.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                self._proc.kill()
-                self._proc.wait(timeout=timeout)
-        self._proc = None
-        self._argv = []
-        self._started_at = None
-        self._meta = {}
+        with self._lock:
+            if self._proc is None:
+                return
+            if self._proc.poll() is None:
+                self._proc.terminate()
+                try:
+                    self._proc.wait(timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    self._proc.kill()
+                    self._proc.wait(timeout=timeout)
+            self._proc = None
+            self._argv = []
+            self._started_at = None
+            self._meta = {}
+
+    def _is_running_locked(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
 
     def is_running(self) -> bool:
-        return self._proc is not None and self._proc.poll() is None
+        with self._lock:
+            return self._is_running_locked()
 
     def status(self) -> dict:
         """JSON-able status: what ``ft ctl`` / the daemon's ``/status`` route
         report. ``uptime_s`` and the rest are ``None``/empty when nothing is
         running (a stopped/never-started child is not an error)."""
-        running = self.is_running()
-        return {
-            "running": running,
-            "pid": self._proc.pid if running else None,
-            "argv": self._argv if running else [],
-            "meta": self._meta if running else {},
-            "uptime_s": (time.monotonic() - self._started_at) if running else None,
-        }
+        with self._lock:
+            running = self._is_running_locked()
+            return {
+                "running": running,
+                "pid": self._proc.pid if running else None,
+                "argv": self._argv if running else [],
+                "meta": self._meta if running else {},
+                "uptime_s": (time.monotonic() - self._started_at) if running else None,
+            }

--- a/python/freetoken/daemon/serve_manager.py
+++ b/python/freetoken/daemon/serve_manager.py
@@ -1,20 +1,72 @@
 """Spawn / restart `ft serve` children.
 
 Upstream NVIDIA path: python/freetoken/daemon/serve_manager.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
+
+``ServeManager`` supervises one child process via plain ``subprocess``
+(torch-free, works whether or not the daemon process itself ever imports
+torch). It is generic over the child's argv rather than hardcoded to
+build ``ft serve``'s specific command line -- :mod:`freetoken.daemon.app`
+is what constructs the real ``[sys.executable, "-m", "freetoken.cli",
+"serve", model, ...]`` argv, which keeps this class unit-testable with a
+trivial subprocess instead of a real ``ft serve`` (which needs an XPU and
+a real checkpoint).
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import subprocess
+import time
+from typing import Optional
 
 
 class ServeManager:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
+    """Starts, stops, and reports the status of one supervised child process."""
 
-    def start(self, *args, **kwargs):
-        unimplemented("ServeManager.start", "shell-daemon")
+    def __init__(self) -> None:
+        self._proc: Optional[subprocess.Popen] = None
+        self._argv: list[str] = []
+        self._started_at: Optional[float] = None
+        self._meta: dict = {}
 
-    def stop(self, *args, **kwargs):
-        unimplemented("ServeManager.stop", "shell-daemon")
+    def start(self, argv: list[str], *, meta: Optional[dict] = None) -> None:
+        """Spawn ``argv`` as the supervised child. Raises ``RuntimeError`` if
+        a child is already running (``stop()`` it first)."""
+        if self.is_running():
+            raise RuntimeError("a child process is already running; stop it first")
+        self._proc = subprocess.Popen(argv)
+        self._argv = list(argv)
+        self._started_at = time.monotonic()
+        self._meta = dict(meta) if meta else {}
 
+    def stop(self, timeout: float = 10.0) -> None:
+        """Terminate the supervised child (SIGTERM, then SIGKILL after
+        ``timeout`` seconds). A no-op if nothing is running."""
+        if self._proc is None:
+            return
+        if self._proc.poll() is None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=timeout)
+        self._proc = None
+        self._argv = []
+        self._started_at = None
+        self._meta = {}
+
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def status(self) -> dict:
+        """JSON-able status: what ``ft ctl`` / the daemon's ``/status`` route
+        report. ``uptime_s`` and the rest are ``None``/empty when nothing is
+        running (a stopped/never-started child is not an error)."""
+        running = self.is_running()
+        return {
+            "running": running,
+            "pid": self._proc.pid if running else None,
+            "argv": self._argv if running else [],
+            "meta": self._meta if running else {},
+            "uptime_s": (time.monotonic() - self._started_at) if running else None,
+        }

--- a/python/freetoken/shell/__init__.py
+++ b/python/freetoken/shell/__init__.py
@@ -1,13 +1,28 @@
 """ft shell entry.
 
 Upstream NVIDIA path: python/freetoken/shell/__init__.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import argparse
+import sys
 
 
-def main(*args, **kwargs):
-    unimplemented("main", "shell-daemon")
+def _parse_args(argv: list[str], prog: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=prog, description="Chat with a running ft-serve endpoint in the terminal.")
+    parser.add_argument("--server-url", default="http://127.0.0.1:8080", help="ft serve base URL (default: http://127.0.0.1:8080)")
+    parser.add_argument("--model", default="default", help="model name to send with each request")
+    return parser.parse_args(argv)
 
+
+def main(argv: list[str] | None = None, prog: str = "ft shell") -> int:
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    try:
+        args = _parse_args(argv, prog=prog)
+    except SystemExit as exc:
+        return int(exc.code if exc.code is not None else 0)
+
+    from freetoken.shell.tui import run_tui
+
+    return run_tui(args.server_url, args.model)

--- a/python/freetoken/shell/tui.py
+++ b/python/freetoken/shell/tui.py
@@ -1,13 +1,96 @@
 """Terminal chat TUI.
 
 Upstream NVIDIA path: python/freetoken/shell/tui.py
-Fill in: GitHub issue `shell-daemon` (see docs/architecture.md).
+Issue: `shell-daemon` (#27, see docs/architecture.md).
+
+A REPL chat loop against a running ``ft serve`` endpoint's OpenAI-compatible
+``/v1/chat/completions`` route, using plain ``urllib`` (no torch, no XPU) --
+this is what "attaches to a running server without XPU in the client
+process" (this issue's accept criterion). Scoped down from a full-screen
+curses/textual TUI to a line-based REPL: real, useful, and trivially
+testable (scripted input, no terminal needed); a richer full-screen UI is
+separable follow-up work built on the same :class:`ChatClient`.
 """
 from __future__ import annotations
 
-from freetoken._stub import unimplemented
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import IO, Callable, Optional
 
 
-def run_tui(*args, **kwargs):
-    unimplemented("run_tui", "shell-daemon")
+class ChatClientError(RuntimeError):
+    """The server was unreachable, or returned an error / unexpected shape."""
 
+
+class ChatClient:
+    """Minimal OpenAI-compatible chat client. Plain HTTP, no torch import
+    anywhere in this class -- an XPU is never required in the process that
+    runs the TUI, only in the server process it talks to."""
+
+    def __init__(self, base_url: str, model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    def send(self, messages: list[dict]) -> str:
+        body = json.dumps({"model": self.model, "messages": messages}).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/v1/chat/completions",
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise ChatClientError(f"server returned {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise ChatClientError(f"could not reach server at {self.base_url}: {exc.reason}") from exc
+        try:
+            return payload["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ChatClientError(f"unexpected response shape: {payload!r}") from exc
+
+
+def run_tui(
+    server_url: str,
+    model: str,
+    *,
+    client: Optional[ChatClient] = None,
+    input_fn: Callable[[str], str] = input,
+    out: IO[str] = sys.stdout,
+) -> int:
+    """Run an interactive terminal chat loop against a live ``ft serve``
+    endpoint. Returns a process exit code (0 on a clean exit -- ``/exit``,
+    ``/quit``, or end-of-input).
+
+    ``input_fn``/``client`` are injectable so this loop is testable without a
+    real terminal or a real running server (tests pass a scripted
+    ``input_fn`` and a stub client).
+    """
+    chat_client = client if client is not None else ChatClient(server_url, model)
+    messages: list[dict] = []
+    out.write(f"Connected to {server_url} (model: {model}). Type /exit to quit.\n")
+    while True:
+        try:
+            line = input_fn("> ")
+        except EOFError:
+            break
+        stripped = line.strip()
+        if stripped in ("/exit", "/quit"):
+            break
+        if not stripped:
+            continue
+        messages.append({"role": "user", "content": line})
+        try:
+            reply = chat_client.send(messages)
+        except ChatClientError as exc:
+            out.write(f"error: {exc}\n")
+            messages.pop()
+            continue
+        messages.append({"role": "assistant", "content": reply})
+        out.write(f"{reply}\n")
+    return 0

--- a/tests/test_control_cli.py
+++ b/tests/test_control_cli.py
@@ -82,3 +82,44 @@ def test_unreachable_daemon_exits_one(monkeypatch, capsys):
 
 def test_missing_subcommand_exits_two():
     assert main([]) == 2
+
+
+def test_daemon_url_accepted_after_the_subcommand(monkeypatch):
+    """PR-Agent review, PR #128: argparse only accepts a parent parser's own
+    options before the subcommand by default, so `ft ctl status --daemon-url
+    <url>` (the natural place to put it) used to fail with "unrecognized
+    arguments"."""
+    from freetoken import control_cli
+
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, base_url):
+            captured["base_url"] = base_url
+
+        def status(self):
+            return {"running": False}
+
+    monkeypatch.setattr(control_cli, "DaemonClient", _FakeClient)
+    assert main(["status", "--daemon-url", "http://example:9"], out=io.StringIO()) == 0
+    assert captured["base_url"] == "http://example:9"
+
+
+def test_daemon_url_before_subcommand_is_not_clobbered_by_the_subparser_default(monkeypatch):
+    """A regression this fix could plausibly introduce: the subparser's own
+    --daemon-url copy re-parsing over the top-level value with its own
+    default instead of leaving it alone."""
+    from freetoken import control_cli
+
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, base_url):
+            captured["base_url"] = base_url
+
+        def status(self):
+            return {"running": False}
+
+    monkeypatch.setattr(control_cli, "DaemonClient", _FakeClient)
+    assert main(["--daemon-url", "http://example:9", "status"], out=io.StringIO()) == 0
+    assert captured["base_url"] == "http://example:9"

--- a/tests/test_control_cli.py
+++ b/tests/test_control_cli.py
@@ -1,0 +1,84 @@
+"""`ft ctl` CLI (issue `shell-daemon`, #27)."""
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from freetoken.control_cli import main
+from freetoken.daemon.client import DaemonConnectionError
+
+
+def test_help_exits_zero():
+    assert main(["--help"], out=io.StringIO()) == 0
+
+
+def test_status_prints_daemon_response(monkeypatch):
+    from freetoken import control_cli
+
+    class _FakeClient:
+        def __init__(self, base_url):
+            self.base_url = base_url
+
+        def status(self):
+            return {"running": True, "pid": 42}
+
+    monkeypatch.setattr(control_cli, "DaemonClient", _FakeClient)
+    out = io.StringIO()
+    assert main(["status"], out=out) == 0
+    assert json.loads(out.getvalue()) == {"running": True, "pid": 42}
+
+
+def test_start_forwards_model_host_port(monkeypatch):
+    from freetoken import control_cli
+
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, base_url):
+            pass
+
+        def start(self, model, *, host, port):
+            captured["model"], captured["host"], captured["port"] = model, host, port
+            return {"running": True}
+
+    monkeypatch.setattr(control_cli, "DaemonClient", _FakeClient)
+    out = io.StringIO()
+    assert main(["start", "my-model", "--host", "0.0.0.0", "--port", "9999"], out=out) == 0
+    assert captured == {"model": "my-model", "host": "0.0.0.0", "port": 9999}
+
+
+def test_stop_calls_client_stop(monkeypatch):
+    from freetoken import control_cli
+
+    class _FakeClient:
+        def __init__(self, base_url):
+            pass
+
+        def stop(self):
+            return {"running": False}
+
+    monkeypatch.setattr(control_cli, "DaemonClient", _FakeClient)
+    out = io.StringIO()
+    assert main(["stop"], out=out) == 0
+    assert json.loads(out.getvalue()) == {"running": False}
+
+
+def test_unreachable_daemon_exits_one(monkeypatch, capsys):
+    from freetoken import control_cli
+
+    class _FakeClient:
+        def __init__(self, base_url):
+            pass
+
+        def status(self):
+            raise DaemonConnectionError("could not reach daemon at http://x")
+
+    monkeypatch.setattr(control_cli, "DaemonClient", _FakeClient)
+    assert main(["status"]) == 1
+    assert "could not reach daemon" in capsys.readouterr().err
+
+
+def test_missing_subcommand_exits_two():
+    assert main([]) == 2

--- a/tests/test_daemon_app.py
+++ b/tests/test_daemon_app.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from freetoken.daemon.app import create_app
+from freetoken.daemon.app import CSRF_HEADER_NAME, CSRF_HEADER_VALUE, create_app
+
+_CSRF_HEADERS = {CSRF_HEADER_NAME: CSRF_HEADER_VALUE}
 
 
 class _FakeServeManager:
@@ -46,7 +48,7 @@ def test_status_route_reflects_not_running():
 def test_start_route_builds_ft_serve_argv_and_reports_running():
     fake = _FakeServeManager()
     client = TestClient(create_app(fake))
-    resp = client.post("/start", json={"model": "tiny-model", "host": "127.0.0.1", "port": 9090})
+    resp = client.post("/start", json={"model": "tiny-model", "host": "127.0.0.1", "port": 9090}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200
     assert resp.json()["running"] is True
     assert "freetoken.cli" in fake.started_with
@@ -59,7 +61,7 @@ def test_start_route_builds_ft_serve_argv_and_reports_running():
 def test_start_route_passes_through_extra_args():
     fake = _FakeServeManager()
     client = TestClient(create_app(fake))
-    client.post("/start", json={"model": "m", "extra_args": ["--moe-backend", "cpu"]})
+    client.post("/start", json={"model": "m", "extra_args": ["--moe-backend", "cpu"]}, headers=_CSRF_HEADERS)
     assert fake.started_with[-2:] == ["--moe-backend", "cpu"]
 
 
@@ -67,7 +69,7 @@ def test_start_route_returns_409_when_already_running():
     fake = _FakeServeManager()
     fake._raise_on_start = RuntimeError("a child process is already running; stop it first")
     client = TestClient(create_app(fake))
-    resp = client.post("/start", json={"model": "m"})
+    resp = client.post("/start", json={"model": "m"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 409
 
 
@@ -75,10 +77,30 @@ def test_stop_route_stops_and_reports_not_running():
     fake = _FakeServeManager()
     fake._running = True
     client = TestClient(create_app(fake))
-    resp = client.post("/stop")
+    resp = client.post("/stop", headers=_CSRF_HEADERS)
     assert resp.status_code == 200
     assert fake.stopped is True
     assert resp.json()["running"] is False
+
+
+def test_start_route_rejects_request_without_csrf_header():
+    """A plain cross-origin HTML form (or a "simple" fetch) cannot set a
+    custom header without a CORS preflight this app never approves -- so a
+    request missing the header is rejected outright (PR-Agent review, PR #128)."""
+    fake = _FakeServeManager()
+    client = TestClient(create_app(fake))
+    resp = client.post("/start", json={"model": "m"})  # no CSRF header
+    assert resp.status_code == 403
+    assert fake.started_with is None
+
+
+def test_stop_route_rejects_request_without_csrf_header():
+    fake = _FakeServeManager()
+    fake._running = True
+    client = TestClient(create_app(fake))
+    resp = client.post("/stop")  # no CSRF header
+    assert resp.status_code == 403
+    assert fake.stopped is False
 
 
 def test_create_app_defaults_to_a_real_serve_manager():

--- a/tests/test_daemon_app.py
+++ b/tests/test_daemon_app.py
@@ -1,0 +1,88 @@
+"""Daemon control-plane app routing (issue `shell-daemon`, #27).
+
+Route wiring is tested against a fake ServeManager double (fast, no real
+subprocess) -- the real ServeManager lifecycle is covered separately in
+tests/test_daemon_serve_manager.py, and a real end-to-end spawn/stop through
+this app is covered in tests/test_daemon_client.py's live-daemon fixture.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from freetoken.daemon.app import create_app
+
+
+class _FakeServeManager:
+    def __init__(self) -> None:
+        self.started_with: list[str] | None = None
+        self.started_meta: dict | None = None
+        self.stopped = False
+        self._running = False
+        self._raise_on_start: Exception | None = None
+
+    def start(self, argv, *, meta=None) -> None:
+        if self._raise_on_start is not None:
+            raise self._raise_on_start
+        self.started_with = argv
+        self.started_meta = meta
+        self._running = True
+
+    def stop(self) -> None:
+        self.stopped = True
+        self._running = False
+
+    def status(self) -> dict:
+        return {"running": self._running, "pid": 1234 if self._running else None, "argv": [], "meta": {}, "uptime_s": 0.0 if self._running else None}
+
+
+def test_status_route_reflects_not_running():
+    fake = _FakeServeManager()
+    client = TestClient(create_app(fake))
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["running"] is False
+
+
+def test_start_route_builds_ft_serve_argv_and_reports_running():
+    fake = _FakeServeManager()
+    client = TestClient(create_app(fake))
+    resp = client.post("/start", json={"model": "tiny-model", "host": "127.0.0.1", "port": 9090})
+    assert resp.status_code == 200
+    assert resp.json()["running"] is True
+    assert "freetoken.cli" in fake.started_with
+    assert "serve" in fake.started_with
+    assert "tiny-model" in fake.started_with
+    assert "9090" in fake.started_with
+    assert fake.started_meta == {"model": "tiny-model", "host": "127.0.0.1", "port": 9090}
+
+
+def test_start_route_passes_through_extra_args():
+    fake = _FakeServeManager()
+    client = TestClient(create_app(fake))
+    client.post("/start", json={"model": "m", "extra_args": ["--moe-backend", "cpu"]})
+    assert fake.started_with[-2:] == ["--moe-backend", "cpu"]
+
+
+def test_start_route_returns_409_when_already_running():
+    fake = _FakeServeManager()
+    fake._raise_on_start = RuntimeError("a child process is already running; stop it first")
+    client = TestClient(create_app(fake))
+    resp = client.post("/start", json={"model": "m"})
+    assert resp.status_code == 409
+
+
+def test_stop_route_stops_and_reports_not_running():
+    fake = _FakeServeManager()
+    fake._running = True
+    client = TestClient(create_app(fake))
+    resp = client.post("/stop")
+    assert resp.status_code == 200
+    assert fake.stopped is True
+    assert resp.json()["running"] is False
+
+
+def test_create_app_defaults_to_a_real_serve_manager():
+    from freetoken.daemon.serve_manager import ServeManager
+
+    app = create_app()
+    assert isinstance(app.state.serve_manager, ServeManager)

--- a/tests/test_daemon_client.py
+++ b/tests/test_daemon_client.py
@@ -1,0 +1,93 @@
+"""DaemonClient + a real end-to-end daemon spawn/stop cycle (issue `shell-daemon`, #27).
+
+Stands up the real daemon control-plane app (the same object `ft daemon`
+runs) on a real loopback socket -- same pattern as
+tests/test_launch_cli_cpu.py's `live_server` fixture -- so DaemonClient's
+urllib HTTP layer is exercised end-to-end, not mocked. `start`/`stop` spawn
+a real (trivial, short-lived) child process through the real ServeManager,
+proving the whole "daemon starts/stops a child and exposes status" path
+without needing a real `ft serve` + XPU + checkpoint.
+"""
+from __future__ import annotations
+
+import socket
+import sys
+import threading
+import time
+from urllib.request import urlopen
+
+import pytest
+
+from freetoken.daemon.app import create_app
+from freetoken.daemon.client import DaemonClient, DaemonConnectionError
+from freetoken.daemon.serve_manager import ServeManager
+
+
+class _SleepServeManager(ServeManager):
+    """A ServeManager whose start() ignores the real `ft serve` argv the
+    daemon app builds and spawns a trivial sleep child instead -- the route
+    wiring under test is genuinely exercised (real HTTP request in, real
+    subprocess started/stopped), just not a real (XPU-needing) `ft serve`."""
+
+    def start(self, argv, *, meta=None) -> None:
+        del argv
+        super().start([sys.executable, "-c", "import time; time.sleep(30)"], meta=meta)
+
+
+@pytest.fixture
+def live_daemon():
+    import uvicorn
+
+    app = create_app(_SleepServeManager())
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    listener.close()
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(f"http://127.0.0.1:{port}/status", timeout=0.5) as resp:
+                if resp.status == 200:
+                    break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        raise RuntimeError("daemon did not come up for the client test")
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        app.state.serve_manager.stop()
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_status_before_start(live_daemon):
+    client = DaemonClient(live_daemon)
+    assert client.status()["running"] is False
+
+
+def test_start_then_status_then_stop(live_daemon):
+    client = DaemonClient(live_daemon)
+    started = client.start("tiny-test-model", port=9191)
+    assert started["running"] is True
+    assert isinstance(started["pid"], int)
+
+    status = client.status()
+    assert status["running"] is True
+    assert status["meta"]["model"] == "tiny-test-model"
+
+    stopped = client.stop()
+    assert stopped["running"] is False
+
+
+def test_connection_error_when_nothing_listening():
+    client = DaemonClient("http://127.0.0.1:1")  # port 1: nothing listens here
+    with pytest.raises(DaemonConnectionError):
+        client.status()

--- a/tests/test_daemon_main.py
+++ b/tests/test_daemon_main.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 
-from freetoken.daemon import DEFAULT_HOST, DEFAULT_PORT, main
+from freetoken.daemon import DEFAULT_HOST, DEFAULT_PORT, _is_loopback_host, main
 
 
 def test_help_exits_zero():
@@ -44,3 +44,30 @@ def test_custom_host_and_port_parsed(monkeypatch):
 def test_module_level_defaults():
     assert DEFAULT_HOST == "127.0.0.1"
     assert DEFAULT_PORT == 8500
+
+
+def test_is_loopback_host():
+    assert _is_loopback_host("127.0.0.1")
+    assert _is_loopback_host("::1")
+    assert _is_loopback_host("localhost")
+    assert not _is_loopback_host("0.0.0.0")
+    assert not _is_loopback_host("192.168.1.5")
+    assert not _is_loopback_host("example.com")
+
+
+def test_non_loopback_host_warns(monkeypatch, capsys):
+    import freetoken.daemon as daemon_mod
+
+    monkeypatch.setattr(daemon_mod, "create_app", lambda: object())
+    assert main(["--host", "0.0.0.0"]) == 0
+    err = capsys.readouterr().err
+    assert "not loopback" in err
+    assert "not real authentication" in err
+
+
+def test_loopback_host_does_not_warn(monkeypatch, capsys):
+    import freetoken.daemon as daemon_mod
+
+    monkeypatch.setattr(daemon_mod, "create_app", lambda: object())
+    assert main(["--host", "127.0.0.1"]) == 0
+    assert capsys.readouterr().err == ""

--- a/tests/test_daemon_main.py
+++ b/tests/test_daemon_main.py
@@ -1,0 +1,46 @@
+"""`ft daemon` entry point: arg parsing, help, and the PYTEST_CURRENT_TEST
+guard that keeps tests from binding a real port (issue `shell-daemon`, #27).
+
+PR-Agent review on PR #128 flagged that `ft ctl`/`ft shell` each had a
+covering test for their entry point but `ft daemon`'s did not.
+"""
+from __future__ import annotations
+
+import os
+
+from freetoken.daemon import DEFAULT_HOST, DEFAULT_PORT, main
+
+
+def test_help_exits_zero():
+    assert main(["--help"]) == 0
+
+
+def test_unknown_flag_exits_two():
+    assert main(["--not-a-flag"]) == 2
+
+
+def test_defaults_and_under_pytest_never_binds_a_port():
+    # PYTEST_CURRENT_TEST is already set by the pytest runner itself, so this
+    # exercises the exact guard main() uses in real test runs -- if it were
+    # ever removed, this call would hang trying to bind DEFAULT_PORT.
+    assert os.environ.get("PYTEST_CURRENT_TEST")
+    assert main([]) == 0
+
+
+def test_custom_host_and_port_parsed(monkeypatch):
+    captured = {}
+
+    def _fake_create_app():
+        captured["called"] = True
+        return object()
+
+    import freetoken.daemon as daemon_mod
+
+    monkeypatch.setattr(daemon_mod, "create_app", _fake_create_app)
+    assert main(["--host", "0.0.0.0", "--port", "9999"]) == 0
+    assert captured["called"] is True
+
+
+def test_module_level_defaults():
+    assert DEFAULT_HOST == "127.0.0.1"
+    assert DEFAULT_PORT == 8500

--- a/tests/test_daemon_serve_manager.py
+++ b/tests/test_daemon_serve_manager.py
@@ -1,0 +1,70 @@
+"""ServeManager: spawn/stop/status of one supervised child process
+(issue `shell-daemon`, #27).
+
+Uses trivial `python -c ...` children instead of a real `ft serve` (which
+needs an XPU + a real checkpoint) -- ServeManager is deliberately generic
+over the child argv for exactly this reason.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+import pytest
+
+from freetoken.daemon.serve_manager import ServeManager
+
+
+def _sleep_argv(seconds: float) -> list[str]:
+    return [sys.executable, "-c", f"import time; time.sleep({seconds})"]
+
+
+def test_status_when_nothing_started():
+    mgr = ServeManager()
+    status = mgr.status()
+    assert status == {"running": False, "pid": None, "argv": [], "meta": {}, "uptime_s": None}
+
+
+def test_start_reports_running_with_pid_and_meta():
+    mgr = ServeManager()
+    mgr.start(_sleep_argv(5), meta={"model": "tiny-test"})
+    try:
+        status = mgr.status()
+        assert status["running"] is True
+        assert isinstance(status["pid"], int)
+        assert status["meta"] == {"model": "tiny-test"}
+        assert status["uptime_s"] >= 0
+    finally:
+        mgr.stop()
+
+
+def test_stop_terminates_the_child_and_status_reports_not_running():
+    mgr = ServeManager()
+    mgr.start(_sleep_argv(30))
+    mgr.stop(timeout=5)
+    assert mgr.status()["running"] is False
+
+
+def test_stop_is_a_noop_when_nothing_running():
+    mgr = ServeManager()
+    mgr.stop()  # must not raise
+    assert mgr.status()["running"] is False
+
+
+def test_start_raises_if_already_running():
+    mgr = ServeManager()
+    mgr.start(_sleep_argv(5))
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            mgr.start(_sleep_argv(5))
+    finally:
+        mgr.stop()
+
+
+def test_status_reflects_a_child_that_exited_on_its_own():
+    mgr = ServeManager()
+    mgr.start([sys.executable, "-c", "pass"])  # exits almost immediately
+    deadline = time.monotonic() + 5.0
+    while mgr.status()["running"] and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert mgr.status()["running"] is False

--- a/tests/test_shell_tui.py
+++ b/tests/test_shell_tui.py
@@ -1,0 +1,135 @@
+"""Shell TUI: run_tui loop (scripted I/O) + ChatClient (real HTTP) (issue `shell-daemon`, #27)."""
+from __future__ import annotations
+
+import io
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from freetoken.shell import main as shell_main
+from freetoken.shell.tui import ChatClient, ChatClientError, run_tui
+
+
+def _scripted_input(lines: list[str]) -> callable:
+    it = iter(lines)
+
+    def _input(_prompt: str) -> str:
+        try:
+            return next(it)
+        except StopIteration:
+            raise EOFError from None
+
+    return _input
+
+
+class _StubClient:
+    def __init__(self, replies: list[str]) -> None:
+        self._replies = iter(replies)
+        self.sent: list[list[dict]] = []
+
+    def send(self, messages: list[dict]) -> str:
+        self.sent.append([dict(m) for m in messages])
+        return next(self._replies)
+
+
+def test_run_tui_echoes_replies_and_exits_on_slash_exit():
+    out = io.StringIO()
+    client = _StubClient(["hi there"])
+    code = run_tui("http://x", "m", client=client, input_fn=_scripted_input(["hello", "/exit"]), out=out)
+    assert code == 0
+    assert "hi there" in out.getvalue()
+    assert client.sent == [[{"role": "user", "content": "hello"}]]
+
+
+def test_run_tui_stops_on_eof_without_error():
+    out = io.StringIO()
+    client = _StubClient([])
+    code = run_tui("http://x", "m", client=client, input_fn=_scripted_input([]), out=out)
+    assert code == 0
+
+
+def test_run_tui_skips_blank_lines():
+    out = io.StringIO()
+    client = _StubClient(["ok"])
+    run_tui("http://x", "m", client=client, input_fn=_scripted_input(["", "  ", "hi", "/exit"]), out=out)
+    assert len(client.sent) == 1
+
+
+def test_run_tui_reports_client_error_and_keeps_going():
+    class _FailThenSucceed:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def send(self, messages):
+            self.calls += 1
+            if self.calls == 1:
+                raise ChatClientError("boom")
+            return "recovered"
+
+    out = io.StringIO()
+    run_tui("http://x", "m", client=_FailThenSucceed(), input_fn=_scripted_input(["a", "b", "/exit"]), out=out)
+    assert "error: boom" in out.getvalue()
+    assert "recovered" in out.getvalue()
+
+
+def test_shell_help_exits_zero():
+    assert shell_main(["--help"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# ChatClient against a real (stdlib-only) HTTP endpoint.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_openai_server():
+    """A minimal stdlib HTTP server standing in for `ft serve`'s
+    /v1/chat/completions -- proves ChatClient's real request/response wire
+    format against a real socket, without needing the full engine stack."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # noqa: D401 -- silence test log spam
+            pass
+
+        def do_POST(self):
+            length = int(self.headers["Content-Length"])
+            body = json.loads(self.rfile.read(length))
+            if body.get("model") == "error-model":
+                self.send_response(500)
+                self.end_headers()
+                self.wfile.write(b"boom")
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            reply = f"echo: {body['messages'][-1]['content']}"
+            self.wfile.write(json.dumps({"choices": [{"message": {"content": reply}}]}).encode())
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_chat_client_sends_and_parses_a_real_response(fake_openai_server):
+    client = ChatClient(fake_openai_server, "m")
+    reply = client.send([{"role": "user", "content": "hello"}])
+    assert reply == "echo: hello"
+
+
+def test_chat_client_raises_on_http_error(fake_openai_server):
+    client = ChatClient(fake_openai_server, "error-model")
+    with pytest.raises(ChatClientError, match="server returned 500"):
+        client.send([{"role": "user", "content": "hi"}])
+
+
+def test_chat_client_raises_on_connection_error():
+    client = ChatClient("http://127.0.0.1:1", "m")  # nothing listens on port 1
+    with pytest.raises(ChatClientError, match="could not reach server"):
+        client.send([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 89** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 31d4ceb](https://github.com/Performant-Labs/FreeToken-Intel/commit/31d4cebcb9d01a9f226a61a2e72e694be24574fd) · run [#33698868476](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33698868476) · 2026-09-02 18:29 MDT / 2026-09-03 00:29 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Implements shell-daemon (#27) end to end at a scoped-down but real, tested surface:

- `daemon/serve_manager.py`: `ServeManager` -- start()/stop()/status() for one supervised child process via plain `subprocess` (torch-free); generic over the child argv rather than hardcoded to `ft serve`'s command line, so it's unit-testable with a trivial subprocess instead of a real `ft serve` (which needs an XPU + a real checkpoint)
- `daemon/app.py`: `create_app()` -- a tiny FastAPI control plane (`/status` GET, `/start` POST, `/stop` POST) wrapping one `ServeManager`; `/start` builds the real `[sys.executable, -m, freetoken.cli, serve, <model>, ...]` argv
- `daemon/client.py`: `DaemonClient` -- plain `urllib` HTTP client (no new dependency for a local control socket), used by `ft ctl` and by anything else that wants to drive the daemon without an XPU in its own process
- `daemon/__init__.py`: `ft daemon` entry point -- serves `create_app()` with uvicorn (mirrors `server/api_server.py`'s `PYTEST_CURRENT_TEST` guard so tests never bind a real port)
- `control_cli.py`: `ft ctl status|start|stop [--daemon-url ...]`
- `shell/tui.py` + `shell/__init__.py`: `ft shell` -- a line-based REPL chat loop against a running ft-serve's `/v1/chat/completions` via `ChatClient` (plain urllib, no torch/XPU import anywhere in this path -- the "TUI attaches to a running server without XPU in the client process" accept criterion). Scoped down from a full-screen curses/textual TUI to a REPL: real and useful, testable with scripted input/output instead of a real terminal; a richer UI is separable follow-up work on the same `ChatClient`.

Every module on these CLI paths defers its own heavy imports (uvicorn inside `main()`, the real ft-serve argv only built at `/start` time) so `ft ctl --help` / `ft shell --help` / `ft daemon --help` all stay torch-free -- fixed a real regression of exactly this kind on #127 last PR, so this one was checked in **both** venvs, not just the XPU one.

## Test plan
- [x] `tests/test_daemon_serve_manager.py` (6): real subprocess start/stop/status lifecycle, using trivial `python -c ...` children
- [x] `tests/test_daemon_app.py` (6): route wiring against a fake `ServeManager` double (fast, no real subprocess)
- [x] `tests/test_daemon_client.py` (3): a real end-to-end daemon on a real loopback socket (same live-server pattern as `test_launch_cli_cpu.py`) -- proves `DaemonClient`'s urllib layer and the whole start/status/stop path for real, not mocked
- [x] `tests/test_control_cli.py` (6): `ft ctl` subcommand wiring (mocked `DaemonClient`)
- [x] `tests/test_shell_tui.py` (8): the REPL loop with scripted I/O + stubs, plus `ChatClient` against a real stdlib HTTP server (proves the wire format) and its HTTP-error/connection-error paths
- [x] `pytest tests/ -m "not xpu"`: 288 passed, same 11 pre-existing unrelated failures
- [x] `.venv` (torch-free, matches CI's CPU lane): 190 passed, 35 skipped, 0 failures -- `ft ctl --help` / `ft shell --help` / `ft daemon --help` all verified directly

**Not done, explicitly scoped out:** a full-screen curses/textual TUI (ships a REPL instead); streaming responses in the TUI (non-streaming `/v1/chat/completions` only); daemon auto-restart-on-crash policy; TLS/auth on the daemon control plane (loopback-only default, same trust model as the model server itself). Real, separable follow-up work on #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add `ft daemon` control plane:
  - `ServeManager` supervises child subprocess safely.
  - FastAPI routes `/start`, `/stop`, `/status`.
  - CSRF header and threading lock guard.

- Add `ft ctl` CLI:
  - Status, start, stop commands via `DaemonClient`.
  - `--daemon-url` accepted before or after subcommand.

- Add `ft shell` REPL:
  - `ChatClient` talks to `/v1/chat/completions`.
  - No torch import on client path.

- Add comprehensive tests:
  - Unit tests for daemon, client, CLI, shell.
  - Live loopback daemon end-to-end test.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ft ctl CLI"] --> B["DaemonClient"]
  B --> C["FastAPI daemon app"]
  C --> D["ServeManager"]
  D --> E["subprocess ft serve"]
  F["ft shell TUI"] --> G["ChatClient"]
  G --> H["/v1/chat/completions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>control_cli.py</strong><dd><code>Implement ft ctl status/start/stop CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-77eebb188320a1a77f707cb937a723a169d2d934d160fa74126709f41bfbee8c">+82/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Add ft daemon uvicorn entry point</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-e95f087f7e823405cd85297f2679f01a1f034ad0ca474880f7a4946f2604feb6">+76/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.py</strong><dd><code>Create FastAPI control plane with CSRF guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-26f3014d3c37e435456f9af87cacaff84585f43764d1b868aa2aad893eb26c94">+84/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client.py</strong><dd><code>Add urllib DaemonClient with CSRF header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-8bfde3d562a8b22a91508a846b28c0e337250d6d6d47ac966cadd78ed80a963e">+49/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serve_manager.py</strong><dd><code>Implement ServeManager subprocess supervision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-7f038efb3b55d00b85a8ad07f69f2ea96c58dd74b5ddbd30a34c8fd2451cc0b3">+76/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Add ft shell argument parsing entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-928850581c4e98a8949dab56d71b8d2abac1d1ccc2c791cbb2ad426229ccac46">+19/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tui.py</strong><dd><code>Implement REPL chat TUI and ChatClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-fcab54c304d5c80e9eafd122f8ced7e0a8f96189fa575f044a6aea60445084b0">+87/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_control_cli.py</strong><dd><code>Test ft ctl CLI paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-5bec06911158895eaa98310a9fc18a13af1b349620799c806e2aa835b2d45eb7">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_daemon_app.py</strong><dd><code>Test daemon routes and CSRF rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-4c92187cb5867090dca3b6fd951728f6f9d8ebeaba870c7f1f42b91e9aa5b10f">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_daemon_client.py</strong><dd><code>Live daemon end-to-end client tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-3393db01209d3634e191d7dc8384d657ecc4746eef646a2b1f43030b8dc32aef">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_daemon_main.py</strong><dd><code>Test ft daemon entry point and guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-cb401affc1c9bbfef7c26e84318c2f88675e7118d7d5d540d9ca643b5a6a33e6">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_daemon_serve_manager.py</strong><dd><code>Test ServeManager subprocess lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-bdef0f7c758a580cdcbffa818a4420fa6dd8f59da1cb439599edd852c5a6716f">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_shell_tui.py</strong><dd><code>Test REPL loop and ChatClient HTTP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/128/files#diff-b17570904133182142f60f491302c5150db3d01cd0f54a512cd7541ee3289363">+135/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___