### PR TITLE
feat(models): wire GPTQ checkpoints through the loader into a real gptq_int4 offload cache (issue #138)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -232,6 +232,7 @@ def load_model(
                     down_banks,
                     moe_backend=moe_backend,
                     moe_cache_size=moe_cache_size,
+                    model_path=model_path,
                 )
             else:
                 _place_expert_weights(model, gate_up_banks, down_banks)
@@ -268,6 +269,7 @@ def load_model(
                     down_banks,
                     moe_backend=moe_backend,
                     moe_cache_size=moe_cache_size,
+                    model_path=model_path,
                 )
             else:
                 _place_expert_weights(model, gate_up_banks, down_banks)
@@ -375,6 +377,7 @@ def _attach_offload_cache(
     down_banks,
     moe_backend: str = "offload",
     moe_cache_size: int | None = None,
+    model_path: str | None = None,
 ) -> None:
     """Build the LRU slot pool and wire it into the offload model (ADR 0002).
 
@@ -389,6 +392,7 @@ def _attach_offload_cache(
     while the model's blocks are indexed by *absolute layer id*, so we also give
     the model the ``moe_layer_id`` map (layer_id -> MoE index) the forward uses.
     """
+    from freetoken.models.weight import GptqExpertBank
     from freetoken.moe.offload_cache import OffloadMoeCache
 
     num_experts = int(getattr(model_config, "num_experts", 0) or 0)
@@ -409,17 +413,51 @@ def _attach_offload_cache(
         cache_size = moe_cache_size
     else:
         cache_size = num_experts + max(2, num_moe)
+    # A GPTQ-quantized checkpoint's banks (issue moe-quant-banks-e2e, #138)
+    # are GptqExpertBank, not a plain tensor/_PlainBank -- detected from the
+    # bank shape itself (load_moe_expert_sources already dispatched to
+    # stream_moe_expert_sources_gptq for these), not re-derived from the
+    # checkpoint path here.
+    is_gptq = bool(gate_up_banks) and isinstance(gate_up_banks[0], GptqExpertBank)
     cache = OffloadMoeCache(
         num_layers=num_moe,
         num_experts=num_experts,
         cache_size=cache_size,
         device=device,
+        quant_format="gptq_int4" if is_gptq else "bf16",
     )
-    # The banks are indexed by MoE-layer order (moe_layers), matching the cache's
-    # 0-based MoE-layer ids.
-    gu = [b.tensor if hasattr(b, "tensor") else b for b in gate_up_banks]
-    dn = [b.tensor if hasattr(b, "tensor") else b for b in down_banks]
-    cache.set_bank_sources({"gate_up": gu, "down": dn})
+    if is_gptq:
+        # Six packed banks (issue moe-quant-banks-schema, #136's schema) --
+        # every bank is one row per expert, so set_bank_sources' generic
+        # per-expert-row contract applies unchanged. g_idx is NOT a bank (it
+        # is shared across every expert of a projection type, see
+        # GptqExpertBank's own docstring): it goes through extra_metadata
+        # instead, one shared [K] tensor per layer per projection type.
+        cache.set_bank_sources(
+            {
+                "qweight_gate_up": [b.qweight for b in gate_up_banks],
+                "qzeros_gate_up": [b.qzeros for b in gate_up_banks],
+                "scales_gate_up": [b.scales for b in gate_up_banks],
+                "qweight_down": [b.qweight for b in down_banks],
+                "qzeros_down": [b.qzeros for b in down_banks],
+                "scales_down": [b.scales for b in down_banks],
+            }
+        )
+        cache.set_extra_metadata("g_idx_gate_up", [b.g_idx for b in gate_up_banks])
+        cache.set_extra_metadata("g_idx_down", [b.g_idx for b in down_banks])
+        # SlotWeightAccessor (#137) refuses to guess this -- the loader (here)
+        # is the one place that has both the checkpoint path and the cache.
+        if model_path is None:
+            raise ValueError("_attach_offload_cache needs model_path to read a GPTQ checkpoint's group_size")
+        from freetoken.models.weight import checkpoint_gptq_group_size
+
+        cache.gptq_group_size = checkpoint_gptq_group_size(model_path)
+    else:
+        # The banks are indexed by MoE-layer order (moe_layers), matching the
+        # cache's 0-based MoE-layer ids.
+        gu = [b.tensor if hasattr(b, "tensor") else b for b in gate_up_banks]
+        dn = [b.tensor if hasattr(b, "tensor") else b for b in down_banks]
+        cache.set_bank_sources({"gate_up": gu, "down": dn})
 
     model.moe_cache = cache
     # Record the resolved backend on the model. The block's MoE forward reads

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -297,12 +297,27 @@ def iter_weights(
 
     # Bank-only mode (the offload-cache path, #135): do NOT eagerly dequantize
     # GPTQ-packed expert tensors -- pass them through raw so a packed-bank
-    # builder can keep them packed in host RAM. Every other call shape keeps
-    # today's eager-dequant behavior (see the docstring above for why that is
-    # fine: the dense-placement call never sees expert tensors regardless).
+    # builder can keep them packed in host RAM.
+    #
+    # The dense-placement call (include_moe_experts=False) never *yields* an
+    # expert tensor (the `expert` filter below drops it) -- but a naive
+    # `_dequantize_gptq_stream(raw_stream)` here would still eagerly
+    # dequantize every routed expert's GPTQ tensors before that filter ever
+    # runs, reintroducing the exact whole-checkpoint eager-dequant RAM blowup
+    # issue #135 eliminated for the bank-fabricator call, just on this call
+    # shape instead (found by issue moe-quant-banks-e2e (#138)'s end-to-end
+    # test: a real load_model() call crashed trying to dequantize experts the
+    # dense placement was always going to discard). Fix: drop routed-expert
+    # GPTQ components from the stream *before* they ever reach the dequant
+    # buffer, so they are never assembled/dequantized at all on this path.
     bank_only = include_moe_experts and not include_non_moe
     raw_stream = _iter_safetensors(model_path, device=device)
-    stream = raw_stream if bank_only else _dequantize_gptq_stream(raw_stream)
+    if bank_only:
+        stream = raw_stream
+    elif not include_moe_experts:
+        stream = _dequantize_gptq_stream(_drop_routed_expert_gptq_components(raw_stream))
+    else:
+        stream = _dequantize_gptq_stream(raw_stream)
 
     for raw_name, tensor in stream:
         # Drop the vision tower and the MTP head outright -- neither is part
@@ -369,6 +384,24 @@ def _iter_safetensors(model_path, device):
     from freetoken.models.weight import iter_safetensors
 
     yield from iter_safetensors(model_path, device=device)
+
+
+def _drop_routed_expert_gptq_components(pairs):
+    """Filter a raw ``(name, tensor)`` stream, dropping routed-expert GPTQ
+    components (``.qweight``/``.qzeros``/``.scales``/``.g_idx``) outright --
+    for the dense-placement call, these are discarded by the main loop's
+    ``expert`` filter anyway, so this stops them from ever reaching
+    :func:`_dequantize_gptq_stream`'s buffer-and-dequantize logic (see the
+    call site's comment, issue #138). Everything else (including a
+    GPTQ-quantized *non*-expert tensor, if a future checkpoint ever has one --
+    none does today, per the real checkpoint's ``quantization_config.dynamic``
+    exclusions) passes through unchanged, still eligible for the normal
+    eager-dequant path.
+    """
+    for name, tensor in pairs:
+        if name.endswith(_GPTQ_SUFFIXES) and ".experts." in name:
+            continue
+        yield name, tensor
 
 
 def _dequantize_gptq_stream(pairs):

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -175,7 +175,46 @@ def load_moe_expert_sources(
         include_moe_experts=True,
         include_non_moe=False,
     )
+    # Issue moe-quant-banks-e2e (#138): a GPTQ-quantized checkpoint's expert
+    # tensors arrive from iter_weights RAW and packed (bank-only mode, see
+    # its docstring) -- stream_moe_expert_sources_gptq (#135) is the only
+    # function that knows how to fold them into per-layer banks without
+    # dequantizing. checkpoint_quant_method reads this straight from the
+    # checkpoint's own config.json, independent of ModelConfig (which does
+    # not carry quantization_config today).
+    if checkpoint_quant_method(model_path) == "gptq":
+        return stream_moe_expert_sources_gptq(src, config)
     return stream_moe_expert_sources(src, config, dtype=dtype, layer_sink=layer_sink)
+
+
+def checkpoint_quant_method(model_path: str) -> Optional[str]:
+    """``quantization_config.quant_method`` from the checkpoint's own
+    ``config.json`` (e.g. ``"gptq"``), or ``None`` for an unquantized
+    checkpoint. Read directly from the raw HF config -- independent of
+    ``ModelConfig``/``parse_config``, which does not stash this today."""
+    hf_config = cached_load_hf_config(model_path)
+    raw = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    qc = raw.get("quantization_config")
+    if not isinstance(qc, dict):
+        text_config = raw.get("text_config")
+        qc = text_config.get("quantization_config") if isinstance(text_config, dict) else None
+    return qc.get("quant_method") if isinstance(qc, dict) else None
+
+
+def checkpoint_gptq_group_size(model_path: str) -> int:
+    """``quantization_config.group_size`` from a GPTQ checkpoint's own
+    ``config.json``. Raises if the checkpoint has no GPTQ
+    ``quantization_config`` -- callers must check :func:`checkpoint_quant_method`
+    first (this is not a general-purpose accessor)."""
+    hf_config = cached_load_hf_config(model_path)
+    raw = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    qc = raw.get("quantization_config")
+    if not isinstance(qc, dict):
+        text_config = raw.get("text_config")
+        qc = text_config.get("quantization_config") if isinstance(text_config, dict) else None
+    if not isinstance(qc, dict) or "group_size" not in qc:
+        raise ValueError(f"{model_path!r} has no quantization_config.group_size (not a GPTQ checkpoint?)")
+    return int(qc["group_size"])
 
 
 def _spec_for_model_path(model_path: str, use_offload_moe: bool = False):
@@ -714,4 +753,6 @@ __all__ = [
     "_PlainBank",
     "GptqExpertBank",
     "stream_moe_expert_sources_gptq",
+    "checkpoint_quant_method",
+    "checkpoint_gptq_group_size",
 ]

--- a/tests/test_qwen35_gptq_e2e_loader.py
+++ b/tests/test_qwen35_gptq_e2e_loader.py
@@ -1,0 +1,214 @@
+"""End-to-end: load_model() wires a GPTQ-quantized checkpoint's experts into
+a real "gptq_int4" OffloadMoeCache and runs a forward step (issue
+`moe-quant-banks-e2e`, #138).
+
+This is the glue #135/#136/#137 (all merged) did not themselves cover:
+- weight.py's load_moe_expert_sources must detect a GPTQ checkpoint
+  (checkpoint_quant_method) and dispatch to stream_moe_expert_sources_gptq
+  instead of the bf16 path
+- loader.py's _attach_offload_cache must detect GptqExpertBank-shaped banks
+  and build the cache with quant_format="gptq_int4", the six packed banks,
+  g_idx as extra_metadata, and cache.gptq_group_size (SlotWeightAccessor,
+  #137, refuses to guess this)
+
+A small (few-KB) fabricated GPTQ checkpoint, not the real 22.73GB
+Qwen3.5-35B-A3B-GPTQ-Int4 checkpoint -- this proves the wiring is correct
+before ever touching real hardware / the real checkpoint at scale.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.loader import load_model
+
+H, I, E, V, L = 32, 16, 4, 64, 1
+GROUP = 16
+NH, NKV, HD = 4, 2, 16
+Q_PROJ_DIM = NH * HD * 2
+O_PROJ_DIM = NH * HD
+KV_PROJ_DIM = NKV * HD
+
+
+def _pack_nibbles(codes: list[int]) -> int:
+    word = 0
+    for i, c in enumerate(codes):
+        word |= c << (4 * i)
+    return word
+
+
+def _gptq_pack(k: int, n: int, *, code: int, zero_code: int, scale: float, group_size: int = GROUP):
+    """A trivial (constant-valued, real-shaped) GPTQ-packed projection:
+    every element decodes to ``scale * (code - (zero_code + 1))``. Includes
+    an explicit ``g_idx`` (sequential groups) -- the real checkpoint ships
+    one per expert, even though desc_act=False means it is reconstructible
+    (see gptq_linear.dequantize_gptq_int4_sequential_groups, #137)."""
+    n_groups = -(-k // group_size)
+    qweight = torch.full((k // 8, n), _pack_nibbles([code] * 8), dtype=torch.int32)
+    qzeros = torch.full((n_groups, n // 8), _pack_nibbles([zero_code] * 8), dtype=torch.int32)
+    scales = torch.full((n_groups, n), scale)
+    g_idx = torch.arange(k, dtype=torch.int32) // group_size
+    return qweight, qzeros, scales, g_idx
+
+
+def _qwen35_gptq_weights() -> dict:
+    """One full-attention layer's dense weights (unquantized -- attention is
+    excluded from quantization_config.dynamic, matching the real checkpoint)
+    plus GPTQ-packed routed experts (per-expert raw layout, the real
+    checkpoint's own shape) and a plain (unquantized) shared expert."""
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+        "model.language_model.layers.0.self_attn.q_proj.weight": torch.randn(Q_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.k_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.v_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.o_proj.weight": torch.randn(H, O_PROJ_DIM),
+        "model.language_model.layers.0.self_attn.q_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.self_attn.k_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(E, H),
+        "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.up_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(H, I),
+        "model.language_model.layers.0.mlp.shared_expert_gate.weight": torch.randn(1, H),
+    }
+    for e in range(E):
+        base = f"model.language_model.layers.0.mlp.experts.{e}"
+        for proj, k, n in (("gate_proj", H, I), ("up_proj", H, I), ("down_proj", I, H)):
+            qweight, qzeros, scales, g_idx = _gptq_pack(k, n, code=(e + 1) % 16, zero_code=7, scale=0.1)
+            w[f"{base}.{proj}.qweight"] = qweight
+            w[f"{base}.{proj}.qzeros"] = qzeros
+            w[f"{base}.{proj}.scales"] = scales
+            w[f"{base}.{proj}.g_idx"] = g_idx
+    return w
+
+
+@pytest.fixture(scope="module")
+def qwen35_gptq_ckpt(tmp_path_factory):
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_gptq")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NKV,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": HD,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {
+            "bits": 4,
+            "group_size": GROUP,
+            "sym": True,
+            "desc_act": False,
+            "quant_method": "gptq",
+            "dynamic": {
+                "-:.*attn.*": {},
+                "-:.*shared_expert.*": {},
+            },
+        },
+    }
+    weights = _qwen35_gptq_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+def test_load_model_builds_a_gptq_int4_offload_cache(qwen35_gptq_ckpt):
+    model, _ = load_model(qwen35_gptq_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+
+    cache = model.moe_cache
+    assert cache.quant_format == "gptq_int4"
+    assert cache.gptq_group_size == GROUP
+    assert set(cache.bank_sources) == {
+        "qweight_gate_up",
+        "qzeros_gate_up",
+        "scales_gate_up",
+        "qweight_down",
+        "qzeros_down",
+        "scales_down",
+    }
+    assert cache.get_extra_metadata("g_idx_gate_up", 0).shape == (H,)
+    assert cache.get_extra_metadata("g_idx_down", 0).shape == (I,)
+
+
+def _drive_prefill(model, seq, T, table_idx=0):
+    """Mirrors test_models_qwen35_loader.py's own helper of the same name --
+    a real forward needs a live Context (KV pool, page table, attention
+    backend), not just load_model()."""
+    from freetoken.attention.triton import TritonAttentionBackend
+    from freetoken.core import Batch, Context, Req, SamplingParams, set_global_ctx
+    from freetoken.kvcache.base import BaseKVCachePool
+
+    req = Req(
+        input_ids=seq,
+        table_idx=table_idx,
+        cached_len=0,
+        output_len=1,
+        uid=0,
+        sampling_params=SamplingParams(),
+        cache_handle=None,
+    )
+    batch = Batch(reqs=[req], phase="prefill")
+    batch.input_ids = torch.arange(T, dtype=torch.long)
+    batch.positions = torch.arange(T, dtype=torch.long)
+    batch.out_loc = torch.arange(T, dtype=torch.long)
+    batch.extend_lens = torch.tensor([T])
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(model.config, 1, 1024, torch.device("cpu"), torch.float32)
+    pt = torch.zeros((1, 1024), dtype=torch.int32)
+    pt[0, :T] = torch.arange(T)
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    backend = TritonAttentionBackend(model.config)
+    backend.prepare_metadata(batch)
+    ctx.attn_backend = backend
+    # The real Engine sets this (engine.py: self.ctx.model = self.model) --
+    # _forward_offload_core reads ctx.model.moe_cache. Not part of
+    # test_models_qwen35_loader.py's own _drive_prefill (its fixture never
+    # exercises the offload path), needed here since this test's whole point
+    # is the offload/gptq_int4 forward.
+    ctx.model = model
+    set_global_ctx(ctx)
+    ctx._batch = batch
+    try:
+        logits = model.forward(batch.input_ids, batch.positions, batch.out_loc)
+    finally:
+        from freetoken.core import reset_global_ctx
+
+        reset_global_ctx()
+    return logits, ctx
+
+
+def test_gptq_checkpoint_forward_step_produces_finite_logits(qwen35_gptq_ckpt):
+    """The real point of this issue (#138): a GPTQ-quantized checkpoint's
+    forward pass runs end-to-end -- SlotWeightAccessor (#137) dequantizes the
+    resident packed experts on the fly, reading from the cache #135/#136/this
+    issue's loader wiring actually built."""
+    model, _ = load_model(qwen35_gptq_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+    seq = torch.randint(0, V, (5,))
+    T = seq.shape[0]
+    logits, _ = _drive_prefill(model, seq, T)
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits).all()


### PR DESCRIPTION
## Summary
#135, #136, #137 (all merged, built in parallel against #134's documented shape contract) each covered one piece of quantized MoE offload banks, but none wired them together end to end. This is that glue, found and fixed by actually driving `load_model()` against a fabricated GPTQ checkpoint -- issue #138's own accept criteria expected "no new production code", but the reality was these three independently-built pieces needed real integration work.

- `weight.py`: `load_moe_expert_sources` now detects a GPTQ checkpoint (new `checkpoint_quant_method()`, reading `quantization_config.quant_method` straight from the checkpoint's own `config.json`, independent of `ModelConfig` which doesn't carry it) and dispatches to `stream_moe_expert_sources_gptq` (#135) instead of the bf16 path. New `checkpoint_gptq_group_size()` reads `quantization_config.group_size` for `SlotWeightAccessor`'s (#137) required `cache.gptq_group_size`.
- `loader.py`: `_attach_offload_cache` detects `GptqExpertBank`-shaped banks and builds the cache with `quant_format="gptq_int4"`, the six packed banks (#136's schema), `g_idx` as `extra_metadata`, and `cache.gptq_group_size` -- previously this unconditionally built a `"bf16"` cache with the wrong two bank names for every checkpoint.

**Real bug found and fixed along the way**: `iter_weights`' dense-placement call (`include_moe_experts=False`, what loader.py's real-checkpoint dense-weight pass always uses) was still running every routed expert's raw GPTQ tensors through the eager dequant-to-bf16 path before discarding them -- the exact whole-checkpoint RAM blowup #135 was built to eliminate for the bank-fabricator call, just reintroduced on this call shape instead. A real `load_model()` call against a fabricated GPTQ checkpoint crashed trying to assemble incomplete GPTQ tensor groups it was about to throw away; fixed by dropping routed-expert GPTQ components from the stream before they ever reach the dequant buffer (new `_drop_routed_expert_gptq_components`), so they are never assembled/dequantized on the dense-placement path at all.

## Test plan
- [x] 2 new tests (`tests/test_qwen35_gptq_e2e_loader.py`), against a small fabricated hybrid Qwen3.5 checkpoint with real GPTQ-packed per-expert tensors (not the real 22.73GB `Qwen3.5-35B-A3B-GPTQ-Int4` checkpoint -- that's this same issue's next, real-hardware step):
  - `load_model()` builds a cache with `quant_format == "gptq_int4"`, the correct six bank names, working `extra_metadata` g_idx, and the right `gptq_group_size`
  - a real forward step (prefill) through the offload path produces finite `[1, V]` logits -- `SlotWeightAccessor` dequantizing on the fly, reading from the cache this PR's wiring actually built
- [x] `pytest tests/ -m "not xpu"`: 375 passed (+2 net), same one pre-existing unrelated failure
- [x] `.venv` (torch-free): 205 passed, 44 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve