### PR TITLE
feat(moe): packed per-channel INT8 offload banks + dequant-at-compute (issue #154)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -392,7 +392,7 @@ def _attach_offload_cache(
     while the model's blocks are indexed by *absolute layer id*, so we also give
     the model the ``moe_layer_id`` map (layer_id -> MoE index) the forward uses.
     """
-    from freetoken.models.weight import GptqExpertBank
+    from freetoken.models.weight import GptqExpertBank, Int8ExpertBank
     from freetoken.moe.offload_cache import OffloadMoeCache
 
     num_experts = int(getattr(model_config, "num_experts", 0) or 0)
@@ -419,14 +419,32 @@ def _attach_offload_cache(
     # stream_moe_expert_sources_gptq for these), not re-derived from the
     # checkpoint path here.
     is_gptq = bool(gate_up_banks) and isinstance(gate_up_banks[0], GptqExpertBank)
+    # A per-channel-INT8 checkpoint's banks (issue moe-quant-banks-int8, #154)
+    # are Int8ExpertBank, detected the same way is_gptq is -- from the bank
+    # type itself, not re-derived from the checkpoint path here.
+    is_int8 = bool(gate_up_banks) and isinstance(gate_up_banks[0], Int8ExpertBank)
     cache = OffloadMoeCache(
         num_layers=num_moe,
         num_experts=num_experts,
         cache_size=cache_size,
         device=device,
-        quant_format="gptq_int4" if is_gptq else "bf16",
+        quant_format="gptq_int4" if is_gptq else ("int8_channel" if is_int8 else "bf16"),
     )
-    if is_gptq:
+    if is_int8:
+        # Four packed banks (issue moe-quant-banks-schema-int8's schema) --
+        # every bank is one row per expert, so set_bank_sources' generic
+        # per-expert-row contract applies unchanged. Unlike gptq_int4 there
+        # is no shared per-projection side tensor (no g_idx equivalent): a
+        # per-channel scale is already one row per expert.
+        cache.set_bank_sources(
+            {
+                "weight_gate_up": [b.weight for b in gate_up_banks],
+                "scale_gate_up": [b.scale for b in gate_up_banks],
+                "weight_down": [b.weight for b in down_banks],
+                "scale_down": [b.scale for b in down_banks],
+            }
+        )
+    elif is_gptq:
         # Six packed banks (issue moe-quant-banks-schema, #136's schema) --
         # every bank is one row per expert, so set_bank_sources' generic
         # per-expert-row contract applies unchanged. g_idx is NOT a bank (it

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1329,13 +1329,17 @@ class _Qwen35MoE:
         # not a silent gap -- gptq_int4 previously would have crashed loudly
         # here (KeyError) rather than produced wrong numbers, and now simply
         # never reaches that code path.
+        # int8_channel (issue moe-quant-banks-int8, #154) hits the exact same
+        # bank-name mismatch as gptq_int4 above ("weight_gate_up"/"scale_..."
+        # instead of "gate_up"/"down") -- excluded for the same reason, not a
+        # separate decision.
         cache_quant_format = getattr(getattr(model, "moe_cache", None), "quant_format", "bf16")
         # The fetch fraction f (share of misses PCIe-fetched, the rest on CPU).
         # Read through ctx.model (the loader stores it there); a test-harness
         # Context that sets none falls back to the block-local 0.0 (pure offload),
         # which is the correct no-split default.
         fetch_frac = float(getattr(model, "moe_hybrid_fetch_fraction", 0.0) or 0.0)
-        if cache_quant_format == "gptq_int4":
+        if cache_quant_format in ("gptq_int4", "int8_channel"):
             fetch_frac = 1.0
         if fetch_frac <= 0.0:
             # No usable profile -> every miss rides PCIe (pure offload).

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -697,9 +697,13 @@ class _Qwen3MoE(nn.Module):
         # not a silent gap -- gptq_int4 previously would have crashed loudly
         # here (KeyError) rather than produced wrong numbers, and now simply
         # never reaches that code path.
+        # int8_channel (issue moe-quant-banks-int8, #154) hits the exact same
+        # bank-name mismatch as gptq_int4 above ("weight_gate_up"/"scale_..."
+        # instead of "gate_up"/"down") -- excluded for the same reason, not a
+        # separate decision.
         cache_quant_format = getattr(getattr(model, "moe_cache", None), "quant_format", "bf16")
         fetch_frac = float(getattr(model, "moe_hybrid_fetch_fraction", 0.0) or 0.0)
-        if cache_quant_format == "gptq_int4":
+        if cache_quant_format in ("gptq_int4", "int8_channel"):
             fetch_frac = 1.0
         if fetch_frac <= 0.0:
             # No usable profile -> every miss rides PCIe (pure offload).

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -794,6 +794,208 @@ def _finalize_gptq_bank(
     )
 
 
+@dataclass(frozen=True)
+class Int8ExpertBank:
+    """One MoE layer's packed per-channel-INT8 bank for one projection slot
+    (``gate_up`` or ``down``) -- the INT8 sibling of :class:`GptqExpertBank`
+    (issue `moe-quant-banks-int8`, #154, part of epic #140).
+
+    ``weight`` / ``scale`` hold one row per expert (``[E, ...]``, per-channel
+    symmetric INT8 -- see :mod:`freetoken.kernel.triton.int8_linear`). Unlike
+    GPTQ there is no shared per-projection side tensor (no ``g_idx``): a
+    per-channel scale is already ``[N]`` per expert, so it fits the plain
+    ``[E, ...]`` per-expert-row bank shape directly with nothing left over.
+
+    Deliberately packed, never dequantized here -- same RAM-blowup rationale
+    as :class:`GptqExpertBank` (issue #134): dequantization happens lazily,
+    per-expert, at compute time (:class:`freetoken.moe.offload_cache.
+    SlotWeightAccessor`) against whichever rows the offload cache's device
+    slot pool has fetched for the current step.
+    """
+
+    weight: torch.Tensor  # [E, N, K] int8 ([out, in] orientation)
+    scale: torch.Tensor  # [E, N] fp32 -- one value per (expert, output channel)
+
+
+_INT8_COMPONENTS = ("weight", "weight_scale")
+
+
+def _parse_int8_expert_key(key: str) -> Tuple[int, str, int, str] | None:
+    """Parse a per-channel-INT8-packed per-expert weight key into ``(layer,
+    proj, expert_id, component)``, or ``None`` if ``key`` is not one.
+
+    Recognizes ``...layers.{L}.mlp.experts.{e}.{gate_proj|up_proj|down_proj}
+    .{weight|weight_scale}``. UNVERIFIED against a real checkpoint (issue
+    #154's own body: no small/cheap real per-channel-INT8 MoE checkpoint has
+    been identified yet, unlike GPTQ's ``_parse_gptq_expert_key`` which was
+    confirmed against ``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``) -- this spelling is
+    modeled on ``compressed-tensors``' own documented ``weight``/
+    ``weight_scale`` suffix convention (the same one its real, confirmed FP8
+    checkpoints use, e.g. ``nm-testing/Meta-Llama-3.1-8B-Instruct-FP8-hf``'s
+    ``mlp.down_proj.weight`` / ``mlp.down_proj.weight_scale``), extrapolated
+    to INT8's per-channel strategy and to MoE's per-expert key shape. Treat
+    as provisionally correct, not proven, until validated against a real
+    per-channel-INT8 MoE checkpoint.
+    """
+    parts = key.split(".")
+    if len(parts) < 2 or parts[-1] not in _INT8_COMPONENTS:
+        return None
+    component = parts[-1]
+    body = parts[:-1]
+    if "mlp" not in body or "experts" not in body:
+        return None
+    try:
+        mlp_pos = body.index("mlp")
+        layer = int(body[mlp_pos - 1])
+    except (ValueError, IndexError):
+        return None
+    if body[mlp_pos + 1] != "experts":
+        return None
+    e_pos = body.index("experts")
+    tail = body[e_pos + 1 :]
+    if len(tail) != 2:
+        return None
+    try:
+        expert_id = int(tail[0])
+    except ValueError:
+        return None
+    proj = tail[1]
+    if proj not in {"gate_proj", "up_proj", "down_proj"}:
+        return None
+    return layer, proj, expert_id, component
+
+
+def stream_moe_expert_sources_int8(
+    tensors: Iterator[Tuple[str, torch.Tensor]],
+    config,
+) -> Tuple[list, list]:
+    """Stream per-channel-INT8-packed per-expert weight tensors into packed
+    per-layer banks (issue `moe-quant-banks-int8`, #154) -- the INT8 sibling
+    of :func:`stream_moe_expert_sources_gptq`.
+
+    ``gate_up`` fuses ``gate_proj`` + ``up_proj`` (the checkpoint stores them
+    as separate quantized tensors, not pre-fused): ``weight``/``scale``
+    concatenate along their ``N`` (output-channel, dim 0 in ``[N, K]``
+    orientation) axis -- both are per-row, so the fused rows stay correct
+    with no shared side tensor to reconcile (unlike GPTQ's ``g_idx``).
+
+    Returns ``(gate_up_banks, down_banks)``, each a list of ``num_layers``
+    :class:`Int8ExpertBank`. Every tensor stays in its packed, quantized form
+    the whole way through -- never dequantized here.
+
+    Finalizes each ``(layer, bank_name)`` as soon as its last component
+    arrives, exactly like :func:`stream_moe_expert_sources_gptq` -- never
+    buffering more than one layer's worth of raw tensors per bank at once
+    (issue #145 found and fixed a real whole-checkpoint-buffering RAM bug in
+    the GPTQ streamer's first draft; this mirrors the fixed version, not the
+    buggy one).
+    """
+    buf: Dict[Tuple[int, str], Dict[int, Dict[str, Dict[str, torch.Tensor]]]] = {}
+    finalized: Dict[Tuple[int, str], Int8ExpertBank] = {}
+
+    for name, tensor in tensors:
+        info = _parse_int8_expert_key(name)
+        if info is None:
+            raise ValueError(f"Unexpected INT8 expert weight key: {name}")
+        layer, proj, expert_id, component = info
+        bank_name = "gate_up" if proj in ("gate_proj", "up_proj") else "down"
+        if not (0 <= layer < config.num_layers):
+            raise ValueError(f"Unexpected MoE expert layer {layer}; expected [0, {config.num_layers})")
+        if not (0 <= expert_id < config.num_experts):
+            raise ValueError(f"Unexpected MoE expert id {expert_id} in layer {layer}")
+        key = (layer, bank_name)
+        if key in finalized:
+            raise ValueError(
+                f"Layer {layer} {bank_name!r}: tensor {name!r} arrived after this bank was already "
+                "finalized -- duplicate key or an out-of-order/re-streamed source?"
+            )
+        by_expert = buf.setdefault(key, {})
+        by_proj = by_expert.setdefault(expert_id, {})
+        by_component = by_proj.setdefault(proj, {})
+        if component in by_component:
+            raise ValueError(f"Duplicate INT8 component {component!r} for layer {layer} expert {expert_id} {proj}")
+        by_component[component] = tensor
+
+        fuse = bank_name == "gate_up"
+        if _int8_bank_is_complete(by_expert, config.num_experts, fuse=fuse):
+            finalized[key] = _finalize_int8_bank(by_expert, config.num_experts, fuse=fuse, layer=layer)
+            del buf[key]  # release the raw per-expert tensors now that the packed bank owns the data
+
+    missing = [
+        (layer, bank_name)
+        for layer in range(config.num_layers)
+        for bank_name in ("gate_up", "down")
+        if (layer, bank_name) not in finalized
+    ]
+    if missing:
+        raise ValueError(f"Missing/incomplete INT8 MoE expert bank(s): {missing}")
+
+    gate_up_banks = [finalized[(layer, "gate_up")] for layer in range(config.num_layers)]
+    down_banks = [finalized[(layer, "down")] for layer in range(config.num_layers)]
+    return gate_up_banks, down_banks
+
+
+def _int8_bank_is_complete(
+    by_expert: Dict[int, Dict[str, Dict[str, torch.Tensor]]],
+    num_experts: int,
+    *,
+    fuse: bool,
+) -> bool:
+    """True once every expert 0..num_experts-1 has all required projections
+    (``gate_proj``+``up_proj`` for ``fuse=True``, else ``down_proj``), each
+    with both INT8 components -- i.e. this ``(layer, bank_name)`` is ready
+    for :func:`_finalize_int8_bank`."""
+    if set(by_expert) != set(range(num_experts)):
+        return False
+    required_projs = ("gate_proj", "up_proj") if fuse else ("down_proj",)
+    for e in range(num_experts):
+        by_proj = by_expert[e]
+        for proj in required_projs:
+            components = by_proj.get(proj)
+            if components is None or set(components) != set(_INT8_COMPONENTS):
+                return False
+    return True
+
+
+def _finalize_int8_bank(
+    by_expert: Dict[int, Dict[str, Dict[str, torch.Tensor]]],
+    num_experts: int,
+    *,
+    fuse: bool,
+    layer: int,
+) -> Int8ExpertBank:
+    if set(by_expert) != set(range(num_experts)):
+        missing = sorted(set(range(num_experts)) - set(by_expert))
+        raise ValueError(f"Layer {layer}: missing INT8 experts {missing}")
+
+    per_expert_rows = []
+    for e in range(num_experts):
+        by_proj = by_expert[e]
+        if fuse:
+            gate = by_proj.get("gate_proj")
+            up = by_proj.get("up_proj")
+            if gate is None or up is None:
+                raise ValueError(f"Layer {layer} expert {e}: missing gate_proj/up_proj INT8 components")
+            weight = torch.cat([gate["weight"], up["weight"]], dim=0)
+            scale = torch.cat([gate["weight_scale"], up["weight_scale"]], dim=0)
+        else:
+            down = by_proj.get("down_proj")
+            if down is None:
+                raise ValueError(f"Layer {layer} expert {e}: missing down_proj INT8 components")
+            weight, scale = down["weight"], down["weight_scale"]
+        per_expert_rows.append((weight, scale))
+
+    # _stack_expert_rows (not torch.stack): the torch XPU build mishandles a
+    # direct cat/stack of 2-D per-expert rows along a new leading dim (see
+    # _stack_expert_rows's own docstring). scale is 1-D per expert, so it is
+    # stacked with a plain torch.stack instead -- the workaround is only
+    # documented for the 2-D weight case.
+    return Int8ExpertBank(
+        weight=_stack_expert_rows([row[0] for row in per_expert_rows]),
+        scale=torch.stack([row[1] for row in per_expert_rows], dim=0),
+    )
+
+
 __all__ = [
     "load_weight",
     "load_moe_expert_sources",
@@ -802,6 +1004,8 @@ __all__ = [
     "_PlainBank",
     "GptqExpertBank",
     "stream_moe_expert_sources_gptq",
+    "Int8ExpertBank",
+    "stream_moe_expert_sources_int8",
     "checkpoint_quant_method",
     "checkpoint_gptq_group_size",
 ]

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -68,6 +68,16 @@ logger = init_logger(__name__)
 # in OffloadMoeCache.extra_metadata instead (see set_extra_metadata /
 # get_extra_metadata below): a plain per-layer side table the compute step
 # (issue #137) reads directly, never routed through the LRU slot machinery.
+#
+# "int8_channel" (issue moe-quant-banks-int8, #154): a per-channel-INT8
+# checkpoint packs each projection into two per-expert tensors -- an int8
+# weight plus one fp scale per output-channel row (see
+# freetoken.kernel.triton.int8_linear.dequantize_int8_channel) -- the
+# simplest of the three formats in #140 (a single scale per row, no group/
+# block structure like gptq_int4's g_idx/group_size). Unlike gptq_int4 there
+# is no shared per-projection side tensor at all: the scale is already one
+# row per expert ([E, N]), so all four banks below fit the plain [E, ...]
+# per-expert-row contract with nothing left over for extra_metadata.
 _BANK_SCHEMAS: dict[str, tuple[str, ...]] = {
     "bf16": ("gate_up", "down"),
     "gptq_int4": (
@@ -77,6 +87,12 @@ _BANK_SCHEMAS: dict[str, tuple[str, ...]] = {
         "qweight_down",
         "qzeros_down",
         "scales_down",
+    ),
+    "int8_channel": (
+        "weight_gate_up",
+        "scale_gate_up",
+        "weight_down",
+        "scale_down",
     ),
 }
 
@@ -610,11 +626,11 @@ class SlotWeightAccessor:
 
     For ``"bf16"`` this is a thin, zero-cost wrapper around the existing
     plain-tensor indexing (behavior is unchanged from before this class
-    existed). For ``"gptq_int4"`` each distinct slot's packed
-    qweight/qzeros/scales are dequantized **at most once per instance** (a
-    `_forward_offload_core` call handles one MoE layer for one step) -- a
-    decode step's working set is typically small (<= num_experts active
-    slots), so this is a bounded, cheap cost per step, never the whole
+    existed). For ``"gptq_int4"`` (and, since issue #154, ``"int8_channel"``)
+    each distinct slot's packed weights are dequantized **at most once per
+    instance** (a `_forward_offload_core` call handles one MoE layer for one
+    step) -- a decode step's working set is typically small (<= num_experts
+    active slots), so this is a bounded, cheap cost per step, never the whole
     checkpoint at once (the RAM-saving point of #134's whole epic).
 
     ``dtype`` is the dequant output dtype -- must match the activation
@@ -627,6 +643,8 @@ class SlotWeightAccessor:
     expert weights that then crashed matmul-ing against the bf16
     activations everywhere else in the model -- caught as a real forward
     pass failure against the real checkpoint, not by any synthetic test).
+    ``int8_channel`` dequantizes to ``self._dtype`` for exactly the same
+    reason, not to the checkpoint's own scale dtype.
     """
 
     def __init__(self, cache: "OffloadMoeCache", intermediate: int, dtype: torch.dtype) -> None:
@@ -659,6 +677,8 @@ class SlotWeightAccessor:
                     "gptq_int4 forward pass runs (SlotWeightAccessor refuses to guess)"
                 )
             self._group_size = int(group_size)
+        elif self.quant_format == "int8_channel":
+            self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
         else:
             self._gu, self._dn = cache.bank_views()
 
@@ -666,6 +686,22 @@ class SlotWeightAccessor:
         """``(gate_w, up_w, down_w)`` for slot ``s_i``, in ``[out, in]``
         weight orientation (matching ``nn.Linear.weight`` / ``_expert_compute``'s
         expected shape) -- gate/up are ``[I, H]``, down is ``[H, I]``."""
+        if self.quant_format == "int8_channel":
+            cached = self._cache.get(s_i)
+            if cached is not None:
+                return cached
+            from freetoken.kernel.triton.int8_linear import dequantize_int8_channel as _dequant
+
+            b = self._banks
+            # weight/scale are already in [out, in] / [out] orientation (per
+            # output channel = per row) -- no transpose needed, unlike GPTQ's
+            # dequant which returns [in, out] and must be .T'd.
+            gu_dense = _dequant(b["weight_gate_up"][s_i], b["scale_gate_up"][s_i], out_dtype=self._dtype)
+            dn_dense = _dequant(b["weight_down"][s_i], b["scale_down"][s_i], out_dtype=self._dtype)
+            i = self._intermediate
+            result = (gu_dense[0:i], gu_dense[i : 2 * i], dn_dense)
+            self._cache[s_i] = result
+            return result
         if self.quant_format != "gptq_int4":
             i = self._intermediate
             return self._gu[s_i, 0:i], self._gu[s_i, i : 2 * i], self._dn[s_i]

--- a/tests/test_moe_hybrid_int8_exclusion.py
+++ b/tests/test_moe_hybrid_int8_exclusion.py
@@ -1,0 +1,116 @@
+"""int8_channel is excluded from the hybrid CPU/PCIe split (issue
+`moe-quant-banks-int8`, #154), the same way gptq_int4 is (issue #137,
+tested in test_moe_hybrid_gptq_exclusion.py): _cpu_subset_math hardcodes the
+"bf16" bank names (model.moe_cache.bank_sources["gate_up"]/["down"]) and
+would KeyError against an "int8_channel" cache's differently-named banks.
+_forward_hybrid forces fetch_frac to 1.0 (pure offload, no CPU split)
+whenever the cache's quant_format is "int8_channel" too.
+
+Tests both _Qwen3MoE._forward_hybrid (qwen3_moe, takes ``model`` directly)
+and _Qwen35MoE._forward_hybrid (qwen3_5_moe, takes a ``ctx`` whose
+``.model`` is the model) via a stand-in ``self`` (unittest.mock), not a
+real model/engine -- isolates the routing decision from real tensor math,
+real weights, or the full loader/engine stack. CPU-only, no XPU.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.qwen3_5_moe import _Qwen35MoE
+from freetoken.models.qwen3_moe import _Qwen3MoE
+
+
+def _fake_model(*, cache_quant_format: str, fetch_fraction: float):
+    model = MagicMock()
+    model.moe_cache = MagicMock()
+    model.moe_cache.quant_format = cache_quant_format
+    model.moe_hybrid_fetch_fraction = fetch_fraction
+    model.moe_hybrid_max_fetch = -1
+    return model
+
+
+def _fake_self_qwen3moe(*, cache_quant_format: str, fetch_fraction: float = 0.5):
+    """(self, model) -- qwen3_moe's _forward_hybrid takes model directly."""
+    self_ = MagicMock(spec=_Qwen3MoE)
+    self_._is_cpu_layer.return_value = False
+    self_._forward_offload.return_value = torch.zeros(1)
+    model = _fake_model(cache_quant_format=cache_quant_format, fetch_fraction=fetch_fraction)
+    return self_, model
+
+
+def _fake_self_qwen35moe(*, cache_quant_format: str, fetch_fraction: float = 0.5):
+    """(self, ctx) -- qwen3_5_moe's _forward_hybrid reads model = ctx.model.
+    Unlike qwen3_moe, the bf16 split path here calls _forward_offload_core
+    (not _forward_offload) for its XPU half -- see the real body."""
+    self_ = MagicMock(spec=_Qwen35MoE)
+    self_._is_cpu_layer.return_value = False
+    self_._forward_offload.return_value = torch.zeros(1)
+    model = _fake_model(cache_quant_format=cache_quant_format, fetch_fraction=fetch_fraction)
+    ctx = MagicMock()
+    ctx.model = model
+    return self_, ctx, model
+
+
+def test_qwen3moe_int8_channel_never_reaches_cpu_split():
+    self_, model = _fake_self_qwen3moe(cache_quant_format="int8_channel", fetch_fraction=0.5)
+    top_idx = torch.zeros(1, 1, dtype=torch.long)
+    top_w = torch.ones(1, 1)
+    flat = torch.zeros(1, 4)
+
+    out = _Qwen3MoE._forward_hybrid(self_, flat, top_idx, top_w, model, batch=None)
+
+    self_._forward_offload.assert_called_once_with(flat, top_idx, top_w, model, None)
+    self_._hybrid_cpu_pool.assert_not_called()
+    torch.testing.assert_close(out, torch.zeros(1))
+
+
+def test_qwen3moe_bf16_still_splits_normally_when_fetch_fraction_is_mid_range():
+    self_, model = _fake_self_qwen3moe(cache_quant_format="bf16", fetch_fraction=0.5)
+    top_idx = torch.tensor([[0, 1]])
+    top_w = torch.tensor([[0.5, 0.5]])
+    flat = torch.zeros(1, 4)
+
+    self_._forward_offload.return_value = torch.zeros(1, 4)
+    self_._hybrid_cpu_pool.return_value.submit.return_value.result.return_value = torch.zeros(1, 4)
+
+    _Qwen3MoE._forward_hybrid(self_, flat, top_idx, top_w, model, batch=None)
+
+    self_._forward_offload.assert_called_once()
+    _, kwargs = self_._forward_offload.call_args
+    assert kwargs.get("exclude"), "expected a real, non-empty CPU-expert split (exclude=...)"
+
+
+def test_qwen35moe_int8_channel_never_reaches_cpu_split():
+    self_, ctx, model = _fake_self_qwen35moe(cache_quant_format="int8_channel", fetch_fraction=0.5)
+    top_idx = torch.zeros(1, 1, dtype=torch.long)
+    top_w = torch.ones(1, 1)
+    flat = torch.zeros(1, 4)
+
+    out = _Qwen35MoE._forward_hybrid(self_, flat, top_idx, top_w, ctx, batch=None)
+
+    self_._forward_offload.assert_called_once_with(flat, top_idx, top_w, ctx, None)
+    self_._hybrid_cpu_pool.assert_not_called()
+    torch.testing.assert_close(out, torch.zeros(1))
+
+
+def test_qwen35moe_bf16_still_splits_normally_when_fetch_fraction_is_mid_range():
+    """Sanity check that the new guard does not accidentally change bf16
+    behavior. qwen3_5_moe's split path calls _forward_offload_core (not
+    _forward_offload) for its XPU half -- see _fake_self_qwen35moe."""
+    self_, ctx, model = _fake_self_qwen35moe(cache_quant_format="bf16", fetch_fraction=0.5)
+    top_idx = torch.tensor([[0, 1]])
+    top_w = torch.tensor([[0.5, 0.5]])
+    flat = torch.zeros(1, 4)
+
+    self_._forward_offload_core.return_value = torch.zeros(1, 4)
+    self_._hybrid_cpu_pool.return_value.submit.return_value.result.return_value = torch.zeros(1, 4)
+
+    _Qwen35MoE._forward_hybrid(self_, flat, top_idx, top_w, ctx, batch=None)
+
+    self_._forward_offload_core.assert_called_once()
+    _, kwargs = self_._forward_offload_core.call_args
+    assert kwargs.get("exclude"), "expected a real, non-empty CPU-expert split (exclude=...)"

--- a/tests/test_moe_offload_int8_schema.py
+++ b/tests/test_moe_offload_int8_schema.py
@@ -1,0 +1,112 @@
+"""Tests for the ``int8_channel`` offload-cache bank schema (issue
+`moe-quant-banks-int8`, #154).
+
+Companion to test_moe_offload_cache.py / test_moe_offload_gptq_schema.py --
+small synthetic per-channel-INT8 fixtures, no real checkpoint, no XPU.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.moe.offload_cache import _BANK_SCHEMAS, OffloadMoeCache
+
+DEVICE = torch.device("cpu")
+L, E, S = 2, 4, 8  # 2 layers, 4 experts, 8 slots
+K, N = 16, 8  # small in/out dims
+
+
+def _packed_bank_sources():
+    """Distinguishable per-(layer, expert) packed rows for every
+    int8_channel bank -- values chosen so a test can tell which
+    (layer, expert) a slot currently holds."""
+
+    def tag(layer, expert):
+        return 100 * (layer + 1) + 10 * (expert + 1)
+
+    sources = {name: [] for name in _BANK_SCHEMAS["int8_channel"]}
+    for layer in range(L):
+        per_bank_layers = {name: [] for name in sources}
+        for expert in range(E):
+            t = tag(layer, expert)
+            for proj, n, k in (("gate_up", 2 * N, K), ("down", N, K)):
+                per_bank_layers[f"weight_{proj}"].append(torch.full((n, k), t % 127, dtype=torch.int8))
+                per_bank_layers[f"scale_{proj}"].append(torch.full((n,), float(t), dtype=torch.float32))
+        for name in sources:
+            sources[name].append(torch.stack(per_bank_layers[name]))
+    return sources
+
+
+def test_schema_registered():
+    assert "int8_channel" in _BANK_SCHEMAS
+    assert _BANK_SCHEMAS["int8_channel"] == (
+        "weight_gate_up",
+        "scale_gate_up",
+        "weight_down",
+        "scale_down",
+    )
+
+
+def test_set_bank_sources_allocates_correctly_shaped_dtyped_device_caches():
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel")
+    sources = _packed_bank_sources()
+    cache.set_bank_sources(sources)
+
+    for name in _BANK_SCHEMAS["int8_channel"]:
+        host_row_shape = sources[name][0].shape[1:]
+        dev_cache = cache.bank_caches[name]
+        assert dev_cache.shape == (S, *host_row_shape)
+        assert dev_cache.dtype == sources[name][0].dtype
+    assert cache.bank_caches["weight_gate_up"].dtype == torch.int8
+    assert cache.bank_caches["scale_gate_up"].dtype == torch.float32
+
+
+def test_materialize_and_copy_missing_moves_real_packed_bytes():
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel")
+    sources = _packed_bank_sources()
+    cache.set_bank_sources(sources)
+
+    cache.materialize_layer(0)
+    cache.copy_missing()
+
+    for expert in range(E):
+        slot = int(cache.slot_for_id[0, expert].item())
+        assert slot != -1
+        expected_tag = 100 * 1 + 10 * (expert + 1)
+        torch.testing.assert_close(
+            cache.bank_caches["weight_gate_up"][slot],
+            torch.full_like(cache.bank_caches["weight_gate_up"][slot], expected_tag % 127),
+        )
+        torch.testing.assert_close(
+            cache.bank_caches["scale_down"][slot],
+            torch.full_like(cache.bank_caches["scale_down"][slot], float(expected_tag)),
+        )
+
+
+def test_rebuild_resizes_int8_schema_pool():
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel")
+    cache.set_bank_sources(_packed_bank_sources())
+    cache.materialize_layer(0)
+    cache.copy_missing()
+
+    cache.rebuild(2 * S)
+    for name in _BANK_SCHEMAS["int8_channel"]:
+        assert cache.bank_caches[name].shape[0] == 2 * S
+    assert int(cache.slot_for_id.min().item()) == -1 or (cache.slot_for_id == -1).all()
+
+
+def test_bf16_schema_unaffected_by_int8_registration():
+    """Strictly-additive check: the existing bf16 schema still behaves
+    exactly as it did before this change."""
+    assert "bf16" in _BANK_SCHEMAS and _BANK_SCHEMAS["bf16"] == ("gate_up", "down")
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="bf16")
+    h, i = 16, 8
+    sources = {
+        "gate_up": [torch.randn(E, 2 * i, h) for _ in range(L)],
+        "down": [torch.randn(E, h, i) for _ in range(L)],
+    }
+    cache.set_bank_sources(sources)
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    assert all(int(cache.slot_for_id[0, e].item()) != -1 for e in range(E))

--- a/tests/test_moe_slot_weight_accessor_int8.py
+++ b/tests/test_moe_slot_weight_accessor_int8.py
@@ -1,0 +1,121 @@
+"""SlotWeightAccessor: the offload forward's per-slot weight lookup,
+abstracted over int8_channel (dequantize-at-compute, issue
+`moe-quant-banks-int8`, #154). Companion to
+test_moe_slot_weight_accessor.py (gptq_int4's own version, #137).
+
+Builds against the shape/bank-name contract registered in
+_BANK_SCHEMAS["int8_channel"] (weight/scale x {gate_up,down}, no extra
+side tensor -- unlike gptq_int4's g_idx, a per-channel scale is already one
+row per expert). CPU-only, small synthetic fixtures, no real checkpoint, no
+XPU.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.int8_linear import dequantize_int8_channel
+from freetoken.moe.offload_cache import OffloadMoeCache, SlotWeightAccessor
+
+DEVICE = torch.device("cpu")
+
+
+def _make_packed_projection(n: int, k: int, *, seed: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """A real (non-constant) small per-channel-INT8-packed ``[N, K]``
+    projection: weight codes and scales vary by row (derived from `seed`),
+    so a test can't accidentally pass by everything happening to be
+    uniform."""
+    g = torch.Generator().manual_seed(seed)
+    weight = torch.randint(-127, 128, (n, k), generator=g, dtype=torch.int8)
+    scale = torch.rand(n, generator=g) * 0.1 + 0.01
+    return weight, scale
+
+
+def _cache_with_int8_bank(k_gu: int, n_gu: int, k_dn: int, n_dn: int, *, num_experts: int, cache_size: int):
+    cache = OffloadMoeCache(1, num_experts, cache_size, DEVICE, quant_format="int8_channel")
+    sources = {name: [] for name in ("weight_gate_up", "scale_gate_up", "weight_down", "scale_down")}
+    projections = []  # keep the raw per-expert projections to check against
+    for e in range(num_experts):
+        gu_w, gu_s = _make_packed_projection(n_gu, k_gu, seed=100 + e)
+        dn_w, dn_s = _make_packed_projection(n_dn, k_dn, seed=200 + e)
+        projections.append((gu_w, gu_s, dn_w, dn_s))
+        for name, t in (
+            ("weight_gate_up", gu_w), ("scale_gate_up", gu_s),
+            ("weight_down", dn_w), ("scale_down", dn_s),
+        ):
+            sources[name].append(t)
+    sources = {name: [torch.stack(v)] for name, v in sources.items()}  # -> [1 layer][E, ...]
+    cache.set_bank_sources(sources)
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    return cache, projections
+
+
+def test_int8_get_matches_direct_dequant_for_each_expert():
+    hidden, inter, num_experts = 16, 8, 3
+    cache, projections = _cache_with_int8_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden,
+        num_experts=num_experts, cache_size=num_experts,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+
+    for e in range(num_experts):
+        slot = int(cache.slot_for_id[0, e].item())
+        gate_w, up_w, down_w = accessor.get(slot)
+        gu_w, gu_s, dn_w, dn_s = projections[e]
+
+        expected_gu = dequantize_int8_channel(gu_w, gu_s, out_dtype=torch.float32)
+        expected_dn = dequantize_int8_channel(dn_w, dn_s, out_dtype=torch.float32)
+
+        torch.testing.assert_close(gate_w, expected_gu[0:inter])
+        torch.testing.assert_close(up_w, expected_gu[inter : 2 * inter])
+        torch.testing.assert_close(down_w, expected_dn)
+
+
+def test_int8_get_dtype_matches_requested_dtype_not_scale_dtype():
+    """Same bug class issue #138 found for gptq_int4: dequantizing to the
+    checkpoint's own scale dtype (here forced to float16) rather than the
+    activation dtype requested at construction would crash matmul-ing
+    against bf16 activations elsewhere in the model."""
+    hidden, inter = 16, 8
+    cache, _ = _cache_with_int8_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden,
+        num_experts=1, cache_size=1,
+    )
+    # Force the scale bank to a dtype that must NOT leak into the output.
+    cache.bank_caches["scale_gate_up"] = cache.bank_caches["scale_gate_up"].to(torch.float16)
+    cache.bank_caches["scale_down"] = cache.bank_caches["scale_down"].to(torch.float16)
+
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.bfloat16)
+    gate_w, up_w, down_w = accessor.get(0)
+    assert gate_w.dtype == torch.bfloat16
+    assert up_w.dtype == torch.bfloat16
+    assert down_w.dtype == torch.bfloat16
+
+
+def test_int8_get_shapes_match_out_in_convention():
+    hidden, inter = 16, 8
+    cache, _ = _cache_with_int8_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden,
+        num_experts=1, cache_size=1,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    gate_w, up_w, down_w = accessor.get(0)
+    assert gate_w.shape == (inter, hidden)
+    assert up_w.shape == (inter, hidden)
+    assert down_w.shape == (hidden, inter)
+
+
+def test_int8_get_caches_per_slot_within_one_instance():
+    """A distinct slot is dequantized once, not once per .get() call."""
+    hidden, inter = 16, 8
+    cache, _ = _cache_with_int8_bank(
+        k_gu=hidden, n_gu=2 * inter, k_dn=inter, n_dn=hidden,
+        num_experts=1, cache_size=1,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    first = accessor.get(0)
+    second = accessor.get(0)
+    for a, b in zip(first, second):
+        assert a.data_ptr() == b.data_ptr()  # identical cached tensor object, not recomputed

--- a/tests/test_weight_int8_banks.py
+++ b/tests/test_weight_int8_banks.py
@@ -1,0 +1,161 @@
+"""``stream_moe_expert_sources_int8``: packed per-channel-INT8 expert banks
+stay packed (issue `moe-quant-banks-int8`, #154, part of epic #140).
+
+CPU-only, synthetic fixtures -- the whole point of this issue is that these
+banks are NEVER dequantized here (that happens lazily, per-expert, at
+compute time via ``SlotWeightAccessor``); the round-trip check below
+dequantizes only for test verification, via the already-shipped
+``dequantize_int8_channel`` (#130).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.int8_linear import dequantize_int8_channel
+from freetoken.models.weight import Int8ExpertBank, stream_moe_expert_sources_int8
+
+
+def _int8_projection(k: int, n: int, *, code: int, scale: float):
+    """A small, real (not random-garbage) per-channel-INT8-packed
+    projection: every row uses the same int8 code / scale, so the
+    dequantized value is a known constant: ``scale * code``."""
+    weight = torch.full((n, k), code, dtype=torch.int8)
+    scale_t = torch.full((n,), scale, dtype=torch.float32)
+    return weight, scale_t
+
+
+def _expert_stream(config, *, gate_kwargs, up_kwargs, down_kwargs):
+    """Yield ``(name, tensor)`` pairs for every expert of every layer, in the
+    UNVERIFIED assumed per-expert INT8 key spelling (see
+    ``_parse_int8_expert_key``'s docstring)."""
+    for layer in range(config.num_layers):
+        for e in range(config.num_experts):
+            for proj, kwargs in (("gate_proj", gate_kwargs), ("up_proj", up_kwargs), ("down_proj", down_kwargs)):
+                weight, scale = _int8_projection(**kwargs)
+                prefix = f"model.layers.{layer}.mlp.experts.{e}.{proj}"
+                yield prefix + ".weight", weight
+                yield prefix + ".weight_scale", scale
+
+
+def test_packed_bank_shapes_match_the_documented_contract():
+    config = SimpleNamespace(num_layers=2, num_experts=3)
+    k, n = 16, 8
+    kwargs = dict(k=k, n=n, code=5, scale=0.5)
+    stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_int8(stream, config)
+
+    assert len(gate_up_banks) == config.num_layers
+    assert len(down_banks) == config.num_layers
+    for bank in gate_up_banks:
+        assert isinstance(bank, Int8ExpertBank)
+        # gate_up fuses gate_proj+up_proj on the N (row/output-channel) axis -> N doubles.
+        assert bank.weight.shape == (config.num_experts, 2 * n, k)
+        assert bank.scale.shape == (config.num_experts, 2 * n)
+        assert bank.weight.dtype == torch.int8
+        assert bank.scale.dtype == torch.float32
+    for bank in down_banks:
+        assert bank.weight.shape == (config.num_experts, n, k)
+        assert bank.scale.shape == (config.num_experts, n)
+
+
+def test_packed_bank_round_trips_to_the_known_fixture_value():
+    config = SimpleNamespace(num_layers=1, num_experts=2)
+    k, n = 16, 8
+    kwargs = dict(k=k, n=n, code=5, scale=0.5)  # -> 0.5 * 5 = 2.5
+    stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_int8(stream, config)
+
+    for e in range(config.num_experts):
+        down = dequantize_int8_channel(down_banks[0].weight[e], down_banks[0].scale[e], out_dtype=torch.float32)
+        torch.testing.assert_close(down, torch.full((n, k), 2.5))
+
+        gate_up = dequantize_int8_channel(gate_up_banks[0].weight[e], gate_up_banks[0].scale[e], out_dtype=torch.float32)
+        torch.testing.assert_close(gate_up, torch.full((2 * n, k), 2.5))
+
+
+def test_gate_up_concatenation_preserves_two_independently_quantized_halves():
+    """A real test of the concat axis, not a trivial no-op: gate_proj and
+    up_proj are quantized with DIFFERENT codes/scales, so the fused bank's
+    two halves must dequantize back to their own distinct source values."""
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    k, n = 16, 8
+    gate_kwargs = dict(k=k, n=n, code=3, scale=0.25)  # -> 0.75
+    up_kwargs = dict(k=k, n=n, code=10, scale=1.0)  # -> 10.0
+    down_kwargs = dict(k=k, n=n, code=5, scale=0.5)
+    stream = _expert_stream(config, gate_kwargs=gate_kwargs, up_kwargs=up_kwargs, down_kwargs=down_kwargs)
+
+    gate_up_banks, _down_banks = stream_moe_expert_sources_int8(stream, config)
+    bank = gate_up_banks[0]
+
+    fused = dequantize_int8_channel(bank.weight[0], bank.scale[0], out_dtype=torch.float32)
+    # gate/up were concatenated on the N (row, dim=0) axis, so the two halves
+    # split along rows.
+    assert fused.shape == (2 * n, k)
+    gate_half, up_half = fused[:n], fused[n:]
+    torch.testing.assert_close(gate_half, torch.full((n, k), 0.75))
+    torch.testing.assert_close(up_half, torch.full((n, k), 10.0))
+
+
+def test_missing_layer_raises():
+    config = SimpleNamespace(num_layers=2, num_experts=1)
+    kwargs = dict(k=8, n=8, code=5, scale=0.5)
+
+    def stream():
+        # only layer 0, layer 1 never appears
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            weight, scale = _int8_projection(**kwargs)
+            prefix = f"model.layers.0.mlp.experts.0.{proj}"
+            yield prefix + ".weight", weight
+            yield prefix + ".weight_scale", scale
+
+    with pytest.raises(ValueError, match="Missing/incomplete INT8 MoE expert bank"):
+        stream_moe_expert_sources_int8(stream(), config)
+
+
+def test_unexpected_key_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    with pytest.raises(ValueError, match="Unexpected INT8 expert weight key"):
+        stream_moe_expert_sources_int8(iter([("not.an.int8.key", torch.zeros(1))]), config)
+
+
+def test_finalizes_each_layer_as_soon_as_it_completes():
+    """Mirrors the real fix issue #145 made for the GPTQ streamer: streaming
+    layer 0 to completion must release its raw buffer before layer 1 is even
+    seen, not wait for the whole generator to be exhausted."""
+    config = SimpleNamespace(num_layers=2, num_experts=1)
+    kwargs = dict(k=8, n=8, code=5, scale=0.5)
+
+    def stream():
+        for layer in range(2):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                weight, scale = _int8_projection(**kwargs)
+                prefix = f"model.layers.{layer}.mlp.experts.0.{proj}"
+                yield prefix + ".weight", weight
+                yield prefix + ".weight_scale", scale
+
+    import freetoken.models.weight as weight_mod
+
+    original_finalize = weight_mod._finalize_int8_bank
+    call_order = []
+
+    def spy(by_expert, num_experts, *, fuse, layer):
+        call_order.append((layer, "gate_up" if fuse else "down"))
+        return original_finalize(by_expert, num_experts, fuse=fuse, layer=layer)
+
+    weight_mod._finalize_int8_bank = spy
+    try:
+        weight_mod.stream_moe_expert_sources_int8(stream(), config)
+    finally:
+        weight_mod._finalize_int8_bank = original_finalize
+
+    layer0_calls = [c for c in call_order if c[0] == 0]
+    layer1_calls = [c for c in call_order if c[0] == 1]
+    assert len(layer0_calls) == 2
+    assert len(layer1_calls) == 2
+    assert call_order.index(layer1_calls[0]) > call_order.index(layer0_calls[-1])


### PR DESCRIPTION
## Summary

Part of #140 (generalize #134's packed offload-bank design beyond GPTQ). Wires per-channel-INT8 weight-only quantization into the ADR-0002 packed offload-bank machinery, mirroring the GPTQ-Int4 work (#135-#138) with INT8's simpler 2-tensor-per-projection shape (int8 weight + one fp scale per output-channel row -- no group/block structure or shared side tensor like GPTQ's `g_idx`).

- `python/freetoken/models/weight.py`: `Int8ExpertBank` + `stream_moe_expert_sources_int8`, finalizing each `(layer, bank_name)` as soon as its components arrive so peak host RAM never holds more than one layer's worth of raw per-expert tensors at once (the incremental-finalization fix issue #145 made for the GPTQ streamer, applied here from the start).
- `python/freetoken/moe/offload_cache.py`: `_BANK_SCHEMAS["int8_channel"]` (`weight_gate_up`, `scale_gate_up`, `weight_down`, `scale_down`) and a `SlotWeightAccessor` branch that dequantizes a resident slot via `dequantize_int8_channel` to the *activation* dtype passed at construction -- not the checkpoint's own scale dtype, the exact dtype bug issue #138 found for GPTQ.
- `python/freetoken/models/loader.py`: `_attach_offload_cache` detects `Int8ExpertBank` the same way it detects `GptqExpertBank` and wires `quant_format="int8_channel"`.
- `python/freetoken/models/qwen3_moe/__init__.py` and `qwen3_5_moe/__init__.py`: `_forward_hybrid` excludes `int8_channel` from the CPU/PCIe hybrid split alongside `gptq_int4` (the CPU half's math still hardcodes the bf16 bank names and would `KeyError` on `int8_channel`'s differently-named banks).

## Verified vs. assumed

**Assumed, flagged as unverified**: the real per-expert INT8 key spelling (`...experts.{e}.{gate_proj|up_proj|down_proj}.weight` / `.weight_scale`). No small/cheap real per-channel-INT8 MoE checkpoint was identified (per issue #154's own risk note). The spelling is modeled on `compressed-tensors`' documented `weight`/`weight_scale` suffix convention -- confirmed against its real, HF-hosted FP8 checkpoints (e.g. `nm-testing/Meta-Llama-3.1-8B-Instruct-FP8-hf`'s `mlp.down_proj.weight` / `mlp.down_proj.weight_scale`) -- extrapolated to INT8's per-channel strategy and to MoE's per-expert key shape. Flagged as provisionally correct, not proven, in `_parse_int8_expert_key`'s docstring, matching issue #154's own risk note.

## Test plan

- [x] `tests/test_weight_int8_banks.py` -- packed-bank builder (shapes, round-trip to known values, gate/up concat correctness, missing-layer / unexpected-key errors, incremental finalization)
- [x] `tests/test_moe_offload_int8_schema.py` -- schema registration + `OffloadMoeCache` bank wiring/materialize/rebuild, bf16 unaffected
- [x] `tests/test_moe_slot_weight_accessor_int8.py` -- `SlotWeightAccessor` dequant-at-compute round-trip, dtype-not-scale-dtype, shape convention, per-slot caching
- [x] `tests/test_moe_hybrid_int8_exclusion.py` -- `_forward_hybrid` routing exclusion for both `qwen3_moe` and `qwen3_5_moe`, bf16 split unaffected
- [x] `.venv/bin/python -m pytest tests/ -q` (torch-free): 205 passed, 48 skipped
- [x] `.venv-xpu/bin/python -m pytest tests/ -q -m "not xpu"` (torch installed): 398 passed, 1 skipped, 1 pre-existing failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`, confirmed to fail identically on `main` before this change -- unrelated to this PR)

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve