### PR TITLE
feat(models): qwen3_5_moe.iter_weights dequantizes GPTQ-packed projections

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -52,6 +52,13 @@ __all__ = ["parse_config", "iter_weights", "Qwen3_5MoEForCausalLM"]
 _LANGUAGE_PREFIX = "model.language_model."
 _LANGUAGE_TARGET = "model."
 _VISUAL_PREFIX = "model.visual."
+_MTP_PREFIX = "mtp."
+
+# GPTQ's four per-projection component tensors (AutoGPTQ layout, see
+# freetoken.kernel.triton.gptq_linear). A checkpoint with no GPTQ tensors at
+# all (the common case) never populates the buffer these key off of, so
+# _dequantize_gptq_stream is a no-op passthrough for a plain bf16 checkpoint.
+_GPTQ_SUFFIXES = (".qweight", ".qzeros", ".scales", ".g_idx")
 
 # The one checkpoint weight that the routed-expert bank fabricator expects to be
 # an *untransposed* [n_experts, hidden, inter] (see qwen3_moe._transpose_down):
@@ -242,9 +249,25 @@ def iter_weights(
 
     * ``model.visual.*`` (the vision tower) is **dropped** -- text serving does
       not run the image encoder.
+    * ``mtp.*`` (the multi-token-prediction head, a separate top-level
+      namespace not nested under ``model.language_model.*``) is **dropped** --
+      this port's engine does not run MTP.
     * ``model.language_model.*`` is **remapped** to ``model.*`` so the loader's
       MoE-bank plumbing (and the forward pass) see the same key shape as the
       dense qwen3_moe model.
+    * A **GPTQ-quantized** checkpoint (e.g. the official
+      ``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``) stores each quantized projection as
+      four tensors -- ``.qweight`` / ``.qzeros`` / ``.scales`` / ``.g_idx`` --
+      instead of one plain ``.weight``. Those four are buffered here (by their
+      shared name prefix) and, once complete, dequantized via
+      :func:`freetoken.kernel.triton.gptq_linear.dequantize_gptq_int4` into a
+      single dense ``.weight`` tensor before entering the rest of this
+      function -- everything below (routing, remapping, host placement) sees
+      the exact same shape it would for a plain bf16 checkpoint. Per the real
+      checkpoint's ``quantization_config.dynamic`` exclusions, only the routed
+      experts' ``gate_proj``/``up_proj``/``down_proj`` are ever quantized this
+      way; attention, the shared expert, embeddings, and ``lm_head`` stay
+      plain bf16/fp16 tensors and pass through unchanged.
     * Routed experts (``.experts.*``) go to **host** (offload banks); everything
       else -- including the always-on shared expert and the linear-attention
       weights -- goes to the dense ``device``.
@@ -258,10 +281,10 @@ def iter_weights(
     _cfg = _cfg_for_path(model_path)
     routed = _expert_source_names(_cfg) if _cfg is not None else None
 
-    for raw_name, tensor in _iter_safetensors(model_path, device=device):
-        # Drop the vision tower outright (text serving does not run the
-        # image encoder).
-        if raw_name.startswith(_VISUAL_PREFIX):
+    for raw_name, tensor in _dequantize_gptq_stream(_iter_safetensors(model_path, device=device)):
+        # Drop the vision tower and the MTP head outright -- neither is part
+        # of the text-serving forward pass this port runs.
+        if raw_name.startswith(_VISUAL_PREFIX) or raw_name.startswith(_MTP_PREFIX):
             continue
         # Remap the language tower to the plain model.* prefix so the loader's
         # MoE-bank plumbing (and the forward pass) see the same key shape as the
@@ -309,6 +332,47 @@ def _iter_safetensors(model_path, device):
     from freetoken.models.weight import iter_safetensors
 
     yield from iter_safetensors(model_path, device=device)
+
+
+def _dequantize_gptq_stream(pairs):
+    """Wrap a raw ``(name, tensor)`` stream, buffering and dequantizing any
+    GPTQ-packed projections (four tensors -- ``.qweight``/``.qzeros``/
+    ``.scales``/``.g_idx`` -- sharing one name prefix) into a single dense
+    ``<prefix>.weight`` tensor, matching the shape a plain bf16 checkpoint's
+    stream already has. Every other tensor passes through unchanged, so this
+    is a no-op for a checkpoint with no GPTQ tensors at all.
+
+    Buffers by prefix rather than assuming the four components arrive
+    consecutively (safetensors preserves each shard's own key order, but
+    that order is not a documented guarantee, and different components of
+    one projection could in principle live in different shards).
+    """
+    import torch
+
+    from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4
+
+    pending: Dict[str, Dict[str, Any]] = {}
+    for name, tensor in pairs:
+        matched_suffix = next((s for s in _GPTQ_SUFFIXES if name.endswith(s)), None)
+        if matched_suffix is None:
+            yield name, tensor
+            continue
+        prefix = name[: -len(matched_suffix)]
+        parts = pending.setdefault(prefix, {})
+        parts[matched_suffix] = tensor
+        if len(parts) < len(_GPTQ_SUFFIXES):
+            continue
+        del pending[prefix]
+        # dequantize_gptq_int4 returns [in_features, out_features]; nn.Linear's
+        # weight convention (what every non-quantized tensor in this stream
+        # already is) is [out_features, in_features].
+        dense = dequantize_gptq_int4(
+            parts[".qweight"], parts[".qzeros"], parts[".scales"], parts[".g_idx"], out_dtype=torch.bfloat16
+        ).T.contiguous()
+        yield prefix + ".weight", dense
+    if pending:
+        incomplete = {prefix: sorted(parts) for prefix, parts in pending.items()}
+        raise ValueError(f"GPTQ tensor stream ended with incomplete projection(s): {incomplete}")
 
 
 # Forward side (the real hybrid model the engine runs, #18 / #14)

--- a/tests/test_qwen35_gptq_loader.py
+++ b/tests/test_qwen35_gptq_loader.py
@@ -1,0 +1,105 @@
+"""qwen3_5_moe.iter_weights: GPTQ-packed projections dequantize correctly
+before entering the rest of the loader pipeline (issue quant-xpu, #10).
+
+Found while preparing to load the real Qwen/Qwen3.5-35B-A3B-GPTQ-Int4
+checkpoint: only the routed experts' gate_proj/up_proj/down_proj are ever
+GPTQ-quantized in that checkpoint (per its own quantization_config.dynamic
+exclusions) -- everything else stays plain bf16/fp16. These tests exercise
+_dequantize_gptq_stream directly (the narrow, real thing this PR adds) with
+small hand-built tensors, independent of the full multimodal fixture in
+test_models_qwen35_loader.py (which already covers the rest of iter_weights
+end to end for a plain, non-quantized checkpoint).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4
+from freetoken.models.qwen3_5_moe import _dequantize_gptq_stream
+
+
+def _pack_nibbles(codes: list[int]) -> int:
+    word = 0
+    for i, c in enumerate(codes):
+        word |= c << (4 * i)
+    return word
+
+
+def _fake_gptq_projection(k: int, n: int, group_size: int):
+    """A small, real (not random-garbage) GPTQ-packed projection: constant
+    weight code 5, zero-point 8, scale 0.5 -- every dequantized element is
+    0.5 * (5 - 8) = -1.5."""
+    assert k % 8 == 0 and n % 8 == 0 and k % group_size == 0
+    n_groups = k // group_size
+    qweight = torch.tensor([[_pack_nibbles([5] * 8)] * n for _ in range(k // 8)], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)] * (n // 8) for _ in range(n_groups)], dtype=torch.int32)
+    scales = torch.full((n_groups, n), 0.5)
+    g_idx = torch.tensor([i // group_size for i in range(k)], dtype=torch.int32)
+    return qweight, qzeros, scales, g_idx
+
+
+def test_passthrough_for_a_stream_with_no_gptq_tensors():
+    pairs = [("a.weight", torch.randn(4, 4)), ("b.bias", torch.randn(4))]
+    out = list(_dequantize_gptq_stream(iter(pairs)))
+    assert [name for name, _ in out] == ["a.weight", "b.bias"]
+    for (_, expected), (_, got) in zip(pairs, out):
+        torch.testing.assert_close(got, expected)
+
+
+def test_dequantizes_a_complete_gptq_projection_to_a_single_weight_tensor():
+    k, n, group_size = 16, 8, 16
+    qweight, qzeros, scales, g_idx = _fake_gptq_projection(k, n, group_size)
+    prefix = "model.language_model.layers.0.mlp.experts.0.gate_proj"
+    pairs = [
+        (prefix + ".qweight", qweight),
+        (prefix + ".qzeros", qzeros),
+        (prefix + ".scales", scales),
+        (prefix + ".g_idx", g_idx),
+    ]
+    out = list(_dequantize_gptq_stream(iter(pairs)))
+    assert len(out) == 1
+    name, tensor = out[0]
+    assert name == prefix + ".weight"
+    # nn.Linear convention: [out_features, in_features] = [n, k].
+    assert tensor.shape == (n, k)
+    torch.testing.assert_close(tensor, torch.full((n, k), -1.5, dtype=tensor.dtype), atol=1e-2, rtol=0)
+
+
+def test_dequantized_tensor_matches_dequantize_gptq_int4_transposed():
+    k, n, group_size = 16, 8, 16
+    qweight, qzeros, scales, g_idx = _fake_gptq_projection(k, n, group_size)
+    prefix = "p"
+    pairs = [(prefix + s, t) for s, t in zip((".qweight", ".qzeros", ".scales", ".g_idx"), (qweight, qzeros, scales, g_idx))]
+    (_, got) = next(iter(_dequantize_gptq_stream(iter(pairs))))
+    expected = dequantize_gptq_int4(qweight, qzeros, scales, g_idx, out_dtype=torch.bfloat16).T.contiguous()
+    torch.testing.assert_close(got, expected)
+
+
+def test_gptq_and_plain_tensors_interleave_correctly():
+    k, n, group_size = 8, 8, 8
+    qweight, qzeros, scales, g_idx = _fake_gptq_projection(k, n, group_size)
+    prefix = "model.language_model.layers.0.mlp.experts.0.down_proj"
+    pairs = [
+        ("model.language_model.embed_tokens.weight", torch.randn(4, 4)),
+        (prefix + ".qweight", qweight),
+        ("model.language_model.layers.0.linear_attn.norm.weight", torch.randn(4)),
+        (prefix + ".g_idx", g_idx),
+        (prefix + ".scales", scales),
+        (prefix + ".qzeros", qzeros),
+    ]
+    out = dict(_dequantize_gptq_stream(iter(pairs)))
+    assert set(out) == {
+        "model.language_model.embed_tokens.weight",
+        "model.language_model.layers.0.linear_attn.norm.weight",
+        prefix + ".weight",
+    }
+
+
+def test_raises_on_an_incomplete_projection_at_stream_end():
+    k, n, group_size = 8, 8, 8
+    qweight, qzeros, scales, _g_idx = _fake_gptq_projection(k, n, group_size)
+    pairs = [("p.qweight", qweight), ("p.qzeros", qzeros), ("p.scales", scales)]  # missing g_idx
+    with pytest.raises(ValueError, match="incomplete"):
+        list(_dequantize_gptq_stream(iter(pairs)))


### PR DESCRIPTION
<!-- argos-status:start -->
> 🔴 **PR-Agent Score: 66** `score-below-70` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/133#issuecomment-5519296238) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit a9bdef7](https://github.com/Performant-Labs/FreeToken-Intel/commit/a9bdef7e201291bd00586b4a403f0b6f91d6321b) · run [#33706518601](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33706518601) · 2026-09-02 20:15 MDT / 2026-09-03 02:15 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Wires #132's GPTQ-Int4 dequant primitive into the `qwen3_5_moe` loader path: a real checkpoint like the official `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` stores each quantized projection as four tensors (`.qweight`/`.qzeros`/`.scales`/`.g_idx`) instead of one plain `.weight`. `iter_weights` now buffers those four by their shared name prefix and dequantizes them into a single dense `.weight` tensor before the rest of the function (routing to host/device, the `language_model.*` -> `model.*` remap) ever sees them -- everything downstream, including `load_moe_expert_sources`'s bank fabricator, stays exactly as it is for a plain bf16 checkpoint. A checkpoint with no GPTQ tensors at all (every existing test fixture) is a straight no-op passthrough, verified by the full existing suite passing unchanged.

Per the real checkpoint's own `quantization_config.dynamic` exclusions, only the routed experts' `gate_proj`/`up_proj`/`down_proj` are ever GPTQ-quantized -- attention, the shared expert, embeddings, and `lm_head` stay plain bf16/fp16 and pass through this stream unchanged, confirmed against the real checkpoint's `model.safetensors.index.json` (63263/64196 tensors are expert tensors; the 785 `mtp.*` tensors and every `linear_attn`/`self_attn` tensor are plain `.weight`, no `.qweight` suffix).

Also drops the `mtp.*` (multi-token-prediction head) tensors outright, the same way `model.visual.*` (the vision tower) already is -- neither is part of the text-serving forward pass this port runs, and `mtp.*` is a separate top-level namespace (not nested under `model.language_model.*`) that would otherwise flow through unremapped and unused.

## Test plan
- [x] 5 new tests (`tests/test_qwen35_gptq_loader.py`) exercise `_dequantize_gptq_stream` directly with small hand-built GPTQ tensors: passthrough for a plain stream, a complete-projection dequant (checked against a hand-computed expected value AND against `dequantize_gptq_int4` called directly), GPTQ/plain tensors interleaved in one stream, and an incomplete-projection-at-stream-end error
- [x] `pytest tests/ -m "not xpu"`: 339 passed (+5 net), the one pre-existing unrelated failure unchanged
- [x] `.venv` (torch-free): 202 passed, 39 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds GPTQ-Int4 dequantization to `qwen3_5_moe.iter_weights`

- Buffers GPTQ suffixes and yields dense `.weight` tensors

- Drops `mtp.*` and vision tower tensors from stream

- Adds five tests for dequant stream behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw safetensors stream"] --> B["_dequantize_gptq_stream"]
  B --> C["Buffers .qweight/.qzeros/.scales/.g_idx by prefix"]
  C --> D["dequantize_gptq_int4 -> dense .weight"]
  B --> E["Plain tensors pass through unchanged"]
  D --> F["Existing iter_weights routing/remap"]
  E --> F
  G["mtp.* dropped"] -.-> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add GPTQ dequantization and MTP drop to Qwen3_5MoE loader</code></dd></summary>
<hr>

python/freetoken/models/qwen3_5_moe/__init__.py

<ul><li>Adds <code>_GPTQ_SUFFIXES</code> and <code>_MTP_PREFIX</code> constants for GPTQ and MTP <br>detection<br> <li> Wraps <code>_iter_safetensors</code> with <code>_dequantize_gptq_stream</code> buffering four <br>GPTQ tensors by prefix<br> <li> Dequantizes complete projections into dense bf16 <code>.weight</code> and <br>transposes to <code>[out_features, in_features]</code><br> <li> Drops <code>mtp.*</code> and <code>model.visual.*</code> namespaces before remapping<br> <li> Raises <code>ValueError</code> for incomplete GPTQ projections at stream end</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/133/files#diff-578d614838cbea4302c133d5cfb27ac4882bac9ead0824ce0ffbfc7429c486cc">+68/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_qwen35_gptq_loader.py</strong><dd><code>Add tests for GPTQ dequant stream in Qwen3.5 loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_qwen35_gptq_loader.py

<ul><li>Adds five tests for <code>_dequantize_gptq_stream</code><br> <li> Covers plain passthrough, complete dequant, interleaved GPTQ/plain, <br>and incomplete projection error<br> <li> Uses hand-built fake GPTQ projections with known expected value<br> <li> Verifies dequantized tensor matches direct <code>dequantize_gptq_int4</code> <br>transpose</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/133/files#diff-5a41579b40e920bb6a59a5f3cc8f11e8faca79fd1d734f11849afb7c7fdf576c">+105/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___