### PR TITLE
feat(kernel): MXFP4 dequantize/quantize primitives (issue #10)

### DIFF
--- a/python/freetoken/kernel/triton/mxfp4_linear.py
+++ b/python/freetoken/kernel/triton/mxfp4_linear.py
@@ -1,0 +1,130 @@
+"""OCP MXFP4 (E2M1, 32-element block, E8M0 shared exponent) weights:
+quantize / dequantize (issue `quant-xpu`, #10 -- MXFP4, the other named
+dtype alongside block-FP8, #125).
+
+Upstream NVIDIA path: python/freetoken/moe/fused_mxfp4.py (``dequant_mxfp4_blocks``)
+                       python/freetoken/kernel/triton/mxfp4_moe.py (the real Triton
+                       GEMV/GEMM kernels, native fp4 tensor-core compute)
+
+Same scoping decision as ``fp8_block_linear.py``: this ports upstream's own
+plain-torch ``dequant_mxfp4_blocks`` reference helper faithfully (the format
+itself is a public spec -- OCP Microscaling, used by real GPT-OSS MXFP4
+checkpoints -- not proprietary, so porting it is a direct, low-risk win),
+adds the missing inverse (``quantize_mxfp4_blocks``, upstream has none --
+it only ever *reads* real MXFP4 checkpoints) so this is round-trip
+testable without a real MXFP4 checkpoint on hand, and a dequant-on-forward
+``mxfp4_linear`` wrapper. The real Triton split-K GEMV / grouped-GEMM
+kernels (native 4-bit tensor-core compute, GPT-OSS's actual decode/prefill
+path) are NOT ported -- unverified whether Intel's Triton-XPU backend
+supports the same bit-manipulation primitives (``exp2``, int8 packing)
+those kernels lean on, and there is no local MXFP4 checkpoint to validate
+a full loader-integration + real-model round trip against.
+
+Format: 32 fp4 (E2M1) elements per block, packed 2-per-byte (16 bytes/block,
+low nibble = even element, high nibble = odd element -- matches upstream's
+``torch.stack((blocks & 0x0F, blocks >> 4), dim=-1)`` unpack order) plus one
+shared ``uint8`` E8M0 exponent per block: ``scale = 2 ** (e8m0_byte - 127)``
+(IEEE-754 float32's own bias -- upstream builds the scale by bit-casting the
+exponent straight into a float32's exponent field, which is exactly this).
+E2M1 has no subnormal *flush*: exponent-bits 00 is itself the subnormal case
+(0.0 / 0.5), so the 8 non-negative magnitudes are
+``[0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]`` and their negatives -- a 16-entry
+LUT indexed by the raw 4-bit code (sign is the MSB).
+"""
+from __future__ import annotations
+
+import torch
+
+_LUT = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+    dtype=torch.float32,
+)
+_MAX_MAGNITUDE = 6.0
+_BLOCK = 32
+
+
+def dequantize_mxfp4_blocks(
+    blocks: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Reconstruct a dense ``[..., K]`` tensor (``K = blocks.shape[-1] * 32``)
+    from MXFP4 blocks + E8M0 scales. ``blocks`` is ``[..., n_blocks, 16]``
+    ``uint8`` (16 packed bytes = 32 fp4 elements per block); ``scales`` is
+    ``[..., n_blocks]`` ``uint8``, one shared exponent per block.
+
+    Ported verbatim from upstream's ``freetoken.moe.fused_mxfp4
+    .dequant_mxfp4_blocks`` (the plain-torch reference path, not the Triton
+    kernel) -- the format is a public spec (OCP Microscaling), not
+    proprietary.
+    """
+    if blocks.dtype != torch.uint8:
+        raise TypeError(f"MXFP4 blocks must be uint8, got {blocks.dtype}")
+    if scales.dtype != torch.uint8:
+        raise TypeError(f"MXFP4 scales must be uint8, got {scales.dtype}")
+    if blocks.shape[-1] != 16:
+        raise ValueError(f"MXFP4 block pack dimension must be 16 bytes, got {blocks.shape[-1]}")
+    if blocks.shape[:-1] != scales.shape:
+        raise ValueError(f"MXFP4 blocks/scales shape mismatch: {tuple(blocks.shape[:-1])} vs {tuple(scales.shape)}")
+
+    nibbles = torch.stack((blocks & 0x0F, blocks >> 4), dim=-1).reshape(*blocks.shape[:-1], 32)
+    lut = _LUT.to(blocks.device)
+    unpacked = lut[nibbles.long()]
+    scale = torch.exp2(scales.float() - 127).unsqueeze(-1)
+    dequantized = unpacked * scale
+    return dequantized.reshape(*blocks.shape[:-2], blocks.shape[-2] * 32).to(out_dtype)
+
+
+def quantize_mxfp4_blocks(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a dense ``[..., K]`` tensor (``K`` a multiple of 32) to MXFP4
+    blocks + E8M0 scales. The inverse of :func:`dequantize_mxfp4_blocks` --
+    upstream has no such function (it only ever reads an already-quantized
+    real checkpoint); this exists so the format is round-trip testable
+    without one, and for any future ``ft checkpoint`` conversion tool that
+    quantizes a bf16 checkpoint down to MXFP4 rather than only reading one.
+
+    Per-block scale is the smallest power-of-two exponent that keeps the
+    block's largest-magnitude element within E2M1's representable range
+    (``|x| <= 6.0``); each scaled element is then quantized to its nearest
+    of the 16 LUT codes (round-to-nearest, not round-to-even).
+    """
+    if weight.shape[-1] % _BLOCK != 0:
+        raise ValueError(f"MXFP4 quantization needs K a multiple of {_BLOCK}, got {weight.shape[-1]}")
+    w = weight.to(torch.float32)
+    blocks_f = w.reshape(*w.shape[:-1], w.shape[-1] // _BLOCK, _BLOCK)
+    amax = blocks_f.abs().amax(dim=-1).clamp_min(1e-12)
+    # Smallest scale s = 2**e such that amax / s <= _MAX_MAGNITUDE.
+    exponent = torch.ceil(torch.log2(amax / _MAX_MAGNITUDE))
+    exponent_byte = exponent.add(127).round().clamp(0, 254).to(torch.uint8)
+    scale = torch.exp2(exponent_byte.float() - 127).unsqueeze(-1)
+    scaled = blocks_f / scale
+
+    lut = _LUT.to(weight.device)
+    # Nearest-LUT-code search: [..., n_blocks, 32, 1] vs [16] -> argmin over the last dim.
+    diffs = (scaled.unsqueeze(-1) - lut).abs()
+    nibbles = diffs.argmin(dim=-1).to(torch.uint8)  # [..., n_blocks, 32], values in [0, 16)
+
+    lo = nibbles[..., 0::2]
+    hi = nibbles[..., 1::2]
+    blocks_u8 = (lo | (hi << 4)).to(torch.uint8)  # [..., n_blocks, 16]
+    return blocks_u8, exponent_byte
+
+
+def mxfp4_linear(
+    x: torch.Tensor,
+    weight_blocks: torch.Tensor,
+    weight_scales: torch.Tensor,
+    *,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x @ dequantize_mxfp4_blocks(weight_blocks, weight_scales).T (+ bias)``.
+
+    Dequant-on-forward drop-in for a quantized ``nn.Linear``-shaped weight
+    (``[out_features, in_features]``). Like ``fp8_block_linear``, a caller
+    driving this repeatedly should dequantize once at load time instead
+    (via :func:`dequantize_mxfp4_blocks` directly) and cache the result --
+    this per-call wrapper pays the dequant cost every call.
+    """
+    w = dequantize_mxfp4_blocks(weight_blocks, weight_scales, out_dtype=x.dtype)
+    return torch.nn.functional.linear(x, w, bias)

--- a/tests/test_mxfp4_quant.py
+++ b/tests/test_mxfp4_quant.py
@@ -1,0 +1,115 @@
+"""Correctness tests for MXFP4 quantize/dequantize (issue quant-xpu, #10).
+
+Pure torch, no XPU dependency, CPU-testable -- same pattern as
+test_fp8_block_quant.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.mxfp4_linear import (
+    dequantize_mxfp4_blocks,
+    mxfp4_linear,
+    quantize_mxfp4_blocks,
+)
+
+
+def _relative_error(out: torch.Tensor, ref: torch.Tensor) -> float:
+    return ((out - ref).norm() / ref.norm().clamp_min(1e-12)).item()
+
+
+def test_dequantize_matches_upstreams_known_encoding():
+    """Hand-built blocks/scales, independent of quantize_mxfp4_blocks, so this
+    checks dequantize_mxfp4_blocks's bit layout against the spec directly
+    (not just self-consistency with our own quantizer)."""
+    # Byte 0x10 = nibbles (0, 1) -> LUT[0]=0.0, LUT[1]=0.5. Byte 0x32 = nibbles
+    # (2, 3) -> LUT[2]=1.0, LUT[3]=1.5. Remaining 14 bytes all zero -> LUT[0].
+    block = torch.zeros(16, dtype=torch.uint8)
+    block[0] = 0x10  # low nibble 0 -> 0.0, high nibble 1 -> 0.5
+    block[1] = 0x32  # low nibble 2 -> 1.0, high nibble 3 -> 1.5
+    scale = torch.tensor(127, dtype=torch.uint8)  # 2**(127-127) == 1.0
+
+    out = dequantize_mxfp4_blocks(block.unsqueeze(0), scale.unsqueeze(0), out_dtype=torch.float32)
+    expected = torch.zeros(32)
+    expected[0], expected[1], expected[2], expected[3] = 0.0, 0.5, 1.0, 1.5
+    torch.testing.assert_close(out.squeeze(0), expected)
+
+
+def test_scale_applies_as_power_of_two():
+    block = torch.zeros(16, dtype=torch.uint8)
+    block[0] = 0x02  # low nibble 2 -> LUT[2] = 1.0
+    scale = torch.tensor(128, dtype=torch.uint8)  # 2**(128-127) == 2.0
+
+    out = dequantize_mxfp4_blocks(block.unsqueeze(0), scale.unsqueeze(0), out_dtype=torch.float32)
+    assert out[0].item() == pytest.approx(2.0)
+
+
+def test_dequantize_rejects_wrong_block_pack_dim():
+    with pytest.raises(ValueError, match="16 bytes"):
+        dequantize_mxfp4_blocks(
+            torch.zeros(1, 15, dtype=torch.uint8), torch.zeros(1, dtype=torch.uint8)
+        )
+
+
+def test_dequantize_rejects_non_uint8():
+    with pytest.raises(TypeError, match="uint8"):
+        dequantize_mxfp4_blocks(torch.zeros(1, 16, dtype=torch.int32), torch.zeros(1, dtype=torch.uint8))
+
+
+def test_dequantize_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="mismatch"):
+        dequantize_mxfp4_blocks(torch.zeros(2, 16, dtype=torch.uint8), torch.zeros(3, dtype=torch.uint8))
+
+
+def test_quantize_round_trip_within_mxfp4_precision():
+    torch.manual_seed(0)
+    w = torch.randn(64, 64) * 0.5  # K=64 -> 2 blocks of 32 per row
+    blocks, scales = quantize_mxfp4_blocks(w)
+    assert blocks.dtype == torch.uint8
+    assert blocks.shape == (64, 2, 16)
+    assert scales.shape == (64, 2)
+
+    back = dequantize_mxfp4_blocks(blocks, scales, out_dtype=torch.float32)
+    err = _relative_error(back, w)
+    # 4-bit (2-mantissa-bit) precision is much coarser than fp8 -- a generous
+    # but real whole-tensor bound, not per-element.
+    assert err < 0.2, f"MXFP4 round-trip relative L2 error too large: {err:.4f}"
+
+
+def test_quantize_rejects_k_not_a_multiple_of_32():
+    with pytest.raises(ValueError, match="multiple of 32"):
+        quantize_mxfp4_blocks(torch.randn(4, 33))
+
+
+def test_quantize_handles_an_all_zero_block():
+    w = torch.zeros(1, 32)
+    blocks, scales = quantize_mxfp4_blocks(w)
+    back = dequantize_mxfp4_blocks(blocks, scales, out_dtype=torch.float32)
+    torch.testing.assert_close(back, w)
+
+
+def test_mxfp4_linear_matches_fp32_reference_matmul():
+    torch.manual_seed(1)
+    x = torch.randn(4, 64)
+    w = torch.randn(16, 64) * 0.5  # [out_features, in_features], K=64
+    blocks, scales = quantize_mxfp4_blocks(w)
+
+    out = mxfp4_linear(x, blocks, scales)
+    ref = torch.nn.functional.linear(x, w)
+    err = _relative_error(out, ref)
+    assert err < 0.2, f"MXFP4-quantized matmul relative L2 error too large: {err:.4f}"
+
+
+def test_mxfp4_linear_with_bias():
+    torch.manual_seed(2)
+    x = torch.randn(2, 32)
+    w = torch.randn(8, 32) * 0.5
+    bias = torch.randn(8)
+    blocks, scales = quantize_mxfp4_blocks(w)
+
+    out = mxfp4_linear(x, blocks, scales, bias=bias)
+    ref = torch.nn.functional.linear(x, w, bias)
+    err = _relative_error(out - bias, ref - bias)
+    assert err < 0.2, f"MXFP4-quantized matmul (with bias) relative L2 error too large: {err:.4f}"


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 96** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 23901fe](https://github.com/Performant-Labs/FreeToken-Intel/commit/23901fe819bedf751a00e06219df776e0b5a532d) · run [#33700135493](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33700135493) · 2026-09-02 18:39 MDT / 2026-09-03 00:39 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Continues quant-xpu (#10) with its other named dtype (MXFP4, alongside block-FP8 shipped in #125): OCP Microscaling fp4 -- 32-element blocks of E2M1 (2-bit exponent, 1-bit mantissa) packed 2-per-byte, one shared uint8 E8M0 exponent per block (`scale = 2**(byte-127)`, IEEE-754's own bias).

`dequantize_mxfp4_blocks` is ported verbatim from upstream's own `freetoken.moe.fused_mxfp4.dequant_mxfp4_blocks` plain-torch reference path (not the Triton kernel) -- the format is a public spec used by real GPT-OSS MXFP4 checkpoints, not proprietary, so this is a direct, low-risk port, cross-checked against the same bit layout in upstream's `mxfp4_moe.py` Triton kernel's `_dequant_fp4_lut`. `quantize_mxfp4_blocks` is new (upstream has none -- it only ever reads an already-quantized real checkpoint): the inverse, so the format is round-trip testable without one on hand, and useful for any future checkpoint-quantization tool. `mxfp4_linear` is a dequant-on-forward `nn.Linear` drop-in, mirroring `fp8_block_linear`'s shape.

**Not ported:** the real Triton split-K GEMV / grouped-GEMM kernels (native 4-bit tensor-core compute) -- unverified whether Intel's Triton-XPU backend supports the same bit-manipulation primitives those lean on, and no local MXFP4 checkpoint to validate a full loader-integration + real-model round trip against. Same scoping call as #125's FP8 work.

## Test plan
- [x] 10 new tests (`tests/test_mxfp4_quant.py`): a hand-built-bytes test that checks the bit layout directly (not just self-consistency with our own quantizer), scale-as-power-of-two, input validation (dtype/shape), an all-zero block, round-trip + matmul relative-L2-error bounds (~11-12% measured -- 4-bit precision is real and much coarser than fp8's ~2-3%, not a bug)
- [x] Verified directly on real XPU hardware (256x256 weight: ~11.5% round-trip / ~11.7% matmul relative error, matching CPU), 0 new exec-queue resets
- [x] `pytest tests/ -m "not xpu"`: 310 passed (+10 net), same 11 pre-existing unrelated failures
- [x] `.venv` (torch-free): 202 passed, 36 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add MXFP4 quantize/dequantize primitives for E2M1/E8M0 blocks

- Add dequant-on-forward `mxfp4_linear` wrapper

- Add CPU tests for bit layout, validation, round-trip


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["quantize_mxfp4_blocks"] -- "dense weight" --> B["MXFP4 blocks + E8M0 scales"]
  B -- "packed bytes" --> C["dequantize_mxfp4_blocks"]
  C -- "dense tensor" --> D["mxfp4_linear wrapper"]
  D -- "nn.functional.linear" --> E["output"]
  F["tests/test_mxfp4_quant.py"] -- "validates" --> A
  F -- "validates" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mxfp4_linear.py</strong><dd><code>Add MXFP4 quantize/dequantize primitives and linear wrapper</code></dd></summary>
<hr>

python/freetoken/kernel/triton/mxfp4_linear.py

<ul><li>Add <code>dequantize_mxfp4_blocks</code> ported from upstream reference<br> <li> Add <code>quantize_mxfp4_blocks</code> inverse using nearest LUT and power-of-two <br>scales<br> <li> Add <code>mxfp4_linear</code> dequant-on-forward <code>nn.Linear</code> drop-in<br> <li> Validate dtypes, pack dimension, and shape consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/129/files#diff-884c0b4156e254dbcfa55f3b5b25543a176e362a6f2e43fd41b651947f7798cb">+130/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mxfp4_quant.py</strong><dd><code>Add CPU tests for MXFP4 primitives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_mxfp4_quant.py

<ul><li>Add hand-built bytes test for independent bit-layout verification<br> <li> Test scale power-of-two, dtype/shape validation errors<br> <li> Verify round-trip and matmul relative L2 error bounds<br> <li> Cover all-zero block and bias path</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/129/files#diff-7177b62ff461d5bad229d53038b6c816db5f70bb8d62cafb523be14f5ea26758">+115/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___