### PR TITLE
feat(kernel): per-channel INT8 weight quantization primitives (issue #10)

### DIFF
--- a/python/freetoken/kernel/triton/int8_linear.py
+++ b/python/freetoken/kernel/triton/int8_linear.py
@@ -1,0 +1,79 @@
+"""Per-channel symmetric INT8 weight quantization (issue `quant-xpu`, #10 --
+INT8, the other named dtype alongside block-FP8 #125 and MXFP4 #129).
+
+Standard weight-only INT8 quantization (the scheme behind e.g. LLM.int8's
+weight path, AWQ/GPTQ's simpler symmetric variant): one scale per output
+channel (row), computed from that row's max absolute value --
+
+    weight_int8[i, j] = round(weight[i, j] / scale[i]).clamp(-127, 127)
+    scale[i]          = amax(weight[i, :]) / 127
+    weight_bf16[i, j] = weight_int8[i, j] * scale[i]
+
+Per-channel (not a single tensor-wide scale) because weight rows in a real
+checkpoint have wildly different magnitudes -- a single global scale would
+waste most of int8's 256 levels on the largest row and flatten every
+smaller one to near-zero.
+
+This is deliberately NOT GGUF's INT8/INT4 quant family (``Q8_0``, ``Q4_0``,
+the ``Q4_K``/``Q5_K`` super-block k-quants): those are a different,
+considerably larger format zoo (this port has no GGUF reader/dequant at
+all yet -- ``models/gguf/`` is an empty stub) and a separate scope from
+this plain, checkpoint-format-agnostic primitive. INT4 is also not
+included here: a *useful* INT4 needs a block/group scheme (a single
+per-channel INT4 scale is far too lossy at only 16 levels spanning a
+whole row) which overlaps enough with MXFP4's block design (#129) that it
+deserves its own follow-up rather than a rushed variant here.
+"""
+from __future__ import annotations
+
+import torch
+
+_INT8_MAX = 127
+
+
+def quantize_int8_channel(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a dense ``[N, K]`` (or higher-rank, last dim = K) tensor to
+    per-row (dim -2, i.e. per output channel for an ``[out, in]`` weight)
+    symmetric INT8. Returns ``(weight_int8, scale)`` where ``scale`` has
+    shape ``weight.shape[:-1]`` (one scale per row)."""
+    w = weight.to(torch.float32)
+    amax = w.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12)
+    scale = amax / _INT8_MAX
+    quantized = (w / scale).round().clamp(-_INT8_MAX, _INT8_MAX).to(torch.int8)
+    return quantized, scale.squeeze(-1)
+
+
+def dequantize_int8_channel(
+    weight_int8: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Inverse of :func:`quantize_int8_channel`. ``scale`` is
+    ``weight_int8.shape[:-1]`` (one value per row)."""
+    if weight_int8.dtype != torch.int8:
+        raise TypeError(f"weight_int8 must be int8, got {weight_int8.dtype}")
+    if tuple(scale.shape) != tuple(weight_int8.shape[:-1]):
+        raise ValueError(
+            f"scale shape {tuple(scale.shape)} does not match weight_int8's row shape {tuple(weight_int8.shape[:-1])}"
+        )
+    return (weight_int8.to(torch.float32) * scale.unsqueeze(-1).to(torch.float32)).to(out_dtype)
+
+
+def int8_linear(
+    x: torch.Tensor,
+    weight_int8: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x @ dequantize_int8_channel(weight_int8, scale).T (+ bias)``.
+
+    Dequant-on-forward drop-in for a quantized ``nn.Linear``-shaped weight
+    (``[out_features, in_features]``), matching ``fp8_block_linear`` /
+    ``mxfp4_linear``'s shape. A caller driving this repeatedly should
+    dequantize once at load time instead (via
+    :func:`dequantize_int8_channel` directly) and cache the result.
+    """
+    w = dequantize_int8_channel(weight_int8, scale, out_dtype=x.dtype)
+    return torch.nn.functional.linear(x, w, bias)

--- a/tests/test_int8_quant.py
+++ b/tests/test_int8_quant.py
@@ -1,0 +1,98 @@
+"""Correctness tests for per-channel symmetric INT8 quantization (issue
+quant-xpu, #10). Pure torch, no XPU dependency, CPU-testable -- same
+pattern as test_fp8_block_quant.py / test_mxfp4_quant.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.int8_linear import (
+    dequantize_int8_channel,
+    int8_linear,
+    quantize_int8_channel,
+)
+
+
+def _relative_error(out: torch.Tensor, ref: torch.Tensor) -> float:
+    return ((out - ref).norm() / ref.norm().clamp_min(1e-12)).item()
+
+
+def test_round_trip_matches_original_within_int8_precision():
+    torch.manual_seed(0)
+    w = torch.randn(64, 128) * 0.5
+    q, scale = quantize_int8_channel(w)
+    assert q.dtype == torch.int8
+    assert scale.shape == (64,)
+
+    back = dequantize_int8_channel(q, scale, out_dtype=torch.float32)
+    err = _relative_error(back, w)
+    assert err < 0.02, f"int8 round-trip relative L2 error too large: {err:.4f}"
+
+
+def test_scale_is_per_row_not_global():
+    """A row with a much larger magnitude must not blow out a smaller row's
+    precision -- the whole point of per-channel over a single global scale."""
+    w = torch.zeros(2, 128)
+    w[0] = torch.full((128,), 100.0)  # huge row
+    w[1] = torch.full((128,), 0.01)  # tiny row
+    q, scale = quantize_int8_channel(w)
+    back = dequantize_int8_channel(q, scale, out_dtype=torch.float32)
+    # The tiny row must still be represented (not flattened to all-zero by a
+    # global scale sized for the huge row).
+    assert back[1].abs().max().item() > 0.0
+    torch.testing.assert_close(back[0], w[0], rtol=0.02, atol=0.02)
+    torch.testing.assert_close(back[1], w[1], rtol=0.02, atol=1e-4)
+
+
+def test_dequantize_rejects_non_int8():
+    with pytest.raises(TypeError, match="int8"):
+        dequantize_int8_channel(torch.zeros(2, 4, dtype=torch.int32), torch.ones(2))
+
+
+def test_dequantize_rejects_mismatched_scale_shape():
+    q = torch.zeros(4, 8, dtype=torch.int8)
+    bad_scale = torch.ones(3)
+    with pytest.raises(ValueError, match="does not match"):
+        dequantize_int8_channel(q, bad_scale)
+
+
+def test_all_zero_row_round_trips_to_zero():
+    w = torch.zeros(1, 16)
+    q, scale = quantize_int8_channel(w)
+    back = dequantize_int8_channel(q, scale, out_dtype=torch.float32)
+    torch.testing.assert_close(back, w)
+
+
+def test_quantized_values_stay_within_int8_range():
+    torch.manual_seed(1)
+    w = torch.randn(8, 32) * 10.0
+    q, _ = quantize_int8_channel(w)
+    assert q.min().item() >= -127
+    assert q.max().item() <= 127
+
+
+def test_int8_linear_matches_fp32_reference_matmul():
+    torch.manual_seed(2)
+    x = torch.randn(4, 128)
+    w = torch.randn(32, 128) * 0.5
+    q, scale = quantize_int8_channel(w)
+
+    out = int8_linear(x, q, scale)
+    ref = torch.nn.functional.linear(x, w)
+    err = _relative_error(out, ref)
+    assert err < 0.02, f"int8-quantized matmul relative L2 error too large: {err:.4f}"
+
+
+def test_int8_linear_with_bias():
+    torch.manual_seed(3)
+    x = torch.randn(2, 64)
+    w = torch.randn(8, 64) * 0.5
+    bias = torch.randn(8)
+    q, scale = quantize_int8_channel(w)
+
+    out = int8_linear(x, q, scale, bias=bias)
+    ref = torch.nn.functional.linear(x, w, bias)
+    err = _relative_error(out - bias, ref - bias)
+    assert err < 0.02, f"int8-quantized matmul (with bias) relative L2 error too large: {err:.4f}"


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 96** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit d8fac8a](https://github.com/Performant-Labs/FreeToken-Intel/commit/d8fac8a446879e6748d0997e6ae4df562f44c17f) · run [#33700629972](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33700629972) · 2026-09-02 18:45 MDT / 2026-09-03 00:45 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Continues quant-xpu (#10): standard weight-only symmetric INT8 (the scheme behind e.g. LLM.int8's weight path / AWQ-GPTQ's simpler symmetric variant) -- one scale per output channel (row), sized from that row's max absolute value:

```
weight_int8[i, j] = round(weight[i, j] / scale[i]).clamp(-127, 127)
scale[i]          = amax(weight[i, :]) / 127
```

Per-channel rather than one global scale: a real checkpoint's weight rows span wildly different magnitudes, so a single tensor-wide scale would be sized for the largest row and flatten every smaller row toward zero (see the new `test_scale_is_per_row_not_global` regression test, which fails outright against a naive single-scale implementation).

**Deliberately NOT** GGUF's INT8/INT4 quant family (`Q8_0`, `Q4_0`, the `Q4_K`/`Q5_K` super-block k-quants) -- a considerably larger, different format zoo this port has no reader/dequant for at all yet (`models/gguf/` is an empty stub). INT4 is also not included here: a useful INT4 needs a block/group scheme (a bare per-channel INT4 scale is far too lossy at only 16 levels spanning a whole row), which overlaps enough with MXFP4's block design (#129) to deserve its own follow-up rather than a rushed variant bolted onto this PR.

## Test plan
- [x] 8 new tests (`tests/test_int8_quant.py`): round-trip + matmul relative-L2-error bounds (~0.7-2% measured, matching int8's real ~1/256 quantization step), the per-row-not-global scale property above, input validation, an all-zero row, and an int8-range bound check
- [x] Verified directly on real XPU hardware (256x256 weight: ~0.69% round-trip / ~0.74% matmul relative error), 0 new exec-queue resets
- [x] `pytest tests/ -m "not xpu"`: 318 passed (+8 net), same 11 pre-existing unrelated failures
- [x] `.venv` (torch-free): 202 passed, 37 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add per-channel symmetric INT8 weight quantization primitives

- Provide dequantize and int8_linear forward helpers

- Add 8 CPU-only correctness tests for quantization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dense weight [N, K]"] --> B["quantize_int8_channel: per-row amax/127 scale"]
  B --> C["weight_int8 int8 tensor"]
  B --> D["scale per row"]
  C --> E["dequantize_int8_channel"]
  D --> E
  E --> F["int8_linear: x @ W.T + bias"]
  G["tests/test_int8_quant.py"] --> H["8 CPU tests validate precision/range/shape"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>int8_linear.py</strong><dd><code>Add per-channel INT8 quantization and linear helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/kernel/triton/int8_linear.py

<ul><li>Add <code>quantize_int8_channel</code> computing per-row scale from max absolute <br>value<br> <li> Add <code>dequantize_int8_channel</code> converting int8 weights to target dtype<br> <li> Add <code>int8_linear</code> wrapper for dequantized linear forward with optional <br>bias<br> <li> Document scope: per-channel symmetric INT8, excluding GGUF and INT4</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/130/files#diff-562a7ae01165816b19dada4633ebde17d56b2004f5bfd81ecc591464dbce838e">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_int8_quant.py</strong><dd><code>Add INT8 quantization correctness tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_int8_quant.py

<ul><li>Add 8 CPU-only tests for quantization, dequantization, and linear<br> <li> Validate per-row scaling preserves small-magnitude rows<br> <li> Check input validation, zero rows, int8 range, and bias</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/130/files#diff-1624e415d5714c0c145b557111c70979fbbcc880a3b257af1b45c2cad06218dc">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___