### PR TITLE
fix(moe): SlotWeightAccessor dequantizes to the activation dtype, not the checkpoint's scales dtype (issue #138)

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1497,7 +1497,7 @@ class _Qwen35MoE:
         # the whole checkpoint (the RAM-saving point of the whole epic, #134).
         from freetoken.moe.offload_cache import SlotWeightAccessor
 
-        slot_weights = SlotWeightAccessor(cache, intermediate)
+        slot_weights = SlotWeightAccessor(cache, intermediate, flat.dtype)
         dev = flat.device
         out = torch.zeros_like(flat)
         routed_cpu = torch.empty(B, k, dtype=torch.int64)

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -590,7 +590,7 @@ class _Qwen3MoE(nn.Module):
         # the whole checkpoint (the RAM-saving point of the whole epic, #134).
         from freetoken.moe.offload_cache import SlotWeightAccessor
 
-        slot_weights = SlotWeightAccessor(cache, intermediate)
+        slot_weights = SlotWeightAccessor(cache, intermediate, flat.dtype)
         dev = flat.device
         out = torch.zeros_like(flat)
         routed_cpu = torch.empty(B, k, dtype=torch.int64)

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -611,16 +611,28 @@ class SlotWeightAccessor:
     For ``"bf16"`` this is a thin, zero-cost wrapper around the existing
     plain-tensor indexing (behavior is unchanged from before this class
     existed). For ``"gptq_int4"`` each distinct slot's packed
-    qweight/qzeros/scales are dequantized to bf16 **at most once per
-    instance** (a `_forward_offload_core` call handles one MoE layer for one
-    step) -- a decode step's working set is typically small (<= num_experts
-    active slots), so this is a bounded, cheap cost per step, never the
-    whole checkpoint at once (the RAM-saving point of #134's whole epic).
+    qweight/qzeros/scales are dequantized **at most once per instance** (a
+    `_forward_offload_core` call handles one MoE layer for one step) -- a
+    decode step's working set is typically small (<= num_experts active
+    slots), so this is a bounded, cheap cost per step, never the whole
+    checkpoint at once (the RAM-saving point of #134's whole epic).
+
+    ``dtype`` is the dequant output dtype -- must match the activation
+    tensor's dtype (``flat``, whatever ``moe_backend="offload"`` loaded the
+    model with -- bf16 by convention, but not guaranteed), NOT the
+    checkpoint's own stored scales dtype (a real bug this class had until
+    issue #138's real-checkpoint validation caught it: the official
+    Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 checkpoint stores ``scales`` as fp16,
+    so dequantizing to "whatever scales.dtype is" silently produced fp16
+    expert weights that then crashed matmul-ing against the bf16
+    activations everywhere else in the model -- caught as a real forward
+    pass failure against the real checkpoint, not by any synthetic test).
     """
 
-    def __init__(self, cache: "OffloadMoeCache", intermediate: int) -> None:
+    def __init__(self, cache: "OffloadMoeCache", intermediate: int, dtype: torch.dtype) -> None:
         self.quant_format = getattr(cache, "quant_format", "bf16")
         self._intermediate = intermediate
+        self._dtype = dtype
         self._cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         if self.quant_format == "gptq_int4":
             self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
@@ -663,18 +675,18 @@ class SlotWeightAccessor:
         from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4_sequential_groups as _dequant
 
         b = self._banks
-        gate_up_dtype = b["scales_gate_up"].dtype
-        down_dtype = b["scales_down"].dtype
         # dequantize_gptq_int4_sequential_groups returns [in_features, out_features]
         # (nn.Linear's transpose); .T gives the [out, in] orientation this port's
-        # bf16 bank rows already use.
+        # bf16 bank rows already use. out_dtype is self._dtype (the model's
+        # activation dtype), NOT the checkpoint's own scales.dtype -- see the
+        # class docstring for the real bug this was.
         gu_dense = _dequant(
             b["qweight_gate_up"][s_i], b["qzeros_gate_up"][s_i], b["scales_gate_up"][s_i],
-            group_size=self._group_size, out_dtype=gate_up_dtype,
+            group_size=self._group_size, out_dtype=self._dtype,
         ).T.contiguous()
         dn_dense = _dequant(
             b["qweight_down"][s_i], b["qzeros_down"][s_i], b["scales_down"][s_i],
-            group_size=self._group_size, out_dtype=down_dtype,
+            group_size=self._group_size, out_dtype=self._dtype,
         ).T.contiguous()
         i = self._intermediate
         result = (gu_dense[0:i], gu_dense[i : 2 * i], dn_dense)

--- a/tests/test_moe_slot_weight_accessor.py
+++ b/tests/test_moe_slot_weight_accessor.py
@@ -79,22 +79,55 @@ def test_gptq_get_matches_direct_dequant_for_each_expert():
         k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
         num_experts=num_experts, cache_size=num_experts,
     )
-    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
 
     for e in range(num_experts):
         slot = int(cache.slot_for_id[0, e].item())
         gate_w, up_w, down_w = accessor.get(slot)
         gu_qw, gu_qz, gu_sc, dn_qw, dn_qz, dn_sc = projections[e]
 
-        # SlotWeightAccessor dequantizes to the bank's own scales dtype (matching
-        # the real checkpoint's fp16/bf16 scales, not a hardcoded dtype); the
-        # fixture's scales are float32, so the expected value must match that.
-        expected_gu = dequantize_gptq_int4_sequential_groups(gu_qw, gu_qz, gu_sc, group_size=group_size, out_dtype=gu_sc.dtype).T
-        expected_dn = dequantize_gptq_int4_sequential_groups(dn_qw, dn_qz, dn_sc, group_size=group_size, out_dtype=dn_sc.dtype).T
+        # SlotWeightAccessor dequantizes to the dtype it was constructed with
+        # (torch.float32 here) -- NOT the bank's own scales dtype (a real bug
+        # this class had until issue #138's real-checkpoint validation caught
+        # it: the official Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 checkpoint stores
+        # scales as fp16 while the rest of the model runs bf16, so dequantizing
+        # to "whatever scales.dtype is" silently produced fp16 expert weights
+        # that then crashed matmul-ing against bf16 activations everywhere else
+        # in the model).
+        expected_gu = dequantize_gptq_int4_sequential_groups(gu_qw, gu_qz, gu_sc, group_size=group_size, out_dtype=torch.float32).T
+        expected_dn = dequantize_gptq_int4_sequential_groups(dn_qw, dn_qz, dn_sc, group_size=group_size, out_dtype=torch.float32).T
 
         torch.testing.assert_close(gate_w, expected_gu[0:inter])
         torch.testing.assert_close(up_w, expected_gu[inter : 2 * inter])
         torch.testing.assert_close(down_w, expected_dn)
+
+
+def test_gptq_get_dtype_matches_requested_dtype_not_scales_dtype():
+    """The real bug found by issue #138's real-checkpoint validation: the
+    official Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 checkpoint stores `scales` as
+    fp16, but the rest of the model (dense weights, activations) runs bf16
+    when moe_backend="offload" loads with dtype=torch.bfloat16 -- an earlier
+    version of SlotWeightAccessor dequantized to "whatever scales.dtype is"
+    (fp16 here), producing a real RuntimeError at the expert matmul
+    ("expected m1 and m2 to have the same dtype, but got: BFloat16 !=
+    Half"), caught on real hardware, not by any synthetic test until now.
+    Builds a fixture whose scales bank is deliberately float16 -- a
+    different dtype than the bfloat16 requested at construction -- and
+    asserts the *output* matches the requested dtype, not the scales'."""
+    hidden, inter, group_size = 16, 8, 8
+    cache, _ = _cache_with_gptq_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
+        num_experts=1, cache_size=1,
+    )
+    # Force the scales bank to a dtype that must NOT leak into the output.
+    cache.bank_caches["scales_gate_up"] = cache.bank_caches["scales_gate_up"].to(torch.float16)
+    cache.bank_caches["scales_down"] = cache.bank_caches["scales_down"].to(torch.float16)
+
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.bfloat16)
+    gate_w, up_w, down_w = accessor.get(0)
+    assert gate_w.dtype == torch.bfloat16
+    assert up_w.dtype == torch.bfloat16
+    assert down_w.dtype == torch.bfloat16
 
 
 def test_gptq_get_shapes_match_out_in_convention():
@@ -103,7 +136,7 @@ def test_gptq_get_shapes_match_out_in_convention():
         k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
         num_experts=1, cache_size=1,
     )
-    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
     gate_w, up_w, down_w = accessor.get(0)
     assert gate_w.shape == (inter, hidden)
     assert up_w.shape == (inter, hidden)
@@ -119,7 +152,7 @@ def test_gptq_get_caches_per_slot_within_one_instance():
         k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden, group_size=group_size,
         num_experts=1, cache_size=1,
     )
-    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
     first = accessor.get(0)
     second = accessor.get(0)
     for a, b in zip(first, second):
@@ -141,7 +174,7 @@ def test_gptq_accessor_refuses_to_guess_group_size():
         "qweight_down": [dn_qw.unsqueeze(0)], "qzeros_down": [dn_qz.unsqueeze(0)], "scales_down": [dn_sc.unsqueeze(0)],
     })
     with pytest.raises(ValueError, match="gptq_group_size"):
-        SlotWeightAccessor(cache, intermediate=inter)
+        SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
 
 
 def test_bf16_accessor_behavior_unchanged():
@@ -155,7 +188,7 @@ def test_bf16_accessor_behavior_unchanged():
     cache.materialize_layer(0)
     cache.copy_missing()
 
-    accessor = SlotWeightAccessor(cache, intermediate=inter)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
     gu, dn = cache.bank_views()
     for e in range(E):
         slot = int(cache.slot_for_id[0, e].item())


### PR DESCRIPTION
## Summary
Third real bug found by issue #138's real-checkpoint validation, this one in the forward pass itself: `SlotWeightAccessor` (#137) dequantized each `gptq_int4` slot to whatever dtype the checkpoint's own `scales` bank happened to be, not the dtype the rest of the model actually runs in. The official `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` checkpoint stores `scales` as fp16, while `moe_backend="offload"` loaded with `dtype=torch.bfloat16` runs every other weight/activation in bf16 -- a real forward pass against the real checkpoint (after a real 179s load succeeded) crashed at the first MoE layer's expert matmul: `RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != c10::Half`. The existing synthetic test suite never caught this because its fixtures happened to use float32 scales matching their own float32 expectations throughout.

**Fix**: `SlotWeightAccessor` now takes an explicit `dtype` constructor argument (the dequant output dtype) instead of reading `scales.dtype`. Both call sites (`qwen3_moe` and `qwen3_5_moe`'s offload forward) pass `flat.dtype` -- the activation tensor already in scope, guaranteed to match every other weight in the forward pass.

## Test plan
- [x] `tests/test_moe_slot_weight_accessor.py`: every existing `SlotWeightAccessor` call updated to pass `dtype=torch.float32` explicitly (previously implicit via the buggy scales-dtype fallback); the first test's comment, which had documented the bug as intentional behavior, corrected; one new test (`test_gptq_get_dtype_matches_requested_dtype_not_scales_dtype`) forces the scales bank to float16 and asserts the *output* is bfloat16 -- the requested dtype, not the scales' -- a direct regression test for exactly this bug
- [x] `pytest tests/ -m "not xpu"`: 378 passed (+1 net), same one pre-existing unrelated failure
- [x] `.venv` (torch-free): 205 passed, 44 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve