### PR TITLE
feat(models): packed GPTQ expert banks stay packed in host RAM (issue #135)

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -258,16 +258,30 @@ def iter_weights(
     * A **GPTQ-quantized** checkpoint (e.g. the official
       ``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``) stores each quantized projection as
       four tensors -- ``.qweight`` / ``.qzeros`` / ``.scales`` / ``.g_idx`` --
-      instead of one plain ``.weight``. Those four are buffered here (by their
-      shared name prefix) and, once complete, dequantized via
-      :func:`freetoken.kernel.triton.gptq_linear.dequantize_gptq_int4` into a
-      single dense ``.weight`` tensor before entering the rest of this
-      function -- everything below (routing, remapping, host placement) sees
-      the exact same shape it would for a plain bf16 checkpoint. Per the real
-      checkpoint's ``quantization_config.dynamic`` exclusions, only the routed
-      experts' ``gate_proj``/``up_proj``/``down_proj`` are ever quantized this
-      way; attention, the shared expert, embeddings, and ``lm_head`` stay
-      plain bf16/fp16 tensors and pass through unchanged.
+      instead of one plain ``.weight``. In **bank-only mode**
+      (``include_moe_experts=True, include_non_moe=False`` -- the offload
+      MoE-bank fabricator's call, ``load_moe_expert_sources``) these four
+      pass through **raw and unmodified**, by design (issue `moe-quant-
+      banks-pack`, #135): dequantizing every expert to bf16 at load time is
+      a 4x expansion that blows the host RAM budget for a real-scale
+      checkpoint (issue #134). A caller that wants packed GPTQ tensors
+      turned into per-layer banks streams this generator's output through
+      :func:`freetoken.models.weight.stream_moe_expert_sources_gptq`, which
+      keeps them packed the whole way through -- dequantization happens
+      lazily, per-expert, at compute time (issue #137), not here. In every
+      **other** call shape (bank-only mode is off), the four components are
+      still dequantized here via
+      :func:`freetoken.kernel.triton.gptq_linear.dequantize_gptq_int4` into
+      a single dense ``.weight`` tensor, matching a plain bf16 checkpoint's
+      shape -- the dense-placement call never sees expert tensors at all
+      (they are filtered out below), so this only actually matters for a
+      hypothetical future non-offload (fully in-VRAM) consumer of this
+      iterator; it is not exercised by the offload path once #136/#137 land.
+      Per the real checkpoint's ``quantization_config.dynamic`` exclusions,
+      only the routed experts' ``gate_proj``/``up_proj``/``down_proj`` are
+      ever quantized this way; attention, the shared expert, embeddings, and
+      ``lm_head`` stay plain bf16/fp16 tensors and pass through unchanged
+      regardless of mode.
     * Routed experts (``.experts.*``) go to **host** (offload banks); everything
       else -- including the always-on shared expert and the linear-attention
       weights -- goes to the dense ``device``.
@@ -281,7 +295,16 @@ def iter_weights(
     _cfg = _cfg_for_path(model_path)
     routed = _expert_source_names(_cfg) if _cfg is not None else None
 
-    for raw_name, tensor in _dequantize_gptq_stream(_iter_safetensors(model_path, device=device)):
+    # Bank-only mode (the offload-cache path, #135): do NOT eagerly dequantize
+    # GPTQ-packed expert tensors -- pass them through raw so a packed-bank
+    # builder can keep them packed in host RAM. Every other call shape keeps
+    # today's eager-dequant behavior (see the docstring above for why that is
+    # fine: the dense-placement call never sees expert tensors regardless).
+    bank_only = include_moe_experts and not include_non_moe
+    raw_stream = _iter_safetensors(model_path, device=device)
+    stream = raw_stream if bank_only else _dequantize_gptq_stream(raw_stream)
+
+    for raw_name, tensor in stream:
         # Drop the vision tower and the MTP head outright -- neither is part
         # of the text-serving forward pass this port runs.
         if raw_name.startswith(_VISUAL_PREFIX) or raw_name.startswith(_MTP_PREFIX):
@@ -294,7 +317,17 @@ def iter_weights(
             if raw_name.startswith(_LANGUAGE_PREFIX)
             else raw_name
         )
-        if routed is not None:
+        is_gptq_component = bank_only and name.endswith(_GPTQ_SUFFIXES)
+        if is_gptq_component:
+            # A raw GPTQ component's name (e.g. "...gate_proj.qweight") is
+            # never in `routed` (which only ever holds "...gate_proj.weight"
+            # spellings) -- classify by the same ".experts." substring the
+            # no-config fallback below already uses. Real routed-expert keys
+            # always carry ".experts." (the shared expert does not: it is
+            # "mlp.shared_expert.*", a different substring), so this is exact,
+            # not a heuristic weakening.
+            expert = ".experts." in name
+        elif routed is not None:
             expert = name in routed
         else:
             expert = ".experts." in name
@@ -305,7 +338,11 @@ def iter_weights(
             continue
         if not include_non_moe and not expert:
             continue
-        if dtype is not None and tensor.dtype != dtype:
+        # Never dtype-cast a raw GPTQ component: qweight/qzeros/g_idx are
+        # int32 and scales carries its own real dtype -- casting any of them
+        # to a requested bf16/fp16 dense dtype would silently corrupt the
+        # packed bits, not "convert" them.
+        if dtype is not None and not is_gptq_component and tensor.dtype != dtype:
             tensor = tensor.to(dtype)
         # Routed experts stream to host (offload banks); the rest (dense: the
         # shared expert, linear-attention weights, embeddings, norms, lm_head)

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import glob
 import json
 import os
-from typing import Iterator, Optional, Tuple
+from dataclasses import dataclass
+from typing import Dict, Iterator, Optional, Tuple
 
 import torch
 from safetensors import safe_open
@@ -326,6 +327,19 @@ def _expert_source_info(key: str) -> Tuple[int, str, Optional[int]] | None:
         return None
     e_pos = parts.index("experts")
     tail = parts[e_pos + 1 :]
+    # A GPTQ-packed component (.qweight/.qzeros/.scales/.g_idx, see
+    # stream_moe_expert_sources_gptq, issue #135) is NOT a plain dense
+    # weight tensor -- silently parsing e.g. "...gate_proj.qweight" as if it
+    # were "...gate_proj"'s actual weight would misinterpret a raw
+    # int32-packed tensor as the dense weight itself (garbage, not an
+    # error). Reject loudly instead of guessing: a GPTQ checkpoint's expert
+    # tensors must go through stream_moe_expert_sources_gptq, not this
+    # (bf16-oriented) function.
+    if tail and tail[-1] in _GPTQ_COMPONENTS:
+        raise ValueError(
+            f"GPTQ-packed expert weight key {key!r} passed to the bf16 expert-source "
+            "streamer; use stream_moe_expert_sources_gptq for a GPTQ checkpoint instead"
+        )
     # Real HF safetensors keys carry a trailing ``.weight`` (``...experts.{e}.{
     # gate|up|down}_proj.weight``); the FTW-normalized packed form (ADR 0002) may
     # omit it (``...experts.{gate_up_proj|down_proj}``). A ``.bias`` trailing token
@@ -490,10 +504,214 @@ def _stack_expert_rows(rows: list) -> torch.Tensor:
     return torch.cat([row.unsqueeze(0) for row in rows], dim=0)
 
 
+@dataclass(frozen=True)
+class GptqExpertBank:
+    """One MoE layer's packed GPTQ-quantized bank for one projection slot
+    (``gate_up`` or ``down``) -- the quantized-format sibling of the plain
+    ``[E, ...]`` bf16 bank tensor ``stream_moe_expert_sources`` produces
+    (issue `moe-quant-banks-pack`, #135).
+
+    ``qweight`` / ``qzeros`` / ``scales`` hold one row per expert (``[E,
+    ...]``, AutoGPTQ's packed-int32 layout -- see
+    :mod:`freetoken.kernel.triton.gptq_linear`). ``g_idx`` does NOT: it is
+    shared across every expert of this projection type in this layer
+    (``g_idx[k] = k // group_size`` depends only on ``K``/``group_size``,
+    both architecture constants, never on which expert), so stacking it per
+    expert would be pure, avoidable duplication.
+
+    Deliberately packed, never dequantized here: dequantizing every expert
+    to bf16 at load time is a 4x expansion that blows the host RAM budget
+    for a real-scale checkpoint (issue #134). Dequantization happens lazily,
+    per-expert, at compute time (issue #137) against whichever of these rows
+    the offload cache's device slot pool has fetched for the current step.
+    """
+
+    qweight: torch.Tensor  # [E, K // 8, N] int32
+    qzeros: torch.Tensor  # [E, ceil(K/group_size), N // 8] int32
+    scales: torch.Tensor  # [E, ceil(K/group_size), N]
+    g_idx: torch.Tensor  # [K] int32 -- shared across every expert
+
+
+_GPTQ_COMPONENTS = ("qweight", "qzeros", "scales", "g_idx")
+
+
+def _parse_gptq_expert_key(key: str) -> Tuple[int, str, int, str] | None:
+    """Parse a GPTQ-packed per-expert weight key into ``(layer, proj,
+    expert_id, component)``, or ``None`` if ``key`` is not one.
+
+    Recognizes ``...layers.{L}.mlp.experts.{e}.{gate_proj|up_proj|down_proj}
+    .{qweight|qzeros|scales|g_idx}`` -- the real checkpoint's raw per-expert
+    GPTQ layout (confirmed against ``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``'s own
+    ``model.safetensors.index.json``; there is no "packed" GPTQ spelling to
+    also accept, unlike :func:`_expert_source_info`'s bf16 case -- GPTQ
+    checkpoints only ever ship the raw per-expert form).
+    """
+    parts = key.split(".")
+    if len(parts) < 2 or parts[-1] not in _GPTQ_COMPONENTS:
+        return None
+    component = parts[-1]
+    body = parts[:-1]
+    if "mlp" not in body or "experts" not in body:
+        return None
+    try:
+        mlp_pos = body.index("mlp")
+        layer = int(body[mlp_pos - 1])
+    except (ValueError, IndexError):
+        return None
+    if body[mlp_pos + 1] != "experts":
+        return None
+    e_pos = body.index("experts")
+    tail = body[e_pos + 1 :]
+    if len(tail) != 2:
+        return None
+    try:
+        expert_id = int(tail[0])
+    except ValueError:
+        return None
+    proj = tail[1]
+    if proj not in {"gate_proj", "up_proj", "down_proj"}:
+        return None
+    return layer, proj, expert_id, component
+
+
+def stream_moe_expert_sources_gptq(
+    tensors: Iterator[Tuple[str, torch.Tensor]],
+    config,
+) -> Tuple[list, list]:
+    """Stream GPTQ-packed per-expert weight tensors into packed per-layer
+    banks (issue `moe-quant-banks-pack`, #135) -- the quantized-format
+    sibling of :func:`stream_moe_expert_sources`.
+
+    Kept as a separate function rather than folded into
+    ``stream_moe_expert_sources``: GPTQ's four-tensor-per-projection shape
+    does not fit that function's single-tensor-per-projection contract, and
+    that bf16 path is well-tested and used by every other model/checkpoint
+    -- not worth risking a regression there to shoehorn GPTQ's shape in.
+
+    ``gate_up`` fuses ``gate_proj`` + ``up_proj`` (the checkpoint stores
+    them as separate quantized tensors, not pre-fused):
+    ``qweight``/``qzeros``/``scales`` concatenate along their ``N``
+    (output-channel) axis; ``g_idx`` does not change (same ``K``/
+    ``group_size`` for both halves -- asserted here, not assumed, and
+    likewise asserted equal across every expert of a bank, since it is
+    architecturally shared, never per-expert -- see :class:`GptqExpertBank`).
+
+    Returns ``(gate_up_banks, down_banks)``, each a list of ``num_layers``
+    :class:`GptqExpertBank`. Every tensor stays in its packed, quantized
+    form the whole way through -- never dequantized here (see
+    :class:`GptqExpertBank`'s docstring for why).
+
+    Simplification versus ``stream_moe_expert_sources``: this buffers a
+    whole layer's raw per-expert tensors before finalizing (not the
+    incremental per-layer-as-soon-as-complete finalization the bf16 path
+    uses to bound peak RAM during load) -- real, packed GPTQ rows are ~4x
+    smaller than their bf16 equivalents to begin with, so this is a smaller
+    concern here; revisit if issue #138's real-checkpoint validation shows
+    it matters.
+    """
+    buf: Dict[Tuple[int, str], Dict[int, Dict[str, Dict[str, torch.Tensor]]]] = {}
+    seen_layers: Dict[str, set] = {"gate_up": set(), "down": set()}
+
+    for name, tensor in tensors:
+        info = _parse_gptq_expert_key(name)
+        if info is None:
+            raise ValueError(f"Unexpected GPTQ expert weight key: {name}")
+        layer, proj, expert_id, component = info
+        bank_name = "gate_up" if proj in ("gate_proj", "up_proj") else "down"
+        if not (0 <= layer < config.num_layers):
+            raise ValueError(f"Unexpected MoE expert layer {layer}; expected [0, {config.num_layers})")
+        if not (0 <= expert_id < config.num_experts):
+            raise ValueError(f"Unexpected MoE expert id {expert_id} in layer {layer}")
+        by_expert = buf.setdefault((layer, bank_name), {})
+        by_proj = by_expert.setdefault(expert_id, {})
+        by_component = by_proj.setdefault(proj, {})
+        if component in by_component:
+            raise ValueError(f"Duplicate GPTQ component {component!r} for layer {layer} expert {expert_id} {proj}")
+        by_component[component] = tensor
+        seen_layers[bank_name].add(layer)
+
+    missing = {
+        name: sorted(set(range(config.num_layers)) - seen)
+        for name, seen in seen_layers.items()
+        if seen != set(range(config.num_layers))
+    }
+    if missing:
+        raise ValueError(f"Missing GPTQ MoE expert source layers: {missing}")
+
+    gate_up_banks = [
+        _finalize_gptq_bank(buf[(layer, "gate_up")], config.num_experts, fuse=True, layer=layer)
+        for layer in range(config.num_layers)
+    ]
+    down_banks = [
+        _finalize_gptq_bank(buf[(layer, "down")], config.num_experts, fuse=False, layer=layer)
+        for layer in range(config.num_layers)
+    ]
+    return gate_up_banks, down_banks
+
+
+def _finalize_gptq_bank(
+    by_expert: Dict[int, Dict[str, Dict[str, torch.Tensor]]],
+    num_experts: int,
+    *,
+    fuse: bool,
+    layer: int,
+) -> GptqExpertBank:
+    if set(by_expert) != set(range(num_experts)):
+        missing = sorted(set(range(num_experts)) - set(by_expert))
+        raise ValueError(f"Layer {layer}: missing GPTQ experts {missing}")
+
+    per_expert_rows = []
+    for e in range(num_experts):
+        by_proj = by_expert[e]
+        if fuse:
+            gate = by_proj.get("gate_proj")
+            up = by_proj.get("up_proj")
+            if gate is None or up is None:
+                raise ValueError(f"Layer {layer} expert {e}: missing gate_proj/up_proj GPTQ components")
+            if not torch.equal(gate["g_idx"], up["g_idx"]):
+                raise ValueError(
+                    f"Layer {layer} expert {e}: gate_proj/up_proj g_idx mismatch (different group_size/K?)"
+                )
+            qweight = torch.cat([gate["qweight"], up["qweight"]], dim=1)
+            qzeros = torch.cat([gate["qzeros"], up["qzeros"]], dim=1)
+            scales = torch.cat([gate["scales"], up["scales"]], dim=1)
+            g_idx = gate["g_idx"]
+        else:
+            down = by_proj.get("down_proj")
+            if down is None:
+                raise ValueError(f"Layer {layer} expert {e}: missing down_proj GPTQ components")
+            qweight, qzeros, scales, g_idx = down["qweight"], down["qzeros"], down["scales"], down["g_idx"]
+        per_expert_rows.append((qweight, qzeros, scales, g_idx))
+
+    # g_idx is shared, not per-expert (see GptqExpertBank docstring): assert
+    # every expert's copy agrees, then keep only one -- stacking it into an
+    # [E, K] bank would be real, avoidable duplication of identical data.
+    g_idx0 = per_expert_rows[0][3]
+    for e, row in enumerate(per_expert_rows[1:], start=1):
+        if not torch.equal(row[3], g_idx0):
+            raise ValueError(
+                f"Layer {layer}: g_idx differs between expert 0 and expert {e} "
+                "(unexpected -- group_size/K should be architecture-constant, identical for every expert)"
+            )
+
+    # _stack_expert_rows (not torch.stack): the torch XPU build mishandles a
+    # direct cat/stack of 2-D per-expert rows along a new leading dim --
+    # unsqueeze-then-cat is the reliable path this codebase already
+    # standardizes on (see _stack_expert_rows's own docstring).
+    return GptqExpertBank(
+        qweight=_stack_expert_rows([row[0] for row in per_expert_rows]),
+        qzeros=_stack_expert_rows([row[1] for row in per_expert_rows]),
+        scales=_stack_expert_rows([row[2] for row in per_expert_rows]),
+        g_idx=g_idx0,
+    )
+
+
 __all__ = [
     "load_weight",
     "load_moe_expert_sources",
     "dummy_moe_expert_sources",
     "iter_safetensors",
     "_PlainBank",
+    "GptqExpertBank",
+    "stream_moe_expert_sources_gptq",
 ]

--- a/tests/test_qwen35_gptq_loader.py
+++ b/tests/test_qwen35_gptq_loader.py
@@ -103,3 +103,103 @@ def test_raises_on_an_incomplete_projection_at_stream_end():
     pairs = [("p.qweight", qweight), ("p.qzeros", qzeros), ("p.scales", scales)]  # missing g_idx
     with pytest.raises(ValueError, match="incomplete"):
         list(_dequantize_gptq_stream(iter(pairs)))
+
+
+# ---------------------------------------------------------------------------
+# iter_weights bank-only mode (issue moe-quant-banks-pack, #135): GPTQ
+# tensors must pass through RAW (not dequantized) when include_moe_experts=
+# True, include_non_moe=False -- the offload MoE-bank fabricator's call
+# shape. Dequantizing every expert to bf16 at load time is a 4x expansion
+# that blows the host RAM budget for a real-scale checkpoint (issue #134).
+# ---------------------------------------------------------------------------
+
+
+def test_bank_only_mode_yields_raw_gptq_components_not_dequantized(monkeypatch, tmp_path):
+    import freetoken.models.qwen3_5_moe as qwen35moe
+
+    k, n, group_size = 8, 8, 8
+    qweight, qzeros, scales, g_idx = _fake_gptq_projection(k, n, group_size)
+    prefix = "model.language_model.layers.0.mlp.experts.0.gate_proj"
+    raw_pairs = [
+        (prefix + ".qweight", qweight),
+        (prefix + ".qzeros", qzeros),
+        (prefix + ".scales", scales),
+        (prefix + ".g_idx", g_idx),
+    ]
+
+    monkeypatch.setattr(qwen35moe, "_iter_safetensors", lambda model_path, device: iter(raw_pairs))
+    monkeypatch.setattr(qwen35moe, "_cfg_for_path", lambda model_path: None)  # fall back to the substring heuristic
+
+    out = dict(
+        qwen35moe.iter_weights(
+            "unused-path", torch.device("cpu"), include_moe_experts=True, include_non_moe=False
+        )
+    )
+    # Raw component names survive (remapped model.language_model.* -> model.*),
+    # not a single dequantized "...gate_proj.weight".
+    assert set(out) == {
+        "model.layers.0.mlp.experts.0.gate_proj.qweight",
+        "model.layers.0.mlp.experts.0.gate_proj.qzeros",
+        "model.layers.0.mlp.experts.0.gate_proj.scales",
+        "model.layers.0.mlp.experts.0.gate_proj.g_idx",
+    }
+    assert out["model.layers.0.mlp.experts.0.gate_proj.qweight"].dtype == torch.int32
+    torch.testing.assert_close(out["model.layers.0.mlp.experts.0.gate_proj.qweight"], qweight)
+    torch.testing.assert_close(out["model.layers.0.mlp.experts.0.gate_proj.g_idx"], g_idx)
+
+
+def test_bank_only_mode_still_drops_non_expert_tensors(monkeypatch):
+    import freetoken.models.qwen3_5_moe as qwen35moe
+
+    k, n, group_size = 8, 8, 8
+    qweight, qzeros, scales, g_idx = _fake_gptq_projection(k, n, group_size)
+    prefix = "model.language_model.layers.0.mlp.experts.0.down_proj"
+    raw_pairs = [
+        ("model.language_model.embed_tokens.weight", torch.randn(4, 4)),
+        (prefix + ".qweight", qweight),
+        (prefix + ".qzeros", qzeros),
+        (prefix + ".scales", scales),
+        (prefix + ".g_idx", g_idx),
+        ("model.language_model.layers.0.linear_attn.norm.weight", torch.randn(4)),
+    ]
+    monkeypatch.setattr(qwen35moe, "_iter_safetensors", lambda model_path, device: iter(raw_pairs))
+    monkeypatch.setattr(qwen35moe, "_cfg_for_path", lambda model_path: None)
+
+    out = dict(
+        qwen35moe.iter_weights(
+            "unused-path", torch.device("cpu"), include_moe_experts=True, include_non_moe=False
+        )
+    )
+    assert set(out) == {
+        "model.layers.0.mlp.experts.0.down_proj.qweight",
+        "model.layers.0.mlp.experts.0.down_proj.qzeros",
+        "model.layers.0.mlp.experts.0.down_proj.scales",
+        "model.layers.0.mlp.experts.0.down_proj.g_idx",
+    }
+
+
+def test_non_bank_only_mode_still_dequantizes_eagerly(monkeypatch):
+    """The non-bank-only call shape (e.g. a hypothetical fully-in-VRAM
+    consumer) keeps today's eager-dequant behavior -- only the offload
+    bank-fabricator's call shape (include_non_moe=False) changed."""
+    import freetoken.models.qwen3_5_moe as qwen35moe
+
+    k, n, group_size = 8, 8, 8
+    qweight, qzeros, scales, g_idx = _fake_gptq_projection(k, n, group_size)
+    prefix = "model.language_model.layers.0.mlp.experts.0.gate_proj"
+    raw_pairs = [
+        (prefix + ".qweight", qweight),
+        (prefix + ".qzeros", qzeros),
+        (prefix + ".scales", scales),
+        (prefix + ".g_idx", g_idx),
+    ]
+    monkeypatch.setattr(qwen35moe, "_iter_safetensors", lambda model_path, device: iter(raw_pairs))
+    monkeypatch.setattr(qwen35moe, "_cfg_for_path", lambda model_path: None)
+
+    out = dict(
+        qwen35moe.iter_weights(
+            "unused-path", torch.device("cpu"), include_moe_experts=True, include_non_moe=True
+        )
+    )
+    assert set(out) == {"model.layers.0.mlp.experts.0.gate_proj.weight"}
+    assert out["model.layers.0.mlp.experts.0.gate_proj.weight"].dtype == torch.bfloat16

--- a/tests/test_weight_gptq_banks.py
+++ b/tests/test_weight_gptq_banks.py
@@ -1,0 +1,189 @@
+"""``stream_moe_expert_sources_gptq``: packed GPTQ expert banks stay packed
+(issue `moe-quant-banks-pack`, #135, part of epic #134).
+
+CPU-only, synthetic fixtures -- the whole point of this issue is that these
+banks are NEVER dequantized here (that happens lazily, per-expert, at
+compute time, issue #137); the round-trip check below dequantizes only for
+test verification, via the already-shipped ``dequantize_gptq_int4`` (#132).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4
+from freetoken.models.weight import GptqExpertBank, stream_moe_expert_sources_gptq
+
+
+def _pack_nibbles(codes: list[int]) -> int:
+    word = 0
+    for i, c in enumerate(codes):
+        word |= c << (4 * i)
+    # A packed word with the sign bit (31) set is a legitimate int32 bit
+    # pattern (dequantize_gptq_int4 masks after shifting, so arithmetic vs
+    # logical right-shift makes no difference to the extracted nibble -- see
+    # gptq_linear._unpack_int32) but torch.tensor(..., dtype=torch.int32)
+    # rejects a Python int >= 2**31 as an overflow. Fold it to the equivalent
+    # two's-complement negative value first.
+    if word >= 1 << 31:
+        word -= 1 << 32
+    return word
+
+
+def _gptq_projection(k: int, n: int, group_size: int, *, weight_code: int, zero_code: int, scale: float):
+    """A small, real (not random-garbage) GPTQ-packed projection: every row
+    uses the same weight code / zero-point / scale, so the dequantized value
+    is a known constant: ``scale * (weight_code - (zero_code + 1))``."""
+    assert k % 8 == 0 and n % 8 == 0 and k % group_size == 0
+    n_groups = k // group_size
+    qweight = torch.tensor([[_pack_nibbles([weight_code] * 8)] * n for _ in range(k // 8)], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([zero_code] * 8)] * (n // 8) for _ in range(n_groups)], dtype=torch.int32)
+    scales = torch.full((n_groups, n), scale)
+    g_idx = torch.tensor([i // group_size for i in range(k)], dtype=torch.int32)
+    return qweight, qzeros, scales, g_idx
+
+
+def _expert_stream(config, *, gate_kwargs, up_kwargs, down_kwargs):
+    """Yield ``(name, tensor)`` pairs for every expert of every layer, in the
+    real checkpoint's raw per-expert GPTQ key spelling."""
+    for layer in range(config.num_layers):
+        for e in range(config.num_experts):
+            for proj, kwargs in (("gate_proj", gate_kwargs), ("up_proj", up_kwargs), ("down_proj", down_kwargs)):
+                qweight, qzeros, scales, g_idx = _gptq_projection(**kwargs)
+                prefix = f"model.layers.{layer}.mlp.experts.{e}.{proj}"
+                yield prefix + ".qweight", qweight
+                yield prefix + ".qzeros", qzeros
+                yield prefix + ".scales", scales
+                yield prefix + ".g_idx", g_idx
+
+
+def test_packed_bank_shapes_match_the_documented_contract():
+    config = SimpleNamespace(num_layers=2, num_experts=3)
+    k, n, group_size = 16, 8, 8
+    kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=7, scale=0.5)
+    stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_gptq(stream, config)
+
+    assert len(gate_up_banks) == config.num_layers
+    assert len(down_banks) == config.num_layers
+    for bank in gate_up_banks:
+        assert isinstance(bank, GptqExpertBank)
+        # gate_up fuses gate_proj+up_proj on the N axis -> N doubles.
+        assert bank.qweight.shape == (config.num_experts, k // 8, 2 * n)
+        assert bank.qzeros.shape == (config.num_experts, k // group_size, 2 * n // 8)
+        assert bank.scales.shape == (config.num_experts, k // group_size, 2 * n)
+        assert bank.g_idx.shape == (k,)
+        assert bank.qweight.dtype == torch.int32
+        assert bank.qzeros.dtype == torch.int32
+        assert bank.g_idx.dtype == torch.int32
+    for bank in down_banks:
+        assert bank.qweight.shape == (config.num_experts, k // 8, n)
+        assert bank.qzeros.shape == (config.num_experts, k // group_size, n // 8)
+        assert bank.scales.shape == (config.num_experts, k // group_size, n)
+        assert bank.g_idx.shape == (k,)
+
+
+def test_packed_bank_round_trips_to_the_known_fixture_value():
+    config = SimpleNamespace(num_layers=1, num_experts=2)
+    k, n, group_size = 16, 8, 8
+    # weight_code=5, zero_code=7 (+1 correction -> 8), scale=0.5 -> 0.5*(5-8) = -1.5.
+    kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=7, scale=0.5)
+    stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_gptq(stream, config)
+
+    for e in range(config.num_experts):
+        down = dequantize_gptq_int4(
+            down_banks[0].qweight[e], down_banks[0].qzeros[e], down_banks[0].scales[e], down_banks[0].g_idx,
+            out_dtype=torch.float32,
+        )
+        # dequantize_gptq_int4 returns [K, N] (in_features, out_features).
+        torch.testing.assert_close(down, torch.full((k, n), -1.5), atol=1e-2, rtol=0)
+
+        gate_up = dequantize_gptq_int4(
+            gate_up_banks[0].qweight[e], gate_up_banks[0].qzeros[e], gate_up_banks[0].scales[e], gate_up_banks[0].g_idx,
+            out_dtype=torch.float32,
+        )
+        torch.testing.assert_close(gate_up, torch.full((k, 2 * n), -1.5), atol=1e-2, rtol=0)
+
+
+def test_gate_up_concatenation_preserves_two_independently_quantized_halves():
+    """A real test of the concat axis, not a trivial no-op: gate_proj and
+    up_proj are quantized with DIFFERENT codes/scales, so the fused bank's
+    two halves must dequantize back to their own distinct source values."""
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    k, n, group_size = 16, 8, 8
+    gate_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=3, zero_code=8, scale=0.25)  # -> 0.25*(3-9) = -1.5
+    up_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=10, zero_code=6, scale=1.0)  # -> 1.0*(10-7) = 3.0
+    down_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=7, scale=0.5)
+    stream = _expert_stream(config, gate_kwargs=gate_kwargs, up_kwargs=up_kwargs, down_kwargs=down_kwargs)
+
+    gate_up_banks, _down_banks = stream_moe_expert_sources_gptq(stream, config)
+    bank = gate_up_banks[0]
+
+    fused = dequantize_gptq_int4(bank.qweight[0], bank.qzeros[0], bank.scales[0], bank.g_idx, out_dtype=torch.float32)
+    # dequantize_gptq_int4 returns [K, N]; gate/up were concatenated on the N
+    # (output-channel, dim=1) axis, so the two halves split along columns.
+    assert fused.shape == (k, 2 * n)
+    gate_half, up_half = fused[:, :n], fused[:, n:]
+    torch.testing.assert_close(gate_half, torch.full((k, n), -1.5))
+    torch.testing.assert_close(up_half, torch.full((k, n), 3.0))
+
+
+def test_g_idx_mismatch_between_gate_and_up_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    k, n = 16, 8
+    gate_kwargs = dict(k=k, n=n, group_size=8, weight_code=5, zero_code=7, scale=0.5)
+    up_kwargs = dict(k=k, n=n, group_size=4, weight_code=5, zero_code=7, scale=0.5)  # different group_size -> different g_idx
+    down_kwargs = gate_kwargs
+    stream = _expert_stream(config, gate_kwargs=gate_kwargs, up_kwargs=up_kwargs, down_kwargs=down_kwargs)
+
+    with pytest.raises(ValueError, match="g_idx mismatch"):
+        stream_moe_expert_sources_gptq(stream, config)
+
+
+def test_g_idx_mismatch_across_experts_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=2)
+    k, n = 16, 8
+
+    def stream():
+        for e, group_size in enumerate((8, 4)):  # expert 0 vs expert 1 disagree
+            kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=7, scale=0.5)
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                qweight, qzeros, scales, g_idx = _gptq_projection(**kwargs)
+                prefix = f"model.layers.0.mlp.experts.{e}.{proj}"
+                yield prefix + ".qweight", qweight
+                yield prefix + ".qzeros", qzeros
+                yield prefix + ".scales", scales
+                yield prefix + ".g_idx", g_idx
+
+    with pytest.raises(ValueError, match="g_idx differs"):
+        stream_moe_expert_sources_gptq(stream(), config)
+
+
+def test_missing_layer_raises():
+    config = SimpleNamespace(num_layers=2, num_experts=1)
+    kwargs = dict(k=8, n=8, group_size=8, weight_code=5, zero_code=7, scale=0.5)
+
+    def stream():
+        # only layer 0, layer 1 never appears
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            qweight, qzeros, scales, g_idx = _gptq_projection(**kwargs)
+            prefix = f"model.layers.0.mlp.experts.0.{proj}"
+            yield prefix + ".qweight", qweight
+            yield prefix + ".qzeros", qzeros
+            yield prefix + ".scales", scales
+            yield prefix + ".g_idx", g_idx
+
+    with pytest.raises(ValueError, match="Missing GPTQ MoE expert source layers"):
+        stream_moe_expert_sources_gptq(stream(), config)
+
+
+def test_unexpected_key_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    with pytest.raises(ValueError, match="Unexpected GPTQ expert weight key"):
+        stream_moe_expert_sources_gptq(iter([("not.a.gptq.key", torch.zeros(1))]), config)


### PR DESCRIPTION
## Summary
Closes the RAM-explosion gap #133 left open (see epic #134): `iter_weights` previously dequantized every GPTQ-packed expert to bf16 at load time -- a 4x expansion that would need ~88GB for the real `Qwen3.5-35B-A3B-GPTQ-Int4` checkpoint (22.73GiB packed) on this box's 29GB RAM, several times more than even the unquantized bf16 checkpoint's own ~70GB.

- `models/weight.py`: new `GptqExpertBank` dataclass + `stream_moe_expert_sources_gptq()`, the quantized-format sibling of `stream_moe_expert_sources` -- kept separate rather than folded in (GPTQ's four-tensor-per-projection shape does not fit that function's contract, and the bf16 path is well-tested and used by every other model; not worth risking a regression there). Banks stay packed the whole way through: `qweight`/`qzeros`/`scales` are `[E, ...]` (one row per expert, matching ADR 0002's per-expert-row convention); `g_idx` is **one shared `[K]` tensor per projection type per layer** (not per-expert -- `g_idx[k] = k // group_size` depends only on `K`/`group_size`, both architecture constants, identical across every expert, so stacking it per-expert would be pure, avoidable duplication). `gate_up` fuses `gate_proj`+`up_proj` by concatenating `qweight`/`qzeros`/`scales` on their N axis (the real checkpoint stores them as separate quantized tensors, not pre-fused) -- `g_idx` agreement between gate and up, and across every expert of a bank, is asserted, not assumed. Uses the existing `_stack_expert_rows` helper (not `torch.stack`) for the per-expert stacking, matching this file's own documented XPU workaround for a `torch.stack`-equivalent bug on this build.
- `models/weight.py`: `_expert_source_info` now rejects a GPTQ-suffixed key (`.qweight`/`.qzeros`/`.scales`/`.g_idx`) loudly instead of silently misparsing it as if it were a plain dense weight tensor -- a real danger once `iter_weights` stops eagerly dequantizing (a raw int32-packed `qweight` tensor consumed as if it were the actual dense weight would be garbage, not an error, without this guard).
- `models/qwen3_5_moe/__init__.py`: `iter_weights`'s bank-only call shape (`include_moe_experts=True, include_non_moe=False` -- the offload MoE-bank fabricator's call) now passes GPTQ components through raw and unmodified instead of eagerly dequantizing them; every other call shape (e.g. a hypothetical fully-in-VRAM consumer) keeps today's eager-dequant behavior unchanged. Also guards dtype-casting: a raw GPTQ component is never cast to a requested dense dtype (`qweight`/`qzeros`/`g_idx` are int32; casting to bf16 would corrupt the packed bits, not "convert" them).

Dequantization happens lazily, per-expert, at compute time against whichever rows the offload cache's device slot pool has fetched for the current step -- issue #137, being built in parallel against this same documented shape contract. The `"gptq_int4"` bank-schema registration in `OffloadMoeCache` (issue #136) is also being built in parallel.

## Test plan
- [x] 15 new tests: `tests/test_weight_gptq_banks.py` (7) exercises `stream_moe_expert_sources_gptq` directly -- packed bank shapes match the documented contract, round-trip to a known fixture value, gate_proj/up_proj concatenation preserves two **independently** quantized halves (not a trivial no-op), g_idx-mismatch detection (both gate/up disagreement and cross-expert disagreement), missing-layer and unexpected-key errors. `tests/test_qwen35_gptq_loader.py` gained 3 more: bank-only mode yields raw (not dequantized) GPTQ components, still correctly drops non-expert tensors, and non-bank-only mode is unaffected
- [x] `pytest tests/ -m "not xpu"`: 349 passed (+15 net), the one pre-existing unrelated failure unchanged
- [x] `.venv` (torch-free): 202 passed, 40 skipped, 0 failures

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve