### PR TITLE
fix(models): apply SiLU to the GDN causal-conv output (issue #147)

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -801,6 +801,12 @@ class _GatedDeltaNet:
         The ring holds the trailing (kernel-1) positions; the new ring is the
         trailing (kernel-1) of the concatenated (old ring + new tokens) sequence,
         and it is written back in place so the next step reads it.
+
+        The reference's ``causal_conv1d_fn``/``causal_conv1d_update`` apply the
+        model's activation (``config.hidden_act``, ``"silu"`` for this
+        checkpoint) elementwise to the WHOLE conv output (query, key, and value
+        channels alike) before the q/k/v split -- this was missing here (issue
+        #147), a real bug affecting every linear-attention layer, every token.
         """
         B, C, T = mixed_qkv.shape
         w = self.conv1d.weight  # [C, 1, K] (groups=C -> each channel is 1 input)
@@ -810,14 +816,15 @@ class _GatedDeltaNet:
                 [torch.zeros(B, C, ring_len, device=mixed_qkv.device, dtype=mixed_qkv.dtype), mixed_qkv],
                 dim=-1,
             )
-            return F.conv1d(padded, w, padding=0, groups=C)[:, :, :T]
+            out = F.conv1d(padded, w, padding=0, groups=C)[:, :, :T]
+            return F.silu(out)
         # Old ring (K-1) + new tokens -> conv output for the new tokens only; the
         # new ring is the trailing (K-1) of that concatenation.
         seq = torch.cat([slot.conv_state.unsqueeze(0), mixed_qkv], dim=-1)  # [B, C, K-1+T]
         out = F.conv1d(seq, w, padding=0, groups=C)[:, :, -T:]
         if T > 0:
             slot.conv_state.copy_(seq[:, :, -ring_len:][0])
-        return out
+        return F.silu(out)
 
     def _delta_rule(self, q, k, v, g, beta, slot, out_dtype=None):
         """Recurrent Gated-Delta-Net over the (post-conv) tokens.

--- a/tests/reference_qwen35.py
+++ b/tests/reference_qwen35.py
@@ -65,7 +65,11 @@ def ref_gated_deltanet(hidden, positions, la, slot_state, dtype):
         )
     else:
         seq = torch.cat([conv_state.unsqueeze(0), mixed], dim=-1)
-    conv = F.conv1d(seq, w, padding=0, groups=la.conv_dim)[:, :, :T]  # [1, C, T]
+    # The real HF reference's causal_conv1d_fn/causal_conv1d_update apply the
+    # model's activation (config.hidden_act, "silu" for this checkpoint)
+    # elementwise to the WHOLE conv output before the q/k/v split (issue #147 --
+    # this was missing from both the port and this "reference" until fixed).
+    conv = F.silu(F.conv1d(seq, w, padding=0, groups=la.conv_dim)[:, :, :T])  # [1, C, T]
     conv_state_new = seq[:, :, -ring:].clone()
 
     z = la.in_proj_z(hidden)  # [T,value_dim]


### PR DESCRIPTION
## Summary

Real, independently-verified correctness bug in `_GatedDeltaNet._conv` (issue #147). Found by direct comparison against the vendored real HF reference source (`transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py`, already present in this project's venvs).

## What was wrong

The reference's Gated-Delta-Net applies the model's activation (`config.hidden_act`, `"silu"` for this checkpoint) elementwise to the **whole** causal-conv output -- query, key, and value channels alike -- via `causal_conv1d_fn(..., activation=self.activation)` / `causal_conv1d_update(..., activation=...)`, before splitting into q/k/v. This port's `_conv` ran the depthwise `F.conv1d` but never applied this activation anywhere. This affects every linear-attention (GDN) layer -- 30 of this checkpoint's 40 decoder layers -- on every token.

`tests/reference_qwen35.py`'s "independent" reference implementation had the identical gap: its own comment said "mirror the real `_GatedDeltaNet._conv` exactly," meaning it was written by copying the port's own (buggy) behavior rather than checking the true upstream HF source -- so it never could have caught this. Fixed there too, restoring it as an actual independent check.

## What this does and doesn't fix

This is a real, source-verified bug, fixed and regression-tested (`test_models_qwen35_loader.py` and the full suite pass). It is **not sufficient on its own** to resolve #147: a real 200-token generation run against the actual checkpoint with this fix applied still produces incoherent output. The sampled tokens land close to (though not identical to) the pre-fix run's, confirming the fix has a real numerical effect, just not enough (alone) to fix generation quality. #147 stays open.

## Test plan
- [x] `tests/test_models_qwen35_loader.py` -- 8 passed
- [x] Full suite in `.venv` (torch-free) -- 205 passed, 44 skipped
- [x] Full suite in `.venv-xpu` (`-m "not xpu"`) -- 378 passed (1 pre-existing unrelated failure, confirmed present on main before this change too)
- [x] Real end-to-end 200-token generation against the actual `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` checkpoint: healthy (no crash/OOM, peak RSS 20.18GiB), confirms the fix changes numeric output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve