### PR TITLE
feat(moe): dequantize GPTQ experts at compute time, not load time (issue #137)

### DIFF
--- a/python/freetoken/kernel/triton/gptq_linear.py
+++ b/python/freetoken/kernel/triton/gptq_linear.py
@@ -99,6 +99,31 @@ def dequantize_gptq_int4(
     )
 
 
+def dequantize_gptq_int4_sequential_groups(
+    qweight: torch.Tensor,
+    qzeros: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    group_size: int,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """:func:`dequantize_gptq_int4`, but for the ``desc_act=False`` case (the
+    real checkpoint's own setting, and the only case this port implements) --
+    computes ``g_idx`` implicitly as ``k // group_size`` instead of requiring
+    the caller to have one in hand.
+
+    ``g_idx`` is deterministic and identical for every expert of a given
+    projection type/layer under ``desc_act=False`` (it depends only on ``K``
+    and ``group_size``, both architecture constants) -- offload-cache bank
+    schemas (issue moe-quant-banks-schema, #136) can therefore skip storing
+    it per-expert entirely and this helper reconstructs it on the fly, once
+    per call, at negligible cost (a single ``[K]`` int32 tensor).
+    """
+    k = qweight.shape[0] * (32 // _BITS)
+    g_idx = torch.arange(k, device=qweight.device, dtype=torch.int32) // group_size
+    return dequantize_gptq_int4(qweight, qzeros, scales, g_idx, out_dtype=out_dtype)
+
+
 def gptq_linear(
     x: torch.Tensor,
     qweight: torch.Tensor,

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1263,11 +1263,30 @@ class _Qwen35MoE:
         # fraction is the fine per-step split for the layers it does not name).
         if self._is_cpu_layer(ctx):
             return self._forward_cpu(flat, top_idx, top_w, ctx, batch)
+        # Issue moe-quant-banks-compute (#137): the CPU half's math
+        # (_cpu_subset_math) reads model.moe_cache.bank_sources["gate_up"] /
+        # ["down"] directly -- the "bf16" schema's bank names -- and runs
+        # plain-float matmuls on them. A "gptq_int4" cache's bank_sources use
+        # different names entirely (qweight_gate_up, ...), so that lookup
+        # would KeyError. Rather than teach the CPU half to dequantize too
+        # (real, separable follow-up work -- the CPU path has none of the
+        # slot-cache/copy_missing machinery SlotWeightAccessor hooks into, so
+        # it would need its own dequant-and-cache logic), this format is
+        # excluded from the hybrid split for now: force fetch_frac to 1.0 so
+        # every miss rides PCIe through the (already gptq_int4-aware)
+        # offload path below. A documented, deliberate tradeoff (this
+        # issue's own accept criteria explicitly allows it as a first cut),
+        # not a silent gap -- gptq_int4 previously would have crashed loudly
+        # here (KeyError) rather than produced wrong numbers, and now simply
+        # never reaches that code path.
+        cache_quant_format = getattr(getattr(model, "moe_cache", None), "quant_format", "bf16")
         # The fetch fraction f (share of misses PCIe-fetched, the rest on CPU).
         # Read through ctx.model (the loader stores it there); a test-harness
         # Context that sets none falls back to the block-local 0.0 (pure offload),
         # which is the correct no-split default.
         fetch_frac = float(getattr(model, "moe_hybrid_fetch_fraction", 0.0) or 0.0)
+        if cache_quant_format == "gptq_int4":
+            fetch_frac = 1.0
         if fetch_frac <= 0.0:
             # No usable profile -> every miss rides PCIe (pure offload).
             return self._forward_offload(flat, top_idx, top_w, ctx, batch)
@@ -1436,8 +1455,16 @@ class _Qwen35MoE:
         #    An expert the pool evicted maps to -1 -> clamped to 0 with valid=False.
         slots = cache.slot_for_id[layer_id].to("cpu").tolist()
         S = cache.cache_size
-        gu, dn = cache.bank_views()  # ([S, 2I, H], [S, H, I])
         intermediate = int(model.config.moe_intermediate_size)
+        # SlotWeightAccessor abstracts gu[s_i, ...]/dn[s_i] bf16 indexing over a
+        # quantized bank format too (issue moe-quant-banks-compute, #137): for
+        # "bf16" this is the exact same plain-tensor indexing as before (zero
+        # behavior change); for "gptq_int4" it dequantizes each distinct
+        # resident slot at most once per step, from the packed banks, never
+        # the whole checkpoint (the RAM-saving point of the whole epic, #134).
+        from freetoken.moe.offload_cache import SlotWeightAccessor
+
+        slot_weights = SlotWeightAccessor(cache, intermediate)
         dev = flat.device
         out = torch.zeros_like(flat)
         routed_cpu = torch.empty(B, k, dtype=torch.int64)
@@ -1506,10 +1533,11 @@ class _Qwen35MoE:
         # loop. index_add_ accumulates exactly as `out[sel] += ...` did.
         for j, s_i, rows in groups:
             idx = torch.tensor(rows, dtype=torch.long, device=dev)
+            gate_w, up_w, down_w = slot_weights.get(s_i)
             y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(
-                gu[s_i, 0:intermediate],
-                gu[s_i, intermediate : 2 * intermediate],
-                dn[s_i],
+                gate_w,
+                up_w,
+                down_w,
                 flat.index_select(0, idx),
             )
             out.index_add_(0, idx, y)

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -581,8 +581,16 @@ class _Qwen3MoE(nn.Module):
         #    An expert the pool evicted maps to -1 -> clamped to 0, valid=False.
         slots = cache.slot_for_id[layer_id].to("cpu").tolist()
         S = cache.cache_size
-        gu, dn = cache.bank_views()  # ([S, 2I, H], [S, H, I])
         intermediate = int(model.config.moe_intermediate_size)
+        # SlotWeightAccessor abstracts gu[s_i, ...]/dn[s_i] bf16 indexing over a
+        # quantized bank format too (issue moe-quant-banks-compute, #137): for
+        # "bf16" this is the exact same plain-tensor indexing as before (zero
+        # behavior change); for "gptq_int4" it dequantizes each distinct
+        # resident slot at most once per step, from the packed banks, never
+        # the whole checkpoint (the RAM-saving point of the whole epic, #134).
+        from freetoken.moe.offload_cache import SlotWeightAccessor
+
+        slot_weights = SlotWeightAccessor(cache, intermediate)
         dev = flat.device
         out = torch.zeros_like(flat)
         routed_cpu = torch.empty(B, k, dtype=torch.int64)
@@ -638,10 +646,11 @@ class _Qwen3MoE(nn.Module):
         #    the loop).
         for j, s_i, rows in groups:
             idx = torch.tensor(rows, dtype=torch.long, device=dev)
+            gate_w, up_w, down_w = slot_weights.get(s_i)
             y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(
-                gu[s_i, 0:intermediate],
-                gu[s_i, intermediate : 2 * intermediate],
-                dn[s_i],
+                gate_w,
+                up_w,
+                down_w,
                 flat.index_select(0, idx),
             )
             out.index_add_(0, idx, y)
@@ -672,11 +681,26 @@ class _Qwen3MoE(nn.Module):
         cleanly to the offload path there. The split applies to the routed-expert
         decode step, where the q* balance lives.
         """
-        # The fetch fraction f (share of misses PCIe-fetched, the rest on CPU).
-        # Read through the model (the loader stores it there); a test-harness
-        # model that sets none falls back to the block-local 0.0 (pure offload),
-        # the correct no-split default.
+        # Issue moe-quant-banks-compute (#137): the CPU half's math
+        # (_cpu_subset_math) reads model.moe_cache.bank_sources["gate_up"] /
+        # ["down"] directly -- the "bf16" schema's bank names -- and runs
+        # plain-float matmuls on them. A "gptq_int4" cache's bank_sources use
+        # different names entirely (qweight_gate_up, ...), so that lookup
+        # would KeyError. Rather than teach the CPU half to dequantize too
+        # (real, separable follow-up work -- the CPU path has none of the
+        # slot-cache/copy_missing machinery SlotWeightAccessor hooks into, so
+        # it would need its own dequant-and-cache logic), this format is
+        # excluded from the hybrid split for now: force fetch_frac to 1.0 so
+        # every miss rides PCIe through the (already gptq_int4-aware)
+        # offload path below. A documented, deliberate tradeoff (this
+        # issue's own accept criteria explicitly allows it as a first cut),
+        # not a silent gap -- gptq_int4 previously would have crashed loudly
+        # here (KeyError) rather than produced wrong numbers, and now simply
+        # never reaches that code path.
+        cache_quant_format = getattr(getattr(model, "moe_cache", None), "quant_format", "bf16")
         fetch_frac = float(getattr(model, "moe_hybrid_fetch_fraction", 0.0) or 0.0)
+        if cache_quant_format == "gptq_int4":
+            fetch_frac = 1.0
         if fetch_frac <= 0.0:
             # No usable profile -> every miss rides PCIe (pure offload).
             return self._forward_offload(flat, top_idx, top_w, model, batch)

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -602,24 +602,6 @@ class OffloadMoeCache:
         return self.device.type == "xpu" and is_xpu_available()
 
 
-# Bank name convention this port uses for the "gptq_int4" schema (issue
-# moe-quant-banks-schema, #136): three packed tensors per projection slot
-# (qweight/qzeros/scales), no g_idx bank -- g_idx is deterministic under
-# desc_act=False (the real checkpoint's setting, the only case this port
-# implements) and is reconstructed on the fly from group_size instead of
-# being stored per-expert (see gptq_linear.dequantize_gptq_int4_sequential_
-# groups). If #136 registers different bank names, update this tuple to
-# match -- it is the single place that name is spelled.
-GPTQ_INT4_BANK_NAMES: tuple[str, ...] = (
-    "qweight_gate_up",
-    "qzeros_gate_up",
-    "scales_gate_up",
-    "qweight_down",
-    "qzeros_down",
-    "scales_down",
-)
-
-
 class SlotWeightAccessor:
     """Per-step accessor for one MoE layer's resident-slot expert weights,
     abstracting the offload forward's ``gu[s_i, ...]`` / ``dn[s_i]`` bf16
@@ -642,13 +624,29 @@ class SlotWeightAccessor:
         self._cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         if self.quant_format == "gptq_int4":
             self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
-            missing = [n for n in GPTQ_INT4_BANK_NAMES if n not in self._banks]
-            if missing:
+            # g_idx is deliberately not a bank (see _BANK_SCHEMAS["gptq_int4"]'s
+            # own comment) -- get() below reconstructs it implicitly from
+            # group_size, correct for this port's only supported case
+            # (desc_act=False, the real checkpoint's own setting).
+            #
+            # No default here on purpose: a wrong-but-plausible group_size
+            # (e.g. silently falling back to some other checkpoint's value)
+            # would dequantize with the wrong group boundaries and produce
+            # silently-wrong-but-finite numbers, not a crash -- caught during
+            # this class's own test-writing, when a fixture forgot to set it
+            # and got a real, non-obvious 50%-of-elements mismatch instead of
+            # an error. The loader (issue #135 / #138) must set
+            # ``cache.gptq_group_size`` from the checkpoint's own
+            # ``quantization_config.group_size`` before any gptq_int4 forward
+            # runs.
+            group_size = getattr(cache, "gptq_group_size", None)
+            if group_size is None:
                 raise ValueError(
-                    f"gptq_int4 schema is missing expected bank(s) {missing}; "
-                    f"registered banks are {sorted(self._banks)}"
+                    "OffloadMoeCache.gptq_group_size is not set -- the loader must set it "
+                    "from the checkpoint's quantization_config.group_size before any "
+                    "gptq_int4 forward pass runs (SlotWeightAccessor refuses to guess)"
                 )
-            self._group_size = int(getattr(cache, "gptq_group_size", 128))
+            self._group_size = int(group_size)
         else:
             self._gu, self._dn = cache.bank_views()
 

--- a/tests/test_gptq_quant.py
+++ b/tests/test_gptq_quant.py
@@ -11,7 +11,11 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4, gptq_linear
+from freetoken.kernel.triton.gptq_linear import (
+    dequantize_gptq_int4,
+    dequantize_gptq_int4_sequential_groups,
+    gptq_linear,
+)
 
 
 def _pack_nibbles(codes: list[int]) -> int:
@@ -110,3 +114,33 @@ def test_gptq_linear_matches_manual_dequant_matmul():
 
     out = gptq_linear(x, qweight, qzeros, scales, g_idx)
     torch.testing.assert_close(out, ref)
+
+
+def test_sequential_groups_matches_explicit_g_idx():
+    """dequantize_gptq_int4_sequential_groups (issue #137's compute-time
+    dequant helper -- no stored g_idx) must match dequantize_gptq_int4 given
+    the equivalent explicit g_idx=[k // group_size for k in range(K)]."""
+    K, N, group_size = 16, 8, 4
+    torch.manual_seed(0)
+    codes = [(k * 5) % 16 for k in range(8)]
+    qweight = torch.tensor([[_pack_nibbles(codes)] * N for _ in range(K // 8)], dtype=torch.int32)
+    n_groups = K // group_size
+    qzeros = torch.tensor([[_pack_nibbles([3 + g] * 8)] for g in range(n_groups)], dtype=torch.int32)  # [n_groups, N//8]
+    scales = torch.stack([torch.full((N,), 0.1 * (g + 1)) for g in range(n_groups)])
+    explicit_g_idx = torch.tensor([k // group_size for k in range(K)], dtype=torch.int32)
+
+    expected = dequantize_gptq_int4(qweight, qzeros, scales, explicit_g_idx, out_dtype=torch.float32)
+    got = dequantize_gptq_int4_sequential_groups(qweight, qzeros, scales, group_size=group_size, out_dtype=torch.float32)
+    torch.testing.assert_close(got, expected)
+
+
+def test_sequential_groups_rejects_nothing_extra_and_shapes_correctly():
+    K, N, group_size = 8, 8, 8
+    codes = [(k * 3) % 16 for k in range(8)]
+    qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)]], dtype=torch.int32)
+    scales = torch.full((1, N), 0.25)
+
+    out = dequantize_gptq_int4_sequential_groups(qweight, qzeros, scales, group_size=group_size)
+    assert out.shape == (K, N)
+    assert out.dtype == torch.bfloat16

--- a/tests/test_moe_hybrid_gptq_exclusion.py
+++ b/tests/test_moe_hybrid_gptq_exclusion.py
@@ -1,0 +1,73 @@
+"""gptq_int4 is excluded from the hybrid CPU/PCIe split (issue
+moe-quant-banks-compute, #137): _cpu_subset_math hardcodes the "bf16" bank
+names (model.moe_cache.bank_sources["gate_up"]/["down"]) and would KeyError
+against a "gptq_int4" cache's differently-named banks. _forward_hybrid now
+forces fetch_frac to 1.0 (pure offload, no CPU split) whenever the cache's
+quant_format is "gptq_int4", documented as a deliberate first-cut tradeoff
+rather than teaching the CPU half to dequantize too.
+
+Tests _Qwen3MoE._forward_hybrid (qwen3_moe) directly via a stand-in ``self``
+(unittest.mock), not a real model/engine -- isolates the routing decision
+(does it call _forward_offload or attempt the CPU split?) from real tensor
+math, real weights, or the full loader/engine stack. CPU-only, no XPU.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.qwen3_moe import _Qwen3MoE
+
+
+def _fake_self(*, cache_quant_format: str, fetch_fraction: float = 0.5):
+    """A MagicMock standing in for `self` in _Qwen3MoE._forward_hybrid,
+    with just enough surface for the method body to run without touching
+    real tensors: _is_cpu_layer -> False (not a whole-layer CPU carve-out),
+    _forward_offload / _cpu_subset_math / _hybrid_cpu_pool stubbed."""
+    self_ = MagicMock(spec=_Qwen3MoE)
+    self_._is_cpu_layer.return_value = False
+    self_._forward_offload.return_value = torch.zeros(1)
+    model = MagicMock()
+    model.moe_cache = MagicMock()
+    model.moe_cache.quant_format = cache_quant_format
+    model.moe_hybrid_fetch_fraction = fetch_fraction
+    model.moe_hybrid_max_fetch = -1
+    return self_, model
+
+
+def test_gptq_int4_never_reaches_cpu_split():
+    self_, model = _fake_self(cache_quant_format="gptq_int4", fetch_fraction=0.5)
+    top_idx = torch.zeros(1, 1, dtype=torch.long)
+    top_w = torch.ones(1, 1)
+    flat = torch.zeros(1, 4)
+
+    out = _Qwen3MoE._forward_hybrid(self_, flat, top_idx, top_w, model, batch=None)
+
+    self_._forward_offload.assert_called_once_with(flat, top_idx, top_w, model, None)
+    self_._hybrid_cpu_pool.assert_not_called()
+    torch.testing.assert_close(out, torch.zeros(1))
+
+
+def test_bf16_still_splits_normally_when_fetch_fraction_is_mid_range():
+    """Sanity check that the new guard does not accidentally change bf16
+    behavior: with a mid-range fetch_fraction and quant_format="bf16", the
+    method must proceed into the real split logic (calling _forward_offload
+    with a non-empty `exclude` set -- the CPU-computed experts), not take
+    the fetch_frac<=0 / >=1.0 early-return shortcuts a forced-1.0 gptq_int4
+    call would take instead."""
+    self_, model = _fake_self(cache_quant_format="bf16", fetch_fraction=0.5)
+    top_idx = torch.tensor([[0, 1]])
+    top_w = torch.tensor([[0.5, 0.5]])
+    flat = torch.zeros(1, 4)
+
+    self_._forward_offload.return_value = torch.zeros(1, 4)
+    self_._hybrid_cpu_pool.return_value.submit.return_value.result.return_value = torch.zeros(1, 4)
+
+    _Qwen3MoE._forward_hybrid(self_, flat, top_idx, top_w, model, batch=None)
+
+    self_._forward_offload.assert_called_once()
+    _, kwargs = self_._forward_offload.call_args
+    assert kwargs.get("exclude"), "expected a real, non-empty CPU-expert split (exclude=...)"

--- a/tests/test_moe_slot_weight_accessor.py
+++ b/tests/test_moe_slot_weight_accessor.py
@@ -1,0 +1,165 @@
+"""SlotWeightAccessor: the offload forward's per-slot weight lookup,
+abstracted over bf16 (unchanged) and gptq_int4 (dequantize-at-compute,
+issue moe-quant-banks-compute, #137).
+
+Builds against the shape/bank-name contract #136 registered in
+_BANK_SCHEMAS["gptq_int4"] (qweight/qzeros/scales x {gate_up,down}, no
+g_idx bank -- reconstructed implicitly from group_size). CPU-only, small
+synthetic fixtures, no real checkpoint, no XPU.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4_sequential_groups
+from freetoken.moe.offload_cache import OffloadMoeCache, SlotWeightAccessor
+
+DEVICE = torch.device("cpu")
+
+
+def _pack_nibbles(codes: list[int]) -> int:
+    word = 0
+    for i, c in enumerate(codes):
+        word |= c << (4 * i)
+    return word
+
+
+def _make_packed_projection(k: int, n: int, group_size: int, *, seed: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """A real (non-constant) small GPTQ-packed [K, N] projection: qweight
+    codes and zero-points vary by position (derived from `seed`), so a test
+    can't accidentally pass by everything happening to be uniform."""
+    g = torch.Generator().manual_seed(seed)
+    n_groups = k // group_size
+    codes = torch.randint(0, 16, (k, n), generator=g)
+    qweight = torch.zeros(k // 8, n, dtype=torch.int32)
+    for row8 in range(k // 8):
+        for col in range(n):
+            word = 0
+            for r in range(8):
+                word |= int(codes[row8 * 8 + r, col]) << (4 * r)
+            qweight[row8, col] = word if word < (1 << 31) else word - (1 << 32)
+    zero_codes = torch.randint(1, 15, (n_groups, n), generator=g)  # stored value (post -1)
+    qzeros = torch.zeros(n_groups, n // 8, dtype=torch.int32)
+    for grp in range(n_groups):
+        for col8 in range(n // 8):
+            word = 0
+            for c in range(8):
+                word |= int(zero_codes[grp, col8 * 8 + c] - 1) << (4 * c)
+            qzeros[grp, col8] = word if word < (1 << 31) else word - (1 << 32)
+    scales = torch.rand(n_groups, n, generator=g) * 0.1 + 0.01
+    return qweight, qzeros, scales
+
+
+def _cache_with_gptq_bank(k_gu: int, n_gu: int, k_dn: int, n_dn: int, group_size: int, *, num_experts: int, cache_size: int):
+    cache = OffloadMoeCache(1, num_experts, cache_size, DEVICE, quant_format="gptq_int4")
+    cache.gptq_group_size = group_size  # SlotWeightAccessor reads this (default 128 otherwise)
+    sources = {name: [] for name in ("qweight_gate_up", "qzeros_gate_up", "scales_gate_up", "qweight_down", "qzeros_down", "scales_down")}
+    projections = []  # keep the raw per-expert projections to check against
+    for e in range(num_experts):
+        gu_qw, gu_qz, gu_sc = _make_packed_projection(k_gu, n_gu, group_size, seed=100 + e)
+        dn_qw, dn_qz, dn_sc = _make_packed_projection(k_dn, n_dn, group_size, seed=200 + e)
+        projections.append((gu_qw, gu_qz, gu_sc, dn_qw, dn_qz, dn_sc))
+        for name, t in (
+            ("qweight_gate_up", gu_qw), ("qzeros_gate_up", gu_qz), ("scales_gate_up", gu_sc),
+            ("qweight_down", dn_qw), ("qzeros_down", dn_qz), ("scales_down", dn_sc),
+        ):
+            sources[name].append(t)
+    sources = {name: [torch.stack(v)] for name, v in sources.items()}  # -> [1 layer][E, ...]
+    cache.set_bank_sources(sources)
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    return cache, projections
+
+
+def test_gptq_get_matches_direct_dequant_for_each_expert():
+    hidden, inter, group_size, num_experts = 16, 8, 8, 3
+    cache, projections = _cache_with_gptq_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
+        num_experts=num_experts, cache_size=num_experts,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter)
+
+    for e in range(num_experts):
+        slot = int(cache.slot_for_id[0, e].item())
+        gate_w, up_w, down_w = accessor.get(slot)
+        gu_qw, gu_qz, gu_sc, dn_qw, dn_qz, dn_sc = projections[e]
+
+        # SlotWeightAccessor dequantizes to the bank's own scales dtype (matching
+        # the real checkpoint's fp16/bf16 scales, not a hardcoded dtype); the
+        # fixture's scales are float32, so the expected value must match that.
+        expected_gu = dequantize_gptq_int4_sequential_groups(gu_qw, gu_qz, gu_sc, group_size=group_size, out_dtype=gu_sc.dtype).T
+        expected_dn = dequantize_gptq_int4_sequential_groups(dn_qw, dn_qz, dn_sc, group_size=group_size, out_dtype=dn_sc.dtype).T
+
+        torch.testing.assert_close(gate_w, expected_gu[0:inter])
+        torch.testing.assert_close(up_w, expected_gu[inter : 2 * inter])
+        torch.testing.assert_close(down_w, expected_dn)
+
+
+def test_gptq_get_shapes_match_out_in_convention():
+    hidden, inter, group_size = 16, 8, 8
+    cache, _ = _cache_with_gptq_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
+        num_experts=1, cache_size=1,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    gate_w, up_w, down_w = accessor.get(0)
+    assert gate_w.shape == (inter, hidden)
+    assert up_w.shape == (inter, hidden)
+    assert down_w.shape == (hidden, inter)
+
+
+def test_gptq_get_caches_per_slot_within_one_instance():
+    """A distinct slot is dequantized once, not once per .get() call -- the
+    whole point of this issue (dequantize only the resident working set,
+    at most once per step, never re-derive redundantly)."""
+    hidden, inter, group_size = 16, 8, 8
+    cache, _ = _cache_with_gptq_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
+        num_experts=1, cache_size=1,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    first = accessor.get(0)
+    second = accessor.get(0)
+    for a, b in zip(first, second):
+        assert a.data_ptr() == b.data_ptr()  # identical cached tensor object, not recomputed
+
+
+def test_gptq_accessor_refuses_to_guess_group_size():
+    """A missing cache.gptq_group_size must raise, not silently default to
+    some group size -- a wrong-but-plausible default would dequantize with
+    the wrong group boundaries and produce silently-wrong-but-finite numbers
+    (found the hard way while writing this test file's own fixtures)."""
+    E, hidden, inter = 1, 16, 8
+    cache = OffloadMoeCache(1, E, E, DEVICE, quant_format="gptq_int4")
+    # Deliberately do NOT set cache.gptq_group_size.
+    gu_qw, gu_qz, gu_sc = _make_packed_projection(hidden, 2 * inter, 8, seed=1)
+    dn_qw, dn_qz, dn_sc = _make_packed_projection(inter, hidden, 8, seed=2)
+    cache.set_bank_sources({
+        "qweight_gate_up": [gu_qw.unsqueeze(0)], "qzeros_gate_up": [gu_qz.unsqueeze(0)], "scales_gate_up": [gu_sc.unsqueeze(0)],
+        "qweight_down": [dn_qw.unsqueeze(0)], "qzeros_down": [dn_qz.unsqueeze(0)], "scales_down": [dn_sc.unsqueeze(0)],
+    })
+    with pytest.raises(ValueError, match="gptq_group_size"):
+        SlotWeightAccessor(cache, intermediate=inter)
+
+
+def test_bf16_accessor_behavior_unchanged():
+    """The bf16 path must be a pure passthrough to bank_views() indexing --
+    no dequant, no extra allocation, identical values to reading gu/dn directly."""
+    E, hidden, inter = 2, 16, 8
+    cache = OffloadMoeCache(1, E, E, DEVICE, quant_format="bf16")
+    gu_src = [torch.randn(E, 2 * inter, hidden)]
+    dn_src = [torch.randn(E, hidden, inter)]
+    cache.set_bank_sources({"gate_up": gu_src, "down": dn_src})
+    cache.materialize_layer(0)
+    cache.copy_missing()
+
+    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    gu, dn = cache.bank_views()
+    for e in range(E):
+        slot = int(cache.slot_for_id[0, e].item())
+        gate_w, up_w, down_w = accessor.get(slot)
+        torch.testing.assert_close(gate_w, gu[slot, 0:inter])
+        torch.testing.assert_close(up_w, gu[slot, inter : 2 * inter])
+        torch.testing.assert_close(down_w, dn[slot])


### PR DESCRIPTION
## Summary
Wires GPTQ-Int4 dequantization into the offload MoE forward's per-slot weight lookup, completing the RAM-saving design #134's epic, #135 (packed host banks, PR #142), and #136 (`gptq_int4` bank schema, PR #141) build toward: banks stay packed in host RAM; a slot's `qweight`/`qzeros`/`scales` are dequantized to bf16 only once per distinct resident slot per step, never the whole checkpoint.

**Depends on #141 (issue #136's `gptq_int4` schema) -- this branch is based on top of it and will need a rebase once #141 merges to main, before this one merges.** Built in parallel per #134's design (against the documented shape contract, not by waiting), and the two agents building #136/#137 independently converged on the exact same bank names and g_idx design, so there is no real design mismatch to resolve -- just the normal merge-order rebase.

- `freetoken.kernel.triton.gptq_linear.dequantize_gptq_int4_sequential_groups`: a convenience wrapper around #132's `dequantize_gptq_int4` that reconstructs `g_idx` implicitly from `group_size` instead of requiring a stored tensor -- correct for this port's only supported case (`desc_act=False`), matching #136's own design that `g_idx` lives outside the per-expert bank/LRU-slot machinery entirely.
- `freetoken.moe.offload_cache.SlotWeightAccessor`: the new per-step, per-MoE-layer accessor abstracting `qwen3_moe`/`qwen3_5_moe`'s `gu[s_i, ...]`/`dn[s_i]` bf16 indexing over a quantized bank format too. `"bf16"` is a zero-behavior-change passthrough; `"gptq_int4"` dequantizes each distinct slot at most once per instance.
- Wired into both `qwen3_moe._Qwen3MoE._forward_offload_core` and `qwen3_5_moe._Qwen35MoE._forward_offload_core` -- the bf16 path is unchanged (verified: the full existing offload/hybrid test suite passes unmodified).

## Design constraints from the epic (#134)
- **Hybrid CPU/PCIe split (#9)**: `_cpu_subset_math` hardcodes the bf16 schema's bank names (`bank_sources["gate_up"]`/`["down"]`) and would `KeyError` for `gptq_int4`. `_forward_hybrid` now forces `fetch_frac` to 1.0 whenever the cache's `quant_format` is `"gptq_int4"` -- every miss rides PCIe through the (already gptq_int4-aware) offload path; `_cpu_subset_math` is never reached for this format. A documented, deliberate first-cut tradeoff (this issue's own accept criteria allows it), not a silent gap.
- **Graph-capture safety (#15)**: verified statically -- the dequant path has zero `.item()`/`.tolist()`/`synchronize()`/`.to("cpu")` calls (grepped, confirmed empty), pure elementwise ops with statically-known shapes. A real capture/replay test on hardware is explicitly deferred: this session hit a real GPU exec-queue reset from an overly-broad test sweep while other work was concurrently active on the shared B70 -- a real-hardware-contention reason, not a code-risk one. #138 (end-to-end validation) is the right place for a real capture test once the box isn't under concurrent parallel-agent load.

## Test plan
- [x] 9 new tests: 2 in `tests/test_gptq_quant.py`, 5 in `tests/test_moe_slot_weight_accessor.py` (gptq `get()` matches direct dequant per expert, shape convention, per-slot caching, a missing `gptq_group_size` raises rather than silently defaulting, bf16 passthrough byte-identical to direct indexing), 2 in `tests/test_moe_hybrid_gptq_exclusion.py`
- [x] `pytest tests/ -m "not xpu"`: 358 passed, the one pre-existing unrelated failure unchanged
- [x] `.venv` (torch-free): 205 passed, 41 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve