### PR TITLE
feat(kernel): GPTQ INT4 dequantize primitives (issue #10)

### DIFF
--- a/python/freetoken/kernel/triton/gptq_linear.py
+++ b/python/freetoken/kernel/triton/gptq_linear.py
@@ -1,0 +1,118 @@
+"""GPTQ INT4 (and INT2/INT8) weight dequantization (issue `quant-xpu`, #10).
+
+Standard AutoGPTQ packed-integer format: this is the storage layout behind
+real checkpoints like the official ``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``
+(``bits: 4, group_size: 128, sym: true, desc_act: false``) -- a group of
+``group_size`` consecutive input features shares one scale (and, for
+asymmetric quantization, one zero-point) per output channel.
+
+Ported from (and cross-checked line-by-line against) the canonical
+reference, AutoGPTQ's own ``QuantLinear`` unpack/dequant path:
+https://github.com/AutoGPTQ/AutoGPTQ/blob/main/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
+-- bit-packing conventions like this one are exactly the kind of thing that
+produces silently-wrong-but-plausible numbers if hand-derived from memory,
+so this was built by pulling the real source rather than guessing (same
+policy as the FP8/MXFP4 ports, #125/#129, which had a public spec to check
+against instead of a reference implementation).
+
+Storage (for a ``[K, N]`` logical weight, ``K`` = in_features, ``N`` =
+out_features, packing factor ``P = 32 // bits`` int32 sub-values per word):
+
+    qweight  int32 [K // P, N]              -- P rows of K packed per word
+    qzeros   int32 [ceil(K/group_size), N // P]  -- P output channels packed per word
+    scales   fp16/bf16/fp32 [ceil(K/group_size), N]
+    g_idx    int32 [K]                       -- g_idx[k] = k // group_size (desc_act=False)
+
+Dequant: ``weight[k, n] = scales[g_idx[k], n] * (unpack(qweight)[k, n] -
+(unpack(qzeros)[g_idx[k], n] + 1))`` -- the ``+ 1`` on the zero-point is a
+real, well-known AutoGPTQ convention (not a bug to "fix"): the packer
+stores ``zero_point - 1`` because the unsigned 4-bit code 0 is reserved,
+so every reader must undo it.
+"""
+from __future__ import annotations
+
+import torch
+
+_BITS = 4  # this port only implements the 4-bit case (the real checkpoint's format)
+
+
+def _unpack_int32(packed: torch.Tensor, *, bits: int, dim: int) -> torch.Tensor:
+    """Unpack ``bits``-wide sub-values from an int32 tensor's ``dim``, where
+    each int32 word holds ``32 // bits`` consecutive values (least-significant
+    bits = the first value). Inserts a new axis of size ``32 // bits``
+    immediately after ``dim``, to be reshaped/flattened by the caller (the
+    two callers below flatten it into the K or N axis respectively --
+    matching AutoGPTQ's own two different post-unpack reshapes)."""
+    p = 32 // bits
+    shifts = torch.arange(0, 32, bits, dtype=torch.int32, device=packed.device)
+    shape = [1] * packed.ndim
+    shape.insert(dim + 1, p)
+    shifts = shifts.reshape(*([1] * dim), p, *([1] * (packed.ndim - dim - 1)))
+    expanded = packed.unsqueeze(dim + 1).expand(*packed.shape[: dim + 1], p, *packed.shape[dim + 1 :])
+    return torch.bitwise_and(torch.bitwise_right_shift(expanded, shifts), (1 << bits) - 1)
+
+
+def dequantize_gptq_int4(
+    qweight: torch.Tensor,
+    qzeros: torch.Tensor,
+    scales: torch.Tensor,
+    g_idx: torch.Tensor,
+    *,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Reconstruct the dense ``[K, N]`` weight (``nn.Linear``'s ``in_features
+    x out_features`` orientation -- transpose the result for a ``[N, K]``
+    ``nn.Linear.weight``) from GPTQ-packed tensors.
+
+    ``qweight`` is ``[K // 8, N]`` int32, ``qzeros`` is
+    ``[ceil(K/group_size), N // 8]`` int32, ``scales`` is
+    ``[ceil(K/group_size), N]``, ``g_idx`` is ``[K]`` int32.
+    """
+    if qweight.dtype != torch.int32:
+        raise TypeError(f"qweight must be int32, got {qweight.dtype}")
+    if qzeros.dtype != torch.int32:
+        raise TypeError(f"qzeros must be int32, got {qzeros.dtype}")
+    if g_idx.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"g_idx must be an integer tensor, got {g_idx.dtype}")
+
+    k_packed, n = qweight.shape
+    k = k_packed * (32 // _BITS)
+    if scales.shape[1] != n or qzeros.shape[1] * (32 // _BITS) != n:
+        raise ValueError(
+            f"qweight/qzeros/scales shape mismatch: qweight={tuple(qweight.shape)}, "
+            f"qzeros={tuple(qzeros.shape)}, scales={tuple(scales.shape)}"
+        )
+    if g_idx.shape[0] != k:
+        raise ValueError(f"g_idx length {g_idx.shape[0]} does not match qweight's implied K={k}")
+
+    # qweight: [K//8, N] -> unpack dim 0 (8 rows packed per int32 word) -> [K//8, 8, N] -> [K, N].
+    weight = _unpack_int32(qweight, bits=_BITS, dim=0).reshape(k, n)
+    # qzeros: [G, N//8] -> unpack dim 1 (8 output channels packed per int32 word) -> [G, N//8, 8] -> [G, N].
+    zeros = _unpack_int32(qzeros, bits=_BITS, dim=1).reshape(qzeros.shape[0], n)
+    zeros = zeros.to(torch.int32) + 1  # AutoGPTQ's stored-minus-one convention
+
+    g_idx = g_idx.long()
+    per_row_scale = scales[g_idx]  # [K, N]
+    per_row_zero = zeros[g_idx]  # [K, N]
+    return (per_row_scale.to(torch.float32) * (weight.to(torch.float32) - per_row_zero.to(torch.float32))).to(
+        out_dtype
+    )
+
+
+def gptq_linear(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    qzeros: torch.Tensor,
+    scales: torch.Tensor,
+    g_idx: torch.Tensor,
+    *,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x @ dequantize_gptq_int4(...).T (+ bias)``. Dequant-on-forward
+    drop-in matching ``fp8_block_linear`` / ``mxfp4_linear`` / ``int8_linear``'s
+    shape -- a caller driving this repeatedly should dequantize once at load
+    time instead (via :func:`dequantize_gptq_int4` directly, transposed to
+    ``nn.Linear``'s ``[out_features, in_features]``) and cache the result.
+    """
+    w = dequantize_gptq_int4(qweight, qzeros, scales, g_idx, out_dtype=x.dtype)
+    return torch.nn.functional.linear(x, w.T, bias)

--- a/tests/test_gptq_quant.py
+++ b/tests/test_gptq_quant.py
@@ -1,0 +1,112 @@
+"""Correctness tests for GPTQ INT4 dequantization (issue quant-xpu, #10).
+
+Pure torch, no XPU dependency, CPU-testable. The known-encoding test hand-
+packs qweight/qzeros bytes via plain Python bit arithmetic (independent of
+dequantize_gptq_int4's own torch bit-ops), so it checks the unpacking math
+against the AutoGPTQ reference layout directly, not just self-consistency.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4, gptq_linear
+
+
+def _pack_nibbles(codes: list[int]) -> int:
+    """8 4-bit codes -> one packed int32 word (LSB = codes[0], matching
+    AutoGPTQ: shift amounts are 0, 4, 8, ..., 28)."""
+    word = 0
+    for i, c in enumerate(codes):
+        assert 0 <= c < 16
+        word |= c << (4 * i)
+    return word
+
+
+def test_dequantize_matches_hand_packed_known_encoding():
+    K, N, group_size = 8, 8, 8  # one group covers the whole K
+    # Every column shares the same 8 4-bit weight codes 0..7 (row k -> code k).
+    codes = list(range(8))
+    qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
+    assert qweight.shape == (1, N)
+
+    # Zero-point 8 (the standard symmetric midpoint) for every output channel:
+    # AutoGPTQ stores (zero_point - 1) packed, so the raw nibble is 7.
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)]], dtype=torch.int32)
+    assert qzeros.shape == (1, N // 8)
+
+    scales = torch.full((1, N), 0.5)
+    g_idx = torch.zeros(K, dtype=torch.int32)  # single group
+
+    out = dequantize_gptq_int4(qweight, qzeros, scales, g_idx, out_dtype=torch.float32)
+    assert out.shape == (K, N)
+    expected_col = torch.tensor([0.5 * (c - 8) for c in codes])  # [-4, -3.5, ..., -0.5]
+    for n in range(N):
+        torch.testing.assert_close(out[:, n], expected_col)
+
+
+def test_dequantize_respects_per_group_scale_and_zero():
+    """Two groups (group_size=4) with different scale/zero -- the low half
+    of K must use group 0's params, the high half group 1's."""
+    K, N, group_size = 8, 8, 4
+    codes = [1] * 8  # every row's weight code is 1 (arbitrary, constant)
+    qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
+    qzeros = torch.tensor(
+        [[_pack_nibbles([7] * 8)], [_pack_nibbles([3] * 8)]], dtype=torch.int32
+    )  # group0 zero=8, group1 zero=4
+    scales = torch.tensor([[1.0] * N, [10.0] * N])
+    g_idx = torch.tensor([i // group_size for i in range(K)], dtype=torch.int32)
+
+    out = dequantize_gptq_int4(qweight, qzeros, scales, g_idx, out_dtype=torch.float32)
+    # group 0 (rows 0-3): scale=1.0, zero=8 -> 1.0 * (1 - 8) = -7
+    torch.testing.assert_close(out[:4, 0], torch.full((4,), -7.0))
+    # group 1 (rows 4-7): scale=10.0, zero=4 -> 10.0 * (1 - 4) = -30
+    torch.testing.assert_close(out[4:, 0], torch.full((4,), -30.0))
+
+
+def test_dequantize_rejects_non_int32_qweight():
+    with pytest.raises(TypeError, match="qweight must be int32"):
+        dequantize_gptq_int4(
+            torch.zeros(1, 8, dtype=torch.int64),
+            torch.zeros(1, 1, dtype=torch.int32),
+            torch.zeros(1, 8),
+            torch.zeros(8, dtype=torch.int32),
+        )
+
+
+def test_dequantize_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="mismatch"):
+        dequantize_gptq_int4(
+            torch.zeros(1, 8, dtype=torch.int32),
+            torch.zeros(1, 1, dtype=torch.int32),
+            torch.zeros(1, 4),  # wrong N
+            torch.zeros(8, dtype=torch.int32),
+        )
+
+
+def test_dequantize_rejects_g_idx_length_mismatch():
+    with pytest.raises(ValueError, match="g_idx"):
+        dequantize_gptq_int4(
+            torch.zeros(1, 8, dtype=torch.int32),
+            torch.zeros(1, 1, dtype=torch.int32),
+            torch.zeros(1, 8),
+            torch.zeros(4, dtype=torch.int32),  # should be K=8
+        )
+
+
+def test_gptq_linear_matches_manual_dequant_matmul():
+    K, N, group_size = 8, 8, 8
+    codes = [(k * 3) % 16 for k in range(8)]
+    qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)]], dtype=torch.int32)
+    scales = torch.full((1, N), 0.25)
+    g_idx = torch.zeros(K, dtype=torch.int32)
+
+    torch.manual_seed(0)
+    x = torch.randn(3, K)
+    w = dequantize_gptq_int4(qweight, qzeros, scales, g_idx, out_dtype=torch.float32)
+    ref = torch.nn.functional.linear(x, w.T)
+
+    out = gptq_linear(x, qweight, qzeros, scales, g_idx)
+    torch.testing.assert_close(out, ref)


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit bdb1e56](https://github.com/Performant-Labs/FreeToken-Intel/commit/bdb1e56da0d2cf189a24f1d922feb551082cad94) · run [#33705894890](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33705894890) · 2026-09-02 20:04 MDT / 2026-09-03 02:04 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Continues quant-xpu (#10): the standard AutoGPTQ packed-integer format -- the storage layout behind real checkpoints like the official `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` (`bits=4, group_size=128, sym=true, desc_act=false`), found while investigating whether a quantized 35B-A3B checkpoint could fit this box's 29GB RAM (it does: 22.73GiB, vs. FP8's 34.88GiB and bf16's ~70GB -- this is now the real, in-progress download target).

Ported from (and cross-checked line-by-line against) AutoGPTQ's own `QuantLinear` unpack/dequant path on GitHub, not derived from memory -- GPTQ's bit-packing (which sub-value lives in which nibble of which int32 word, and the well-known "stored zero-point is off by one" convention) is exactly the kind of thing that produces silently-wrong-but-plausible numbers if guessed. Verified bit-exact identical between CPU and real XPU hardware on a 128x64 random-bits fixture (max abs diff 0.0), 0 new exec-queue resets.

`dequantize_gptq_int4(qweight, qzeros, scales, g_idx)` reconstructs the dense `[K, N]` weight; `gptq_linear` is a dequant-on-forward `nn.Linear` drop-in, matching `fp8_block_linear` / `mxfp4_linear` / `int8_linear`'s shape.

## Test plan
- [x] 6 new tests (`tests/test_gptq_quant.py`): two hand-packed known-encoding tests (bytes built via plain Python bit arithmetic, independent of the module's own torch bit-ops -- one single-group, one two-group to prove per-group scale/zero-point indexing via `g_idx` is correct), input validation, and a `gptq_linear`-matches-manual-dequant-matmul check
- [x] Verified bit-exact identical between CPU and real XPU hardware, 0 new exec-queue resets
- [x] `pytest tests/ -m "not xpu"`: 334 passed (+6 net), the one remaining pre-existing unrelated failure unchanged
- [x] `.venv` (torch-free): 202 passed, 38 skipped, 0 failures

**Not implemented:** 2-bit/3-bit/8-bit GPTQ (only the 4-bit case, the real checkpoint's format); `desc_act=True` (the target checkpoint doesn't use it); a native low-precision GEMM kernel (dequant-on-load only, same scoping call as the other three quant primitives this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `dequantize_gptq_int4` for AutoGPTQ packed INT4 weights

- Add `gptq_linear` dequant-on-forward `nn.Linear` drop-in

- Validate dtypes and shape mismatches in dequantize path

- Add tests for known encodings and linear parity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Packed["AutoGPTQ INT4 tensors (qweight, qzeros, scales, g_idx)"]
  Dequant["dequantize_gptq_int4 unpack/dequant"]
  Dense["Dense [K, N] weight"]
  Linear["gptq_linear dequant-on-forward"]
  Output["Linear output"]
  Tests["tests/test_gptq_quant.py"]
  Packed -- "unpack" --> Dequant
  Dequant -- "produces" --> Dense
  Packed -- "forward" --> Linear
  Linear -- "returns" --> Output
  Tests -- "verify" --> Dequant
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gptq_linear.py</strong><dd><code>Add GPTQ INT4 dequantization kernel functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/kernel/triton/gptq_linear.py

<ul><li>Add <code>_unpack_int32</code> helper for 4-bit packed int32 sub-value unpacking<br> <li> Add <code>dequantize_gptq_int4</code> to reconstruct dense [K, N] weights<br> <li> Add <code>gptq_linear</code> dequant-on-forward <code>nn.Linear</code> drop-in<br> <li> Implement dtype and shape validation for quantized inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/132/files#diff-d523b4dd4ab8acb8254ff82b7430670e8e347d964d845f42acfd499961854ca5">+118/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gptq_quant.py</strong><dd><code>Add GPTQ INT4 dequantization correctness tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_gptq_quant.py

<ul><li>Add hand-packed known-encoding tests for single and two groups<br> <li> Add input validation tests for dtype and shape mismatches<br> <li> Add <code>gptq_linear</code> matches manual dequant-matmul test</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/132/files#diff-05c2b1ca20b3af60ff537c39fa39d433bb022dbd5ed8f4c1db797d70147acc00">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___