### PR TITLE
fix(models): _expert_source_names never matched a real checkpoint's actual keys

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -74,20 +74,30 @@ def _expert_source_names(cfg: ModelConfig) -> set:
     """The (remapped) key suffixes that are routed-expert weights: these go to
     the host offload banks, everything else stays dense on the device.
 
-    Mirrors qwen3_moe's ``_is_expert_key`` so the loader's MoE-bank plumbing
-    (``load_moe_expert_sources`` / ``stream_moe_expert_sources``) can resolve the
-    experts out of the remapped ``model.*`` keys. A routed-expert weight carries
-    a ``.experts.`` segment; the dense shared expert (``mlp.shared_expert.*``)
-    does not, so it stays on the device.
+    A routed-expert weight carries a ``.experts.`` segment; the dense shared
+    expert (``mlp.shared_expert.*``) does not, so it stays on the device.
+
+    Real checkpoint files always store one tensor **per expert** (``model.
+    layers.{i}.mlp.experts.{e}.gate_proj.weight``, not a single fused
+    ``experts.gate_proj.weight`` with no expert index) -- this previously
+    generated only the un-indexed spelling, which never matches any real
+    checkpoint's keys, so every routed expert silently fell through to "not
+    an expert" and got dropped. Found via a real (if tiny) non-GPTQ
+    checkpoint: the GPTQ bank-only path never exercises this function (it
+    classifies experts by a ``.experts.`` substring check instead, see
+    ``iter_weights``), so this bug was invisible on every GPTQ checkpoint
+    tested so far.
     """
     names = set()
     if cfg.is_moe:
         for i in range(cfg.first_k_dense_replace, cfg.num_moe_layers + cfg.first_k_dense_replace):
             mlp = f"model.layers.{i}.mlp.experts"
-            for suffix in ("gate_proj.weight", "up_proj.weight", "down_proj.weight"):
-                names.add(f"{mlp}.{suffix}")
-            # The real (packed) Qwen3.5/3.6 layout also uses the fused / un-suffixed
-            # names; accept both so a checkpoint in either spelling routes correctly.
+            for e in range(cfg.num_experts or 0):
+                for suffix in ("gate_proj.weight", "up_proj.weight", "down_proj.weight"):
+                    names.add(f"{mlp}.{e}.{suffix}")
+            # The fused / un-suffixed names (a single [E, ...] tensor per layer,
+            # no per-expert index) also route correctly if a checkpoint ever
+            # ships that spelling instead.
             names.add(f"{mlp}.gate_up_proj")
             names.add(f"{mlp}.down_proj")
     return names

--- a/tests/test_models_qwen35_loader.py
+++ b/tests/test_models_qwen35_loader.py
@@ -223,6 +223,72 @@ def test_load_moe_expert_sources_builds_banks_from_remapped_keys(qwen35_ckpt):
     assert down[0].device.type == "cpu"
 
 
+def test_load_moe_expert_sources_builds_banks_from_per_expert_indexed_keys(tmp_path_factory):
+    """Real checkpoint files (including the official Qwen/Qwen3.5-35B-A3B-
+    GPTQ-Int4, and any plain bf16 Qwen3.5/3.6 MoE checkpoint) always store one
+    tensor PER EXPERT (``mlp.experts.{e}.gate_proj.weight``), never the fused
+    un-indexed spelling (``mlp.experts.gate_up_proj``) the rest of this file's
+    fixture uses. _expert_source_names previously generated ONLY the fused
+    spelling, so it never matched any real checkpoint's actual keys -- every
+    routed expert silently fell through to "not an expert" and got dropped
+    (a real load_model() call on a real per-expert-indexed checkpoint raised
+    "Missing MoE expert source layers"). The GPTQ bank-only path never
+    exercises _expert_source_names (it classifies experts by a raw
+    ``.experts.`` substring check instead), which is why this was invisible
+    on every GPTQ checkpoint tested so far -- found via a real (tiny)
+    HuggingFace test checkpoint (tiny-random/qwen3.5-moe) that uses the
+    per-expert-indexed spelling."""
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_per_expert")
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": _qwen35_text_config(),
+    }
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+        "model.language_model.layers.1.self_attn.q_proj.weight": torch.randn(Q_PROJ_DIM, H),
+        "model.language_model.layers.1.self_attn.k_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.1.self_attn.v_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.1.self_attn.o_proj.weight": torch.randn(H, O_PROJ_DIM),
+        "model.language_model.layers.1.self_attn.q_norm.weight": torch.randn(HD),
+        "model.language_model.layers.1.self_attn.k_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.linear_attn.in_proj_qkv.weight": torch.randn(QKV_DIM, H),
+        "model.language_model.layers.0.linear_attn.in_proj_z.weight": torch.randn(VALUE_DIM, H),
+        "model.language_model.layers.0.linear_attn.in_proj_b.weight": torch.randn(NV, H),
+        "model.language_model.layers.0.linear_attn.in_proj_a.weight": torch.randn(NV, H),
+        "model.language_model.layers.0.linear_attn.conv1d.weight": torch.randn(CONV_DIM, 1, CONV_K),
+        "model.language_model.layers.0.linear_attn.out_proj.weight": torch.randn(H, VALUE_DIM),
+        "model.language_model.layers.0.linear_attn.A_log": torch.randn(NV),
+        "model.language_model.layers.0.linear_attn.dt_bias": torch.randn(NV),
+    }
+    for layer in range(L):
+        w[f"model.language_model.layers.{layer}.mlp.gate.weight"] = torch.randn(E, H)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert.gate_proj.weight"] = torch.randn(I, H)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert.up_proj.weight"] = torch.randn(I, H)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert.down_proj.weight"] = torch.randn(H, I)
+        w[f"model.language_model.layers.{layer}.mlp.shared_expert_gate.weight"] = torch.randn(1, H)
+        for e in range(E):
+            base = f"model.language_model.layers.{layer}.mlp.experts.{e}"
+            w[f"{base}.gate_proj.weight"] = torch.randn(I, H)
+            w[f"{base}.up_proj.weight"] = torch.randn(I, H)
+            w[f"{base}.down_proj.weight"] = torch.randn(H, I)
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in w.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in w}})
+    )
+
+    gate_up, down = load_moe_expert_sources(str(path), dtype=torch.bfloat16)
+    assert len(gate_up) == L and len(down) == L
+    assert gate_up[0].shape == (E, 2 * I, H)
+    assert down[0].shape == (E, H, I)
+
+
 # --- the top-level loader path -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Real, previously-undiscovered bug, unrelated to GPTQ or issue #147's incoherence directly -- found while building a genuine end-to-end reference comparison using a real (tiny) non-GPTQ Qwen3.5-MoE checkpoint for the first time this session.

## What was wrong

\`_expert_source_names\` built the routed-expert key set as the un-indexed spelling (\`model.layers.{i}.mlp.experts.gate_proj.weight\` -- a single fused tensor per layer, no per-expert index). Every real checkpoint file -- including the official \`Qwen/Qwen3.5-35B-A3B-GPTQ-Int4\` and any plain bf16 Qwen3.5/3.6 MoE checkpoint -- stores one tensor **per expert** instead (\`...experts.{e}.gate_proj.weight\`), so this never matched: every routed expert silently fell through the \`expert = name in routed\` check and got dropped.

This was invisible on every GPTQ checkpoint tested so far because the GPTQ bank-only call path never consults \`_expert_source_names\` -- it classifies experts by a raw \`.experts.\` substring check instead (see \`iter_weights\`). It surfaced only when loading \`tiny-random/qwen3.5-moe\` (a real HuggingFace test checkpoint of this exact architecture, downloaded to build a genuine end-to-end reference comparison for #147) for the first time -- \`load_model()\` raised \`ValueError: Missing MoE expert source layers\`. Every existing test fixture for this loader also happened to use only the fused/un-indexed spelling, so nothing caught it before.

## Fix

Generate the real per-expert-indexed names for every expert \`0..num_experts-1\`, keeping the fused spelling too (harmless, and correct if a checkpoint ever does ship that way).

## Test plan
- [x] New regression test: \`test_load_moe_expert_sources_builds_banks_from_per_expert_indexed_keys\` -- a fabricated checkpoint using the real per-expert-indexed spelling, proving \`load_moe_expert_sources\` now finds and banks the experts
- [x] \`tests/test_models_qwen35_loader.py\` -- 9 passed
- [x] Full suite in \`.venv\` (torch-free) -- 205 passed, 44 skipped
- [x] Full suite in \`.venv-xpu\` (\`-m "not xpu"\`) -- 379 passed (1 pre-existing unrelated failure, confirmed present on main too)
- [x] Real end-to-end: \`tiny-random/qwen3.5-moe\` (real HF test checkpoint, 4 layers, 128 experts, plain bf16) now loads and runs a forward step through our engine successfully (previously failed with \`Missing MoE expert source layers\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve