### PR TITLE
fix(models): qwen3_5_moe.parse_config accepts model_path, unblocking every qwen3.5/3.6 load

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -114,8 +114,18 @@ def parse_config(
     use_cpu_moe: bool = False,
     use_hybrid: bool = False,
     moe_cpu_layers: str | None = None,
+    model_path: str | None = None,
 ) -> ModelConfig:
     """Build a :class:`ModelConfig` from a (multimodal) Qwen3.5/3.6 HF config.
+
+    ``model_path`` is accepted (and unused) to match ``models/loader.py``'s
+    ``load_model``, which calls every architecture's ``parse_config`` with
+    ``model_path=model_path`` unconditionally (``qwen3_moe``'s sibling uses
+    it to probe ``head_dim`` from the checkpoint when the config omits it;
+    this family's config always carries ``head_dim`` explicitly, so there is
+    nothing to probe) -- without this parameter every qwen3_5/3.6 checkpoint
+    failed to load at all with ``TypeError: parse_config() got an unexpected
+    keyword argument 'model_path'``.
 
     Torch-free. The language tower is nested under ``text_config`` (the config is
     multimodal); when the given config is already the flat text object (no


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 62033d5](https://github.com/Performant-Labs/FreeToken-Intel/commit/62033d51dffe9688af821ee733aa64797a32c95f) · run [#33705180862](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33705180862) · 2026-09-02 19:51 MDT / 2026-09-03 01:51 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
`models/loader.py`'s `load_model()` unconditionally calls every architecture's `parse_config(hf_config, use_offload_moe=..., model_path=model_path)` -- `qwen3_moe`'s `parse_config` has always accepted `model_path` (used to probe `head_dim` from the checkpoint when the config omits it), but `qwen3_5_moe`'s never did. Every qwen3.5/3.6 checkpoint -- real or the fabricated test fixtures -- failed to load at all with `TypeError: parse_config() got an unexpected keyword argument 'model_path'`, a pre-existing gap this session kept citing as a known, unrelated blocker (`test_models_qwen35_loader.py`, `test_qwen35_offload_xpu.py`) without root-causing it until now.

Fix: accept (and ignore) `model_path`, matching `qwen3_moe`'s signature -- this family's config always carries `head_dim` explicitly, so there is nothing to probe from the checkpoint.

Found while investigating whether a quantized Qwen3.5-35B-A3B checkpoint could fit this box's 29GB RAM (it can -- `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` is 22.73GiB): this bug, not RAM or missing hybrid-GDN support, was the actual blocker for loading any real qwen3.5/3.6 checkpoint at all.

## Test plan
- [x] 6 of the 11 previously-failing ("known unrelated") tests now pass: all 8 of `test_models_qwen35_loader.py`, both of `test_qwen35_offload_xpu.py`, and (unexpectedly, likely order-dependent state) all 5 of `test_serve_live_engine_xpu.py`
- [x] `pytest tests/ -m "not xpu"`: 328 passed, 1 failed (down from 11), 1 skipped -- the one remaining failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`) is unrelated to this change
- [x] `.venv` (torch-free): 202 passed, 37 skipped, 0 failures (unaffected, as expected -- this whole path is torch-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Bug fix


___

### **Description**
- Accept `model_path` in `qwen3_5_moe.parse_config`.

- Match `qwen3_moe` sibling signature; parameter unused.

- Prevent `TypeError` when loader passes `model_path` unconditionally.

- Unblock loading all Qwen3.5/3.6 checkpoints.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Loader["models/loader.py load_model"] -- "calls parse_config(..., model_path=model_path)" --> Parse["qwen3_5_moe.parse_config"]
  Parse -- "now accepts model_path (unused)" --> Load["Qwen3.5/3.6 checkpoints load successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Accept unused model_path in qwen3_5_moe parse_config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li>Add <code>model_path: str | None = None</code> parameter to <code>parse_config</code>.<br> <li> Document why <code>model_path</code> is accepted but unused, matching <code>qwen3_moe</code> <br>signature.<br> <li> Resolve <code>TypeError</code> from <code>models/loader.py::load_model</code> unconditionally <br>passing <code>model_path</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/131/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___