### PR TITLE
Revert: GPTQ zero-point fix from #148 was wrong -- restore the +1 correction

### DIFF
--- a/python/freetoken/kernel/triton/gptq_linear.py
+++ b/python/freetoken/kernel/triton/gptq_linear.py
@@ -24,23 +24,10 @@ out_features, packing factor ``P = 32 // bits`` int32 sub-values per word):
     g_idx    int32 [K]                       -- g_idx[k] = k // group_size (desc_act=False)
 
 Dequant: ``weight[k, n] = scales[g_idx[k], n] * (unpack(qweight)[k, n] -
-unpack(qzeros)[g_idx[k], n])``.
-
-Zero-point convention (issue #147): legacy AutoGPTQ v1 packers store
-``zero_point - 1`` (because the unsigned 4-bit code 0 was reserved), which
-would need a ``+ 1`` correction on read. This port originally assumed that
-convention from documentation, without checking it against real checkpoint
-bytes -- that was wrong. The real checkpoint this port targets
-(``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``, ``sym: true``, produced by GPTQModel,
-identifiable by its ``quantization_config``'s ``"dynamic"`` key that legacy
-AutoGPTQ configs never have) stores the true zero-point directly with no
-offset: every routed expert's ``qzeros`` for a symmetric 4-bit tensor
-unpacks to a uniform nibble value of ``8`` (the exact symmetric midpoint for
-a 4-bit code), and dequantizing with a blind ``+ 1`` shifts every weight by
-one full zero-point step, verified as a real, non-negligible systematic
-bias (dequantized weight mean of ``-0.0018`` vs. an expected/measured
-~``0`` without the offset, ~27% of the weight's own std) -- this was the
-root cause of incoherent end-to-end generation output. No ``+ 1`` on read.
+(unpack(qzeros)[g_idx[k], n] + 1))`` -- the ``+ 1`` on the zero-point is a
+real, well-known AutoGPTQ convention (not a bug to "fix"): the packer
+stores ``zero_point - 1`` because the unsigned 4-bit code 0 is reserved,
+so every reader must undo it.
 """
 from __future__ import annotations
 
@@ -102,7 +89,7 @@ def dequantize_gptq_int4(
     weight = _unpack_int32(qweight, bits=_BITS, dim=0).reshape(k, n)
     # qzeros: [G, N//8] -> unpack dim 1 (8 output channels packed per int32 word) -> [G, N//8, 8] -> [G, N].
     zeros = _unpack_int32(qzeros, bits=_BITS, dim=1).reshape(qzeros.shape[0], n)
-    zeros = zeros.to(torch.int32)  # this checkpoint format stores the true zero-point directly (see module docstring)
+    zeros = zeros.to(torch.int32) + 1  # AutoGPTQ's stored-minus-one convention
 
     g_idx = g_idx.long()
     per_row_scale = scales[g_idx]  # [K, N]

--- a/tests/test_gptq_quant.py
+++ b/tests/test_gptq_quant.py
@@ -25,12 +25,6 @@ def _pack_nibbles(codes: list[int]) -> int:
     for i, c in enumerate(codes):
         assert 0 <= c < 16
         word |= c << (4 * i)
-    # A packed word with bit 31 set (e.g. every nibble = 8) is a legitimate
-    # int32 bit pattern, but torch.tensor(..., dtype=torch.int32) rejects a
-    # Python int >= 2**31 as an overflow -- fold to the equivalent
-    # two's-complement negative value first (see also test_weight_gptq_banks).
-    if word >= 1 << 31:
-        word -= 1 << 32
     return word
 
 
@@ -42,9 +36,8 @@ def test_dequantize_matches_hand_packed_known_encoding():
     assert qweight.shape == (1, N)
 
     # Zero-point 8 (the standard symmetric midpoint) for every output channel:
-    # this checkpoint format (issue #147) stores the true zero-point directly,
-    # so the raw nibble is 8, not the legacy AutoGPTQ-v1 stored-minus-one 7.
-    qzeros = torch.tensor([[_pack_nibbles([8] * 8)]], dtype=torch.int32)
+    # AutoGPTQ stores (zero_point - 1) packed, so the raw nibble is 7.
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)]], dtype=torch.int32)
     assert qzeros.shape == (1, N // 8)
 
     scales = torch.full((1, N), 0.5)
@@ -64,7 +57,7 @@ def test_dequantize_respects_per_group_scale_and_zero():
     codes = [1] * 8  # every row's weight code is 1 (arbitrary, constant)
     qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
     qzeros = torch.tensor(
-        [[_pack_nibbles([8] * 8)], [_pack_nibbles([4] * 8)]], dtype=torch.int32
+        [[_pack_nibbles([7] * 8)], [_pack_nibbles([3] * 8)]], dtype=torch.int32
     )  # group0 zero=8, group1 zero=4
     scales = torch.tensor([[1.0] * N, [10.0] * N])
     g_idx = torch.tensor([i // group_size for i in range(K)], dtype=torch.int32)
@@ -110,7 +103,7 @@ def test_gptq_linear_matches_manual_dequant_matmul():
     K, N, group_size = 8, 8, 8
     codes = [(k * 3) % 16 for k in range(8)]
     qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
-    qzeros = torch.tensor([[_pack_nibbles([8] * 8)]], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)]], dtype=torch.int32)
     scales = torch.full((1, N), 0.25)
     g_idx = torch.zeros(K, dtype=torch.int32)
 
@@ -145,7 +138,7 @@ def test_sequential_groups_rejects_nothing_extra_and_shapes_correctly():
     K, N, group_size = 8, 8, 8
     codes = [(k * 3) % 16 for k in range(8)]
     qweight = torch.tensor([[_pack_nibbles(codes)] * N], dtype=torch.int32)
-    qzeros = torch.tensor([[_pack_nibbles([8] * 8)]], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)]], dtype=torch.int32)
     scales = torch.full((1, N), 0.25)
 
     out = dequantize_gptq_int4_sequential_groups(qweight, qzeros, scales, group_size=group_size)

--- a/tests/test_qwen35_gptq_e2e_loader.py
+++ b/tests/test_qwen35_gptq_e2e_loader.py
@@ -42,9 +42,7 @@ def _pack_nibbles(codes: list[int]) -> int:
 
 def _gptq_pack(k: int, n: int, *, code: int, zero_code: int, scale: float, group_size: int = GROUP):
     """A trivial (constant-valued, real-shaped) GPTQ-packed projection:
-    every element decodes to ``scale * (code - zero_code)`` (this checkpoint
-    format's zero-point is stored directly, no +1 correction -- issue #147).
-    Includes
+    every element decodes to ``scale * (code - (zero_code + 1))``. Includes
     an explicit ``g_idx`` (sequential groups) -- the real checkpoint ships
     one per expert, even though desc_act=False means it is reconstructible
     (see gptq_linear.dequantize_gptq_int4_sequential_groups, #137)."""

--- a/tests/test_qwen35_gptq_loader.py
+++ b/tests/test_qwen35_gptq_loader.py
@@ -24,22 +24,17 @@ def _pack_nibbles(codes: list[int]) -> int:
     word = 0
     for i, c in enumerate(codes):
         word |= c << (4 * i)
-    # Fold a word with bit 31 set (e.g. every nibble = 8) to its two's-
-    # complement negative value -- torch.tensor(..., dtype=torch.int32)
-    # rejects a Python int >= 2**31 as an overflow otherwise.
-    if word >= 1 << 31:
-        word -= 1 << 32
     return word
 
 
 def _fake_gptq_projection(k: int, n: int, group_size: int):
     """A small, real (not random-garbage) GPTQ-packed projection: constant
-    weight code 5, zero-point 8 (stored directly, no +1 correction -- issue
-    #147), scale 0.5 -- every dequantized element is 0.5 * (5 - 8) = -1.5."""
+    weight code 5, zero-point 8, scale 0.5 -- every dequantized element is
+    0.5 * (5 - 8) = -1.5."""
     assert k % 8 == 0 and n % 8 == 0 and k % group_size == 0
     n_groups = k // group_size
     qweight = torch.tensor([[_pack_nibbles([5] * 8)] * n for _ in range(k // 8)], dtype=torch.int32)
-    qzeros = torch.tensor([[_pack_nibbles([8] * 8)] * (n // 8) for _ in range(n_groups)], dtype=torch.int32)
+    qzeros = torch.tensor([[_pack_nibbles([7] * 8)] * (n // 8) for _ in range(n_groups)], dtype=torch.int32)
     scales = torch.full((n_groups, n), 0.5)
     g_idx = torch.tensor([i // group_size for i in range(k)], dtype=torch.int32)
     return qweight, qzeros, scales, g_idx

--- a/tests/test_weight_gptq_banks.py
+++ b/tests/test_weight_gptq_banks.py
@@ -36,9 +36,7 @@ def _pack_nibbles(codes: list[int]) -> int:
 def _gptq_projection(k: int, n: int, group_size: int, *, weight_code: int, zero_code: int, scale: float):
     """A small, real (not random-garbage) GPTQ-packed projection: every row
     uses the same weight code / zero-point / scale, so the dequantized value
-    is a known constant: ``scale * (weight_code - zero_code)`` (this
-    checkpoint format's zero-point is stored directly, no +1 correction --
-    see issue #147)."""
+    is a known constant: ``scale * (weight_code - (zero_code + 1))``."""
     assert k % 8 == 0 and n % 8 == 0 and k % group_size == 0
     n_groups = k // group_size
     qweight = torch.tensor([[_pack_nibbles([weight_code] * 8)] * n for _ in range(k // 8)], dtype=torch.int32)
@@ -92,8 +90,8 @@ def test_packed_bank_shapes_match_the_documented_contract():
 def test_packed_bank_round_trips_to_the_known_fixture_value():
     config = SimpleNamespace(num_layers=1, num_experts=2)
     k, n, group_size = 16, 8, 8
-    # weight_code=5, zero_code=8, scale=0.5 -> 0.5*(5-8) = -1.5.
-    kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=8, scale=0.5)
+    # weight_code=5, zero_code=7 (+1 correction -> 8), scale=0.5 -> 0.5*(5-8) = -1.5.
+    kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=7, scale=0.5)
     stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
 
     gate_up_banks, down_banks = stream_moe_expert_sources_gptq(stream, config)
@@ -119,8 +117,8 @@ def test_gate_up_concatenation_preserves_two_independently_quantized_halves():
     two halves must dequantize back to their own distinct source values."""
     config = SimpleNamespace(num_layers=1, num_experts=1)
     k, n, group_size = 16, 8, 8
-    gate_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=3, zero_code=9, scale=0.25)  # -> 0.25*(3-9) = -1.5
-    up_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=10, zero_code=7, scale=1.0)  # -> 1.0*(10-7) = 3.0
+    gate_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=3, zero_code=8, scale=0.25)  # -> 0.25*(3-9) = -1.5
+    up_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=10, zero_code=6, scale=1.0)  # -> 1.0*(10-7) = 3.0
     down_kwargs = dict(k=k, n=n, group_size=group_size, weight_code=5, zero_code=7, scale=0.5)
     stream = _expert_stream(config, gate_kwargs=gate_kwargs, up_kwargs=up_kwargs, down_kwargs=down_kwargs)
 


### PR DESCRIPTION
## Summary

PR #148 was wrong. It removed the AutoGPTQ v1 `+1` zero-point correction based on an insufficient signal (near-zero dequantized weight mean), when the actual authoritative convention -- verified against the real, actively-maintained `gptqmodel` reference implementation -- requires the `+1`.

## What went wrong in #148

The real checkpoint's `quantization_config` has no `checkpoint_format` field. `gptqmodel.utils.model_dequant._uses_gptq_v1_qzeros` treats a missing field as `"gptq"` (the v1 family), which needs the `+1` correction -- the code #148 removed. I ran gptqmodel's own dequant utility directly against this checkpoint's real tensors (layer 0/expert 0, both `gate_proj` and `down_proj`) and it produces dequantized weight statistics that exactly match the ORIGINAL (pre-#148) code: mean `-0.001848`/std `0.006902` for `gate_proj`, mean `-0.003479` for `down_proj` -- not the near-zero mean #148 treated as proof of correctness. A near-zero mean is not a reliable signal for calibrated GPTQ weights; #148's heuristic was the wrong test.

## What this does and doesn't fix

This restores the original, correct dequant convention. Issue #147 (incoherent generation from the real checkpoint) is **still open and unexplained** -- this revert only undoes an incorrect fix on top of it, it does not newly break anything #148 had actually fixed (it hadn't fixed anything real).

## Test plan
- [x] `tests/test_gptq_quant.py`, `test_weight_gptq_banks.py`, `test_qwen35_gptq_loader.py`, `test_qwen35_gptq_e2e_loader.py`, `test_moe_offload_gptq_schema.py`, `test_moe_slot_weight_accessor.py`, `test_moe_hybrid_gptq_exclusion.py` -- 46 passed (revert restores the original fixtures cleanly)
- [x] Cross-checked against `gptqmodel` (pip-installed into an isolated scratch venv for this diagnostic only, not added as a project dependency), the actively-maintained authoritative GPTQ reference implementation, run directly against real checkpoint tensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve