### PR TITLE
feat(moe): packed block-FP8 offload banks + dequant-at-compute (issue #152)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -392,7 +392,7 @@ def _attach_offload_cache(
     while the model's blocks are indexed by *absolute layer id*, so we also give
     the model the ``moe_layer_id`` map (layer_id -> MoE index) the forward uses.
     """
-    from freetoken.models.weight import GptqExpertBank
+    from freetoken.models.weight import Fp8BlockExpertBank, GptqExpertBank
     from freetoken.moe.offload_cache import OffloadMoeCache
 
     num_experts = int(getattr(model_config, "num_experts", 0) or 0)
@@ -419,12 +419,24 @@ def _attach_offload_cache(
     # stream_moe_expert_sources_gptq for these), not re-derived from the
     # checkpoint path here.
     is_gptq = bool(gate_up_banks) and isinstance(gate_up_banks[0], GptqExpertBank)
+    # A block-FP8-quantized checkpoint's banks (issue moe-quant-banks-fp8,
+    # #152) are Fp8BlockExpertBank, detected the same way -- from the bank
+    # shape itself (load_moe_expert_sources already dispatched to
+    # stream_moe_expert_sources_fp8 for these), not re-derived from the
+    # checkpoint path here.
+    is_fp8_block = bool(gate_up_banks) and isinstance(gate_up_banks[0], Fp8BlockExpertBank)
+    if is_gptq:
+        quant_format = "gptq_int4"
+    elif is_fp8_block:
+        quant_format = "fp8_block"
+    else:
+        quant_format = "bf16"
     cache = OffloadMoeCache(
         num_layers=num_moe,
         num_experts=num_experts,
         cache_size=cache_size,
         device=device,
-        quant_format="gptq_int4" if is_gptq else "bf16",
+        quant_format=quant_format,
     )
     if is_gptq:
         # Six packed banks (issue moe-quant-banks-schema, #136's schema) --
@@ -452,6 +464,20 @@ def _attach_offload_cache(
         from freetoken.models.weight import checkpoint_gptq_group_size
 
         cache.gptq_group_size = checkpoint_gptq_group_size(model_path)
+    elif is_fp8_block:
+        # Four packed banks (_BANK_SCHEMAS["fp8_block"]) -- every bank is one
+        # row per expert, so set_bank_sources' generic per-expert-row contract
+        # applies unchanged. Unlike GPTQ there is no shared side tensor to
+        # register via set_extra_metadata (see Fp8BlockExpertBank's own
+        # docstring): block-FP8's weight_scale_inv is genuinely per-expert.
+        cache.set_bank_sources(
+            {
+                "weight_gate_up": [b.weight for b in gate_up_banks],
+                "scale_gate_up": [b.weight_scale_inv for b in gate_up_banks],
+                "weight_down": [b.weight for b in down_banks],
+                "scale_down": [b.weight_scale_inv for b in down_banks],
+            }
+        )
     else:
         # The banks are indexed by MoE-layer order (moe_layers), matching the
         # cache's 0-based MoE-layer ids.

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1328,14 +1328,17 @@ class _Qwen35MoE:
         # issue's own accept criteria explicitly allows it as a first cut),
         # not a silent gap -- gptq_int4 previously would have crashed loudly
         # here (KeyError) rather than produced wrong numbers, and now simply
-        # never reaches that code path.
+        # never reaches that code path. "fp8_block" (issue
+        # moe-quant-banks-fp8, #152) has the exact same gap -- its
+        # bank_sources are named weight_gate_up/scale_gate_up/... -- and gets
+        # the same forced-fetch_frac=1.0 treatment for the same reason.
         cache_quant_format = getattr(getattr(model, "moe_cache", None), "quant_format", "bf16")
         # The fetch fraction f (share of misses PCIe-fetched, the rest on CPU).
         # Read through ctx.model (the loader stores it there); a test-harness
         # Context that sets none falls back to the block-local 0.0 (pure offload),
         # which is the correct no-split default.
         fetch_frac = float(getattr(model, "moe_hybrid_fetch_fraction", 0.0) or 0.0)
-        if cache_quant_format == "gptq_int4":
+        if cache_quant_format in ("gptq_int4", "fp8_block"):
             fetch_frac = 1.0
         if fetch_frac <= 0.0:
             # No usable profile -> every miss rides PCIe (pure offload).

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -696,10 +696,13 @@ class _Qwen3MoE(nn.Module):
         # issue's own accept criteria explicitly allows it as a first cut),
         # not a silent gap -- gptq_int4 previously would have crashed loudly
         # here (KeyError) rather than produced wrong numbers, and now simply
-        # never reaches that code path.
+        # never reaches that code path. "fp8_block" (issue
+        # moe-quant-banks-fp8, #152) has the exact same gap -- its
+        # bank_sources are named weight_gate_up/scale_gate_up/... -- and gets
+        # the same forced-fetch_frac=1.0 treatment for the same reason.
         cache_quant_format = getattr(getattr(model, "moe_cache", None), "quant_format", "bf16")
         fetch_frac = float(getattr(model, "moe_hybrid_fetch_fraction", 0.0) or 0.0)
-        if cache_quant_format == "gptq_int4":
+        if cache_quant_format in ("gptq_int4", "fp8_block"):
             fetch_frac = 1.0
         if fetch_frac <= 0.0:
             # No usable profile -> every miss rides PCIe (pure offload).

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -197,8 +197,15 @@ def load_moe_expert_sources(
     # dequantizing. checkpoint_quant_method reads this straight from the
     # checkpoint's own config.json, independent of ModelConfig (which does
     # not carry quantization_config today).
-    if checkpoint_quant_method(model_path) == "gptq":
+    quant_method = checkpoint_quant_method(model_path)
+    if quant_method == "gptq":
         return stream_moe_expert_sources_gptq(src, config)
+    # "fp8" (issue moe-quant-banks-fp8, #152): DeepSeek-V3 / sglang / vLLM's
+    # own quantization_config.quant_method spelling for the block-FP8
+    # convention this streams (verified against deepseek-ai/DeepSeek-V3's
+    # real config.json -- see stream_moe_expert_sources_fp8's docstring).
+    if quant_method == "fp8":
+        return stream_moe_expert_sources_fp8(src, config)
     return stream_moe_expert_sources(src, config, dtype=dtype, layer_sink=layer_sink)
 
 
@@ -393,6 +400,19 @@ def _expert_source_info(key: str) -> Tuple[int, str, Optional[int]] | None:
         raise ValueError(
             f"GPTQ-packed expert weight key {key!r} passed to the bf16 expert-source "
             "streamer; use stream_moe_expert_sources_gptq for a GPTQ checkpoint instead"
+        )
+    # Same defense for block-FP8's per-block scale component (see
+    # stream_moe_expert_sources_fp8, issue #152). Unlike GPTQ's qweight/qzeros/
+    # g_idx, block-FP8's OTHER component is spelled ``.weight`` -- identical to
+    # a plain dense tensor's own trailing token -- so it cannot be rejected the
+    # same way and instead relies on load_moe_expert_sources' checkpoint_quant_method
+    # dispatch (the primary safety net for both quantized formats) to never reach
+    # this function at all. ``weight_scale_inv`` has no such collision, so it is
+    # rejected here too, as defense in depth.
+    if tail and tail[-1] == "weight_scale_inv":
+        raise ValueError(
+            f"block-FP8-packed expert weight key {key!r} passed to the bf16 expert-source "
+            "streamer; use stream_moe_expert_sources_fp8 for a block-FP8 checkpoint instead"
         )
     # Real HF safetensors keys carry a trailing ``.weight`` (``...experts.{e}.{
     # gate|up|down}_proj.weight``); the FTW-normalized packed form (ADR 0002) may
@@ -794,6 +814,227 @@ def _finalize_gptq_bank(
     )
 
 
+@dataclass(frozen=True)
+class Fp8BlockExpertBank:
+    """One MoE layer's packed block-FP8 bank for one projection slot
+    (``gate_up`` or ``down``) -- the block-FP8 sibling of
+    :class:`GptqExpertBank` (issue `moe-quant-banks-fp8`, #152, part of the
+    same #134/#140 epic).
+
+    ``weight`` / ``weight_scale_inv`` hold one row per expert (``[E, ...]``,
+    the DeepSeek-V3 / sglang / vLLM ``w8a8_block_fp8`` layout -- see
+    :mod:`freetoken.kernel.triton.fp8_block_linear`). Unlike GPTQ's ``g_idx``,
+    block-FP8 has no side tensor shared across experts: every expert's scale
+    table is a function of that expert's own weight magnitudes alone, so both
+    tensors fit the plain per-expert ``[E, ...]`` bank shape and there is
+    nothing left over for ``OffloadMoeCache.extra_metadata``.
+
+    Deliberately packed, never dequantized here: dequantizing every expert to
+    the activation dtype at load time is the same real-scale RAM blowup issue
+    #134 built ADR 0002 to avoid. Dequantization happens lazily, per-expert,
+    at compute time (:class:`freetoken.moe.offload_cache.SlotWeightAccessor`)
+    against whichever row the offload cache's device slot pool has fetched
+    for the current step.
+    """
+
+    weight: torch.Tensor  # [E, N, K] torch.float8_e4m3fn
+    weight_scale_inv: torch.Tensor  # [E, ceil(N/block), ceil(K/block)]
+
+
+_FP8_COMPONENTS = ("weight", "weight_scale_inv")
+_FP8_DEFAULT_BLOCK = 128  # DeepSeek-V3 / sglang / vLLM's own default; see fp8_block_linear.py
+
+
+def _parse_fp8_expert_key(key: str) -> Tuple[int, str, int, str] | None:
+    """Parse a block-FP8-packed per-expert weight key into ``(layer, proj,
+    expert_id, component)``, or ``None`` if ``key`` is not one.
+
+    Recognizes ``...layers.{L}.mlp.experts.{e}.{gate_proj|up_proj|down_proj}
+    .{weight|weight_scale_inv}`` -- verified against the real
+    ``deepseek-ai/DeepSeek-V3`` checkpoint's own ``model.safetensors.index.json``
+    on HuggingFace (its ``config.json`` reads ``quantization_config ==
+    {"quant_method": "fp8", "fmt": "e4m3", "activation_scheme": "dynamic",
+    "weight_block_size": [128, 128]}``, and ``model.layers.3.mlp.experts.0.
+    gate_proj.{weight,weight_scale_inv}`` are real keys in its index) -- the
+    same per-expert key shape GPTQ uses (:func:`_parse_gptq_expert_key`), just
+    with block-FP8's two components instead of GPTQ's four, and no shared
+    ``g_idx``-like side tensor.
+    """
+    parts = key.split(".")
+    if len(parts) < 2 or parts[-1] not in _FP8_COMPONENTS:
+        return None
+    component = parts[-1]
+    body = parts[:-1]
+    if "mlp" not in body or "experts" not in body:
+        return None
+    try:
+        mlp_pos = body.index("mlp")
+        layer = int(body[mlp_pos - 1])
+    except (ValueError, IndexError):
+        return None
+    if body[mlp_pos + 1] != "experts":
+        return None
+    e_pos = body.index("experts")
+    tail = body[e_pos + 1 :]
+    if len(tail) != 2:
+        return None
+    try:
+        expert_id = int(tail[0])
+    except ValueError:
+        return None
+    proj = tail[1]
+    if proj not in {"gate_proj", "up_proj", "down_proj"}:
+        return None
+    return layer, proj, expert_id, component
+
+
+def stream_moe_expert_sources_fp8(
+    tensors: Iterator[Tuple[str, torch.Tensor]],
+    config,
+    *,
+    block: int = _FP8_DEFAULT_BLOCK,
+) -> Tuple[list, list]:
+    """Stream block-FP8-packed per-expert weight tensors into packed per-layer
+    banks (issue `moe-quant-banks-fp8`, #152) -- the block-FP8 sibling of
+    :func:`stream_moe_expert_sources_gptq`.
+
+    ``gate_up`` fuses ``gate_proj`` + ``up_proj`` (the checkpoint stores them
+    as separate quantized tensors, not pre-fused): both ``weight`` and
+    ``weight_scale_inv`` concatenate along dim 0, the ``N`` (output-channel)
+    axis -- matching every other bank's ``[E, 2I, H]`` gate-then-up
+    convention. Unlike GPTQ's ``K``-axis groups (architecture-constant and
+    shared across the whole checkpoint, so concatenating on ``N`` never
+    crosses a group boundary), block-FP8 blocks the ``N`` axis too:
+    concatenating two independently-quantized ``[N, K]`` tensors only
+    produces a tensor whose blocks still exactly cover ``block`` rows each if
+    ``gate_proj``'s own ``N`` (the MoE intermediate size) is itself a multiple
+    of ``block`` -- true of every real block-FP8 checkpoint found so far
+    (DeepSeek-V3's ``moe_intermediate_size`` is 2048, evenly divisible by its
+    own ``weight_block_size`` of 128) -- asserted in :func:`_finalize_fp8_bank`
+    rather than assumed, raising loudly instead of silently misaligning the
+    fused scale table.
+
+    Finalizes each ``(layer, bank_name)`` as soon as its last component
+    arrives, mirroring :func:`stream_moe_expert_sources_gptq`'s incremental
+    per-layer finalization -- never buffering more than one layer's worth of
+    raw per-expert tensors at once (issue #145 found and fixed a real
+    whole-checkpoint-buffering RAM bug in the GPTQ version's first draft; the
+    same bug class is avoided here from the start, not retrofitted).
+    """
+    buf: Dict[Tuple[int, str], Dict[int, Dict[str, Dict[str, torch.Tensor]]]] = {}
+    finalized: Dict[Tuple[int, str], Fp8BlockExpertBank] = {}
+
+    for name, tensor in tensors:
+        info = _parse_fp8_expert_key(name)
+        if info is None:
+            raise ValueError(f"Unexpected block-FP8 expert weight key: {name}")
+        layer, proj, expert_id, component = info
+        bank_name = "gate_up" if proj in ("gate_proj", "up_proj") else "down"
+        if not (0 <= layer < config.num_layers):
+            raise ValueError(f"Unexpected MoE expert layer {layer}; expected [0, {config.num_layers})")
+        if not (0 <= expert_id < config.num_experts):
+            raise ValueError(f"Unexpected MoE expert id {expert_id} in layer {layer}")
+        key = (layer, bank_name)
+        if key in finalized:
+            raise ValueError(
+                f"Layer {layer} {bank_name!r}: tensor {name!r} arrived after this bank was already "
+                "finalized -- duplicate key or an out-of-order/re-streamed source?"
+            )
+        by_expert = buf.setdefault(key, {})
+        by_proj = by_expert.setdefault(expert_id, {})
+        by_component = by_proj.setdefault(proj, {})
+        if component in by_component:
+            raise ValueError(f"Duplicate block-FP8 component {component!r} for layer {layer} expert {expert_id} {proj}")
+        by_component[component] = tensor
+
+        fuse = bank_name == "gate_up"
+        if _fp8_bank_is_complete(by_expert, config.num_experts, fuse=fuse):
+            finalized[key] = _finalize_fp8_bank(by_expert, config.num_experts, fuse=fuse, layer=layer, block=block)
+            del buf[key]  # release the raw per-expert tensors now that the packed bank owns the data
+
+    missing = [
+        (layer, bank_name)
+        for layer in range(config.num_layers)
+        for bank_name in ("gate_up", "down")
+        if (layer, bank_name) not in finalized
+    ]
+    if missing:
+        raise ValueError(f"Missing/incomplete block-FP8 MoE expert bank(s): {missing}")
+
+    gate_up_banks = [finalized[(layer, "gate_up")] for layer in range(config.num_layers)]
+    down_banks = [finalized[(layer, "down")] for layer in range(config.num_layers)]
+    return gate_up_banks, down_banks
+
+
+def _fp8_bank_is_complete(
+    by_expert: Dict[int, Dict[str, Dict[str, torch.Tensor]]],
+    num_experts: int,
+    *,
+    fuse: bool,
+) -> bool:
+    """True once every expert 0..num_experts-1 has all required projections
+    (``gate_proj``+``up_proj`` for ``fuse=True``, else ``down_proj``), each
+    with both block-FP8 components -- i.e. this ``(layer, bank_name)`` is
+    ready for :func:`_finalize_fp8_bank`."""
+    if set(by_expert) != set(range(num_experts)):
+        return False
+    required_projs = ("gate_proj", "up_proj") if fuse else ("down_proj",)
+    for e in range(num_experts):
+        by_proj = by_expert[e]
+        for proj in required_projs:
+            components = by_proj.get(proj)
+            if components is None or set(components) != set(_FP8_COMPONENTS):
+                return False
+    return True
+
+
+def _finalize_fp8_bank(
+    by_expert: Dict[int, Dict[str, Dict[str, torch.Tensor]]],
+    num_experts: int,
+    *,
+    fuse: bool,
+    layer: int,
+    block: int,
+) -> Fp8BlockExpertBank:
+    if set(by_expert) != set(range(num_experts)):
+        missing = sorted(set(range(num_experts)) - set(by_expert))
+        raise ValueError(f"Layer {layer}: missing block-FP8 experts {missing}")
+
+    per_expert_rows = []
+    for e in range(num_experts):
+        by_proj = by_expert[e]
+        if fuse:
+            gate = by_proj.get("gate_proj")
+            up = by_proj.get("up_proj")
+            if gate is None or up is None:
+                raise ValueError(f"Layer {layer} expert {e}: missing gate_proj/up_proj block-FP8 components")
+            # See stream_moe_expert_sources_fp8's docstring for why this
+            # alignment must hold before the N-axis concat below is safe.
+            n_gate = gate["weight"].shape[0]
+            if n_gate % block != 0:
+                raise ValueError(
+                    f"Layer {layer} expert {e}: gate_proj N={n_gate} is not a multiple of block={block}; "
+                    "fusing gate_proj+up_proj on the N axis would misalign the fused weight_scale_inv"
+                )
+            weight = torch.cat([gate["weight"], up["weight"]], dim=0)
+            weight_scale_inv = torch.cat([gate["weight_scale_inv"], up["weight_scale_inv"]], dim=0)
+        else:
+            down = by_proj.get("down_proj")
+            if down is None:
+                raise ValueError(f"Layer {layer} expert {e}: missing down_proj block-FP8 components")
+            weight, weight_scale_inv = down["weight"], down["weight_scale_inv"]
+        per_expert_rows.append((weight, weight_scale_inv))
+
+    # _stack_expert_rows (not torch.stack): the torch XPU build mishandles a
+    # direct cat/stack of 2-D per-expert rows along a new leading dim --
+    # unsqueeze-then-cat is the reliable path this codebase already
+    # standardizes on (see _stack_expert_rows's own docstring).
+    return Fp8BlockExpertBank(
+        weight=_stack_expert_rows([row[0] for row in per_expert_rows]),
+        weight_scale_inv=_stack_expert_rows([row[1] for row in per_expert_rows]),
+    )
+
+
 __all__ = [
     "load_weight",
     "load_moe_expert_sources",
@@ -802,6 +1043,8 @@ __all__ = [
     "_PlainBank",
     "GptqExpertBank",
     "stream_moe_expert_sources_gptq",
+    "Fp8BlockExpertBank",
+    "stream_moe_expert_sources_fp8",
     "checkpoint_quant_method",
     "checkpoint_gptq_group_size",
 ]

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -68,6 +68,17 @@ logger = init_logger(__name__)
 # in OffloadMoeCache.extra_metadata instead (see set_extra_metadata /
 # get_extra_metadata below): a plain per-layer side table the compute step
 # (issue #137) reads directly, never routed through the LRU slot machinery.
+#
+# "fp8_block" (issue moe-quant-banks-fp8, #152): a block-FP8-quantized
+# checkpoint (DeepSeek-V3 / sglang / vLLM's public w8a8_block_fp8 convention,
+# see freetoken.kernel.triton.fp8_block_linear) packs each projection into
+# two per-expert tensors -- weight (fp8) + weight_scale_inv (the per-block
+# scale table) -- instead of GPTQ's three. Four banks total: {weight,
+# weight_scale_inv} x {gate_up,down}. All four are one-row-per-expert
+# ([E, ...]), same as bf16/gptq_int4, so they fit set_bank_sources/
+# copy_missing/rebuild unchanged too. Unlike GPTQ, block-FP8 has no
+# shared-across-experts side tensor (no g_idx analogue): every expert's
+# weight_scale_inv is genuinely its own, so nothing needs extra_metadata here.
 _BANK_SCHEMAS: dict[str, tuple[str, ...]] = {
     "bf16": ("gate_up", "down"),
     "gptq_int4": (
@@ -77,6 +88,12 @@ _BANK_SCHEMAS: dict[str, tuple[str, ...]] = {
         "qweight_down",
         "qzeros_down",
         "scales_down",
+    ),
+    "fp8_block": (
+        "weight_gate_up",
+        "scale_gate_up",
+        "weight_down",
+        "scale_down",
     ),
 }
 
@@ -610,12 +627,13 @@ class SlotWeightAccessor:
 
     For ``"bf16"`` this is a thin, zero-cost wrapper around the existing
     plain-tensor indexing (behavior is unchanged from before this class
-    existed). For ``"gptq_int4"`` each distinct slot's packed
-    qweight/qzeros/scales are dequantized **at most once per instance** (a
-    `_forward_offload_core` call handles one MoE layer for one step) -- a
-    decode step's working set is typically small (<= num_experts active
-    slots), so this is a bounded, cheap cost per step, never the whole
-    checkpoint at once (the RAM-saving point of #134's whole epic).
+    existed). For ``"gptq_int4"`` and ``"fp8_block"`` (issue
+    moe-quant-banks-fp8, #152) each distinct slot's packed weights are
+    dequantized **at most once per instance** (a `_forward_offload_core` call
+    handles one MoE layer for one step) -- a decode step's working set is
+    typically small (<= num_experts active slots), so this is a bounded,
+    cheap cost per step, never the whole checkpoint at once (the RAM-saving
+    point of #134's whole epic).
 
     ``dtype`` is the dequant output dtype -- must match the activation
     tensor's dtype (``flat``, whatever ``moe_backend="offload"`` loaded the
@@ -659,6 +677,19 @@ class SlotWeightAccessor:
                     "gptq_int4 forward pass runs (SlotWeightAccessor refuses to guess)"
                 )
             self._group_size = int(group_size)
+        elif self.quant_format == "fp8_block":
+            self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
+            # No group_size-style checkpoint parameter to thread through here:
+            # block-FP8's block size is a fixed convention (128), not a
+            # per-checkpoint choice like GPTQ's group_size -- every real
+            # block-FP8 checkpoint found so far (DeepSeek-V3 included) uses
+            # weight_block_size == [128, 128]. An optional cache.fp8_block_size
+            # override is still honored (falls back to the module default)
+            # in case a future checkpoint's quantization_config.weight_block_size
+            # ever differs.
+            from freetoken.kernel.triton.fp8_block_linear import _BLOCK as _FP8_DEFAULT_BLOCK
+
+            self._fp8_block = int(getattr(cache, "fp8_block_size", None) or _FP8_DEFAULT_BLOCK)
         else:
             self._gu, self._dn = cache.bank_views()
 
@@ -666,19 +697,41 @@ class SlotWeightAccessor:
         """``(gate_w, up_w, down_w)`` for slot ``s_i``, in ``[out, in]``
         weight orientation (matching ``nn.Linear.weight`` / ``_expert_compute``'s
         expected shape) -- gate/up are ``[I, H]``, down is ``[H, I]``."""
-        if self.quant_format != "gptq_int4":
+        if self.quant_format == "bf16":
             i = self._intermediate
             return self._gu[s_i, 0:i], self._gu[s_i, i : 2 * i], self._dn[s_i]
         cached = self._cache.get(s_i)
         if cached is not None:
             return cached
+        if self.quant_format == "fp8_block":
+            from freetoken.kernel.triton.fp8_block_linear import dequantize_block_fp8
+
+            b = self._banks
+            # dequantize_block_fp8 reconstructs [N, K] -- already the [out, in]
+            # orientation this port's bank rows use (unlike GPTQ's dequant,
+            # which returns [in, out] and needs a .T). out_dtype is
+            # self._dtype (the model's activation dtype), NOT the checkpoint's
+            # own stored weight_scale_inv dtype -- the same dtype bug class
+            # issue #138 found for gptq_int4 (see the class docstring).
+            gu_dense = dequantize_block_fp8(
+                b["weight_gate_up"][s_i], b["scale_gate_up"][s_i],
+                block=self._fp8_block, out_dtype=self._dtype,
+            )
+            dn_dense = dequantize_block_fp8(
+                b["weight_down"][s_i], b["scale_down"][s_i],
+                block=self._fp8_block, out_dtype=self._dtype,
+            )
+            i = self._intermediate
+            result = (gu_dense[0:i].contiguous(), gu_dense[i : 2 * i].contiguous(), dn_dense.contiguous())
+            self._cache[s_i] = result
+            return result
         from freetoken.kernel.triton.gptq_linear import dequantize_gptq_int4_sequential_groups as _dequant
 
         b = self._banks
         # dequantize_gptq_int4_sequential_groups returns [in_features, out_features]
         # (nn.Linear's transpose); .T gives the [out, in] orientation this port's
         # bf16 bank rows already use. out_dtype is self._dtype (the model's
-        # activation dtype), NOT the checkpoint's own scales.dtype -- see the
+        # activation dtype), NOT the checkpoint's own stored scales dtype -- see the
         # class docstring for the real bug this was.
         gu_dense = _dequant(
             b["qweight_gate_up"][s_i], b["qzeros_gate_up"][s_i], b["scales_gate_up"][s_i],

--- a/tests/test_moe_hybrid_fp8_exclusion.py
+++ b/tests/test_moe_hybrid_fp8_exclusion.py
@@ -1,0 +1,68 @@
+"""fp8_block is excluded from the hybrid CPU/PCIe split (issue
+`moe-quant-banks-fp8`, #152), mirroring gptq_int4's exclusion (issue #137):
+_cpu_subset_math hardcodes the "bf16" bank names
+(model.moe_cache.bank_sources["gate_up"]/["down"]) and would KeyError against
+an "fp8_block" cache's differently-named banks. _forward_hybrid now forces
+fetch_frac to 1.0 (pure offload, no CPU split) whenever the cache's
+quant_format is "gptq_int4" OR "fp8_block", documented as a deliberate
+first-cut tradeoff rather than teaching the CPU half to dequantize too.
+
+Tests _Qwen3MoE._forward_hybrid (qwen3_moe) directly via a stand-in ``self``
+(unittest.mock), same as test_moe_hybrid_gptq_exclusion.py -- isolates the
+routing decision (does it call _forward_offload or attempt the CPU split?)
+from real tensor math, real weights, or the full loader/engine stack.
+CPU-only, no XPU.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.qwen3_moe import _Qwen3MoE
+
+
+def _fake_self(*, cache_quant_format: str, fetch_fraction: float = 0.5):
+    self_ = MagicMock(spec=_Qwen3MoE)
+    self_._is_cpu_layer.return_value = False
+    self_._forward_offload.return_value = torch.zeros(1)
+    model = MagicMock()
+    model.moe_cache = MagicMock()
+    model.moe_cache.quant_format = cache_quant_format
+    model.moe_hybrid_fetch_fraction = fetch_fraction
+    model.moe_hybrid_max_fetch = -1
+    return self_, model
+
+
+def test_fp8_block_never_reaches_cpu_split():
+    self_, model = _fake_self(cache_quant_format="fp8_block", fetch_fraction=0.5)
+    top_idx = torch.zeros(1, 1, dtype=torch.long)
+    top_w = torch.ones(1, 1)
+    flat = torch.zeros(1, 4)
+
+    out = _Qwen3MoE._forward_hybrid(self_, flat, top_idx, top_w, model, batch=None)
+
+    self_._forward_offload.assert_called_once_with(flat, top_idx, top_w, model, None)
+    self_._hybrid_cpu_pool.assert_not_called()
+    torch.testing.assert_close(out, torch.zeros(1))
+
+
+def test_bf16_still_splits_normally_when_fetch_fraction_is_mid_range():
+    """Sanity check that the new fp8_block guard does not accidentally
+    change bf16 behavior: with a mid-range fetch_fraction and
+    quant_format="bf16", the method must proceed into the real split logic."""
+    self_, model = _fake_self(cache_quant_format="bf16", fetch_fraction=0.5)
+    top_idx = torch.tensor([[0, 1]])
+    top_w = torch.tensor([[0.5, 0.5]])
+    flat = torch.zeros(1, 4)
+
+    self_._forward_offload.return_value = torch.zeros(1, 4)
+    self_._hybrid_cpu_pool.return_value.submit.return_value.result.return_value = torch.zeros(1, 4)
+
+    _Qwen3MoE._forward_hybrid(self_, flat, top_idx, top_w, model, batch=None)
+
+    self_._forward_offload.assert_called_once()
+    _, kwargs = self_._forward_offload.call_args
+    assert kwargs.get("exclude"), "expected a real, non-empty CPU-expert split (exclude=...)"

--- a/tests/test_moe_offload_fp8_schema.py
+++ b/tests/test_moe_offload_fp8_schema.py
@@ -1,0 +1,120 @@
+"""Tests for the ``fp8_block`` offload-cache bank schema (issue
+`moe-quant-banks-fp8`, #152).
+
+Companion to test_moe_offload_gptq_schema.py (the ``gptq_int4`` schema's own
+tests) and test_moe_offload_cache.py / test_moe_offload_rebuild.py (the
+``bf16`` schema's). Small synthetic packed-fp8 fixtures, no real checkpoint,
+no XPU.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.moe.offload_cache import _BANK_SCHEMAS, OffloadMoeCache
+
+DEVICE = torch.device("cpu")
+L, E, S = 2, 4, 8  # 2 layers, 4 experts, 8 slots
+N, K, BLOCK = 8, 16, 8  # small in/out dims + block size (both multiples of BLOCK)
+
+
+def _packed_bank_sources():
+    """Distinguishable per-(layer, expert) packed rows for every fp8_block
+    bank -- values chosen so a test can tell which (layer, expert) a slot
+    currently holds, same spirit as the gptq_int4 schema's own fixture."""
+    n_blocks_row, n_blocks_col = N // BLOCK, K // BLOCK
+
+    def tag(layer, expert):
+        return 100 * (layer + 1) + 10 * (expert + 1)
+
+    sources = {name: [] for name in _BANK_SCHEMAS["fp8_block"]}
+    for layer in range(L):
+        per_bank_layers = {name: [] for name in sources}
+        for expert in range(E):
+            t = tag(layer, expert)
+            for proj, n, k in (("gate_up", N, K), ("down", N, K)):
+                per_bank_layers[f"weight_{proj}"].append(torch.full((n, k), float(t), dtype=torch.float8_e4m3fn))
+                per_bank_layers[f"scale_{proj}"].append(torch.full((n_blocks_row, n_blocks_col), float(t), dtype=torch.float32))
+        for name in sources:
+            sources[name].append(torch.stack(per_bank_layers[name]))
+    return sources
+
+
+def test_schema_registered():
+    assert "fp8_block" in _BANK_SCHEMAS
+    assert _BANK_SCHEMAS["fp8_block"] == (
+        "weight_gate_up",
+        "scale_gate_up",
+        "weight_down",
+        "scale_down",
+    )
+
+
+def test_set_bank_sources_allocates_correctly_shaped_dtyped_device_caches():
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="fp8_block")
+    sources = _packed_bank_sources()
+    cache.set_bank_sources(sources)
+
+    for name in _BANK_SCHEMAS["fp8_block"]:
+        host_row_shape = sources[name][0].shape[1:]
+        dev_cache = cache.bank_caches[name]
+        assert dev_cache.shape == (S, *host_row_shape)
+        assert dev_cache.dtype == sources[name][0].dtype
+    assert cache.bank_caches["weight_gate_up"].dtype == torch.float8_e4m3fn
+    assert cache.bank_caches["scale_gate_up"].dtype == torch.float32
+
+
+def test_materialize_and_copy_missing_moves_real_packed_bytes():
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="fp8_block")
+    sources = _packed_bank_sources()
+    cache.set_bank_sources(sources)
+
+    cache.materialize_layer(0)
+    cache.copy_missing()
+
+    for expert in range(E):
+        slot = int(cache.slot_for_id[0, expert].item())
+        assert slot != -1
+        expected_tag = 100 * 1 + 10 * (expert + 1)
+        # fp8_e4m3 has coarse precision at this magnitude (tag 110 rounds to
+        # 112, e.g.) -- round the expected value through the same dtype
+        # rather than asserting against the un-rounded tag.
+        expected_fp8 = torch.tensor(float(expected_tag), dtype=torch.float8_e4m3fn).to(torch.float32)
+        torch.testing.assert_close(
+            cache.bank_caches["weight_gate_up"][slot].to(torch.float32),
+            torch.full_like(cache.bank_caches["weight_gate_up"][slot].to(torch.float32), expected_fp8.item()),
+        )
+        torch.testing.assert_close(
+            cache.bank_caches["scale_down"][slot],
+            torch.full_like(cache.bank_caches["scale_down"][slot], float(expected_tag)),
+        )
+
+
+def test_rebuild_resizes_fp8_schema_pool():
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="fp8_block")
+    cache.set_bank_sources(_packed_bank_sources())
+    cache.materialize_layer(0)
+    cache.copy_missing()
+
+    cache.rebuild(2 * S)
+    for name in _BANK_SCHEMAS["fp8_block"]:
+        assert cache.bank_caches[name].shape[0] == 2 * S
+    assert int(cache.slot_for_id.min().item()) == -1 or (cache.slot_for_id == -1).all()
+
+
+def test_bf16_and_gptq_schemas_unaffected_by_fp8_registration():
+    """Strictly-additive check: the existing schemas still behave exactly as
+    they did before this change."""
+    assert "bf16" in _BANK_SCHEMAS and _BANK_SCHEMAS["bf16"] == ("gate_up", "down")
+    assert "gptq_int4" in _BANK_SCHEMAS
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="bf16")
+    h, i = 16, 8
+    sources = {
+        "gate_up": [torch.randn(E, 2 * i, h) for _ in range(L)],
+        "down": [torch.randn(E, h, i) for _ in range(L)],
+    }
+    cache.set_bank_sources(sources)
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    assert all(int(cache.slot_for_id[0, e].item()) != -1 for e in range(E))

--- a/tests/test_moe_slot_weight_accessor_fp8.py
+++ b/tests/test_moe_slot_weight_accessor_fp8.py
@@ -1,0 +1,170 @@
+"""SlotWeightAccessor: the offload forward's per-slot weight lookup,
+abstracted over bf16 (unchanged), gptq_int4, and fp8_block (issue
+`moe-quant-banks-fp8`, #152) -- dequantize-at-compute.
+
+Builds against the shape/bank-name contract registered in
+_BANK_SCHEMAS["fp8_block"] (weight/scale x {gate_up,down}, no shared side
+tensor -- unlike gptq_int4's g_idx, block-FP8's scale is genuinely per
+expert). CPU-only, small synthetic fixtures, no real checkpoint, no XPU.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.fp8_block_linear import dequantize_block_fp8, quantize_block_fp8
+from freetoken.moe.offload_cache import OffloadMoeCache, SlotWeightAccessor
+
+DEVICE = torch.device("cpu")
+
+
+def _make_packed_projection(n: int, k: int, block: int, *, seed: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """A real (non-constant) small block-FP8-packed [N, K] projection: values
+    vary by position (derived from `seed`), so a test can't accidentally pass
+    by everything happening to be uniform."""
+    g = torch.Generator().manual_seed(seed)
+    dense = torch.randn(n, k, generator=g)
+    return quantize_block_fp8(dense, block=block)
+
+
+def _cache_with_fp8_bank(n_gu: int, k_gu: int, n_dn: int, k_dn: int, block: int, *, num_experts: int, cache_size: int):
+    cache = OffloadMoeCache(1, num_experts, cache_size, DEVICE, quant_format="fp8_block")
+    cache.fp8_block_size = block  # SlotWeightAccessor reads this (default 128 otherwise)
+    sources = {name: [] for name in ("weight_gate_up", "scale_gate_up", "weight_down", "scale_down")}
+    projections = []  # keep the raw per-expert projections to check against
+    for e in range(num_experts):
+        gu_w, gu_s = _make_packed_projection(n_gu, k_gu, block, seed=100 + e)
+        dn_w, dn_s = _make_packed_projection(n_dn, k_dn, block, seed=200 + e)
+        projections.append((gu_w, gu_s, dn_w, dn_s))
+        for name, t in (
+            ("weight_gate_up", gu_w), ("scale_gate_up", gu_s),
+            ("weight_down", dn_w), ("scale_down", dn_s),
+        ):
+            sources[name].append(t)
+    sources = {name: [torch.stack(v)] for name, v in sources.items()}  # -> [1 layer][E, ...]
+    cache.set_bank_sources(sources)
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    return cache, projections
+
+
+def test_fp8_get_matches_direct_dequant_for_each_expert():
+    hidden, inter, block, num_experts = 16, 8, 8, 3
+    cache, projections = _cache_with_fp8_bank(
+        n_gu=2 * inter, k_gu=hidden, n_dn=hidden, k_dn=inter, block=block,
+        num_experts=num_experts, cache_size=num_experts,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+
+    for e in range(num_experts):
+        slot = int(cache.slot_for_id[0, e].item())
+        gate_w, up_w, down_w = accessor.get(slot)
+        gu_w, gu_s, dn_w, dn_s = projections[e]
+
+        # SlotWeightAccessor dequantizes to the dtype it was constructed with
+        # (torch.float32 here) -- NOT the bank's own weight_scale_inv dtype (the
+        # same dtype bug class issue #138 found for gptq_int4: the loaded
+        # checkpoint's stored scale dtype must never leak into the dequantized
+        # output, which must match the model's activation dtype instead).
+        expected_gu = dequantize_block_fp8(gu_w, gu_s, block=block, out_dtype=torch.float32)
+        expected_dn = dequantize_block_fp8(dn_w, dn_s, block=block, out_dtype=torch.float32)
+
+        torch.testing.assert_close(gate_w, expected_gu[0:inter])
+        torch.testing.assert_close(up_w, expected_gu[inter : 2 * inter])
+        torch.testing.assert_close(down_w, expected_dn)
+
+
+def test_fp8_get_dtype_matches_requested_dtype_not_scale_dtype():
+    """The gptq_int4 bug class (#138) applied to fp8_block: dequantizing must
+    always target the requested dtype, never whatever dtype the checkpoint
+    happens to store weight_scale_inv as. Builds a fixture whose scale bank is
+    deliberately float16 -- a different dtype than the bfloat16 requested at
+    construction -- and asserts the *output* matches the requested dtype."""
+    hidden, inter, block = 16, 8, 8
+    cache, _ = _cache_with_fp8_bank(
+        n_gu=2 * inter, k_gu=hidden, n_dn=hidden, k_dn=inter, block=block,
+        num_experts=1, cache_size=1,
+    )
+    cache.bank_caches["scale_gate_up"] = cache.bank_caches["scale_gate_up"].to(torch.float16)
+    cache.bank_caches["scale_down"] = cache.bank_caches["scale_down"].to(torch.float16)
+
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.bfloat16)
+    gate_w, up_w, down_w = accessor.get(0)
+    assert gate_w.dtype == torch.bfloat16
+    assert up_w.dtype == torch.bfloat16
+    assert down_w.dtype == torch.bfloat16
+
+
+def test_fp8_get_shapes_match_out_in_convention():
+    hidden, inter, block = 16, 8, 8
+    cache, _ = _cache_with_fp8_bank(
+        n_gu=2 * inter, k_gu=hidden, n_dn=hidden, k_dn=inter, block=block,
+        num_experts=1, cache_size=1,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    gate_w, up_w, down_w = accessor.get(0)
+    assert gate_w.shape == (inter, hidden)
+    assert up_w.shape == (inter, hidden)
+    assert down_w.shape == (hidden, inter)
+
+
+def test_fp8_get_caches_per_slot_within_one_instance():
+    """A distinct slot is dequantized once, not once per .get() call -- the
+    whole point of this issue (dequantize only the resident working set, at
+    most once per step, never re-derive redundantly)."""
+    hidden, inter, block = 16, 8, 8
+    cache, _ = _cache_with_fp8_bank(
+        n_gu=2 * inter, k_gu=hidden, n_dn=hidden, k_dn=inter, block=block,
+        num_experts=1, cache_size=1,
+    )
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    first = accessor.get(0)
+    second = accessor.get(0)
+    for a, b in zip(first, second):
+        assert a.data_ptr() == b.data_ptr()  # identical cached tensor object, not recomputed
+
+
+def test_fp8_accessor_defaults_block_size_to_128():
+    """Unlike gptq_int4's group_size (a genuine per-checkpoint choice, so
+    SlotWeightAccessor refuses to guess it), block-FP8's block size is a
+    fixed, universal convention (128) that every real checkpoint found so
+    far uses -- so a cache with no fp8_block_size override must not raise,
+    and must dequantize using the module's own default block."""
+    hidden, inter = 256, 128  # multiples of the real default block (128)
+    cache, projections = _cache_with_fp8_bank(
+        n_gu=2 * inter, k_gu=hidden, n_dn=hidden, k_dn=inter, block=128,
+        num_experts=1, cache_size=1,
+    )
+    del cache.fp8_block_size  # exercise the no-override default, not this fixture's explicit set
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    gate_w, up_w, down_w = accessor.get(0)
+    gu_w, gu_s, dn_w, dn_s = projections[0]
+    expected_gu = dequantize_block_fp8(gu_w, gu_s, block=128, out_dtype=torch.float32)
+    expected_dn = dequantize_block_fp8(dn_w, dn_s, block=128, out_dtype=torch.float32)
+    torch.testing.assert_close(gate_w, expected_gu[0:inter])
+    torch.testing.assert_close(up_w, expected_gu[inter : 2 * inter])
+    torch.testing.assert_close(down_w, expected_dn)
+
+
+def test_bf16_accessor_behavior_unchanged():
+    """The bf16 path must be a pure passthrough to bank_views() indexing --
+    no dequant, no extra allocation, identical values to reading gu/dn
+    directly. Re-asserted here (mirrors test_moe_slot_weight_accessor.py) as
+    a strictly-additive check against this issue's fp8_block branch."""
+    E, hidden, inter = 2, 16, 8
+    cache = OffloadMoeCache(1, E, E, DEVICE, quant_format="bf16")
+    gu_src = [torch.randn(E, 2 * inter, hidden)]
+    dn_src = [torch.randn(E, hidden, inter)]
+    cache.set_bank_sources({"gate_up": gu_src, "down": dn_src})
+    cache.materialize_layer(0)
+    cache.copy_missing()
+
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    gu, dn = cache.bank_views()
+    for e in range(E):
+        slot = int(cache.slot_for_id[0, e].item())
+        gate_w, up_w, down_w = accessor.get(slot)
+        torch.testing.assert_close(gate_w, gu[slot, 0:inter])
+        torch.testing.assert_close(up_w, gu[slot, inter : 2 * inter])
+        torch.testing.assert_close(down_w, dn[slot])

--- a/tests/test_weight_fp8_banks.py
+++ b/tests/test_weight_fp8_banks.py
@@ -1,0 +1,177 @@
+"""``stream_moe_expert_sources_fp8``: packed block-FP8 expert banks stay
+packed (issue `moe-quant-banks-fp8`, #152, part of epic #140/#134).
+
+CPU-only, synthetic fixtures -- the whole point of this issue is that these
+banks are NEVER dequantized here (that happens lazily, per-expert, at
+compute time, via SlotWeightAccessor); the round-trip check below
+dequantizes only for test verification, via the already-shipped
+``dequantize_block_fp8`` (issue #125).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.fp8_block_linear import dequantize_block_fp8, quantize_block_fp8
+from freetoken.models.weight import Fp8BlockExpertBank, stream_moe_expert_sources_fp8
+
+
+def _fp8_projection(n: int, k: int, value: float, *, block: int = 8):
+    """A small, real (not random-garbage) block-FP8-packed [N, K] projection:
+    every element is the same constant, so the dequantized value round-trips
+    (within fp8's coarse quantization error) to a known constant."""
+    dense = torch.full((n, k), value)
+    weight, scale = quantize_block_fp8(dense, block=block)
+    return weight, scale
+
+
+def _expert_stream(config, *, gate_value, up_value, down_value, n: int, k: int, block: int):
+    """Yield ``(name, tensor)`` pairs for every expert of every layer, in the
+    real checkpoint's raw per-expert block-FP8 key spelling (verified against
+    deepseek-ai/DeepSeek-V3's own model.safetensors.index.json)."""
+    for layer in range(config.num_layers):
+        for e in range(config.num_experts):
+            for proj, value in (("gate_proj", gate_value), ("up_proj", up_value), ("down_proj", down_value)):
+                weight, scale = _fp8_projection(n, k, value, block=block)
+                prefix = f"model.layers.{layer}.mlp.experts.{e}.{proj}"
+                yield prefix + ".weight", weight
+                yield prefix + ".weight_scale_inv", scale
+
+
+def test_packed_bank_shapes_match_the_documented_contract():
+    config = SimpleNamespace(num_layers=2, num_experts=3)
+    n, k, block = 8, 16, 8
+    stream = _expert_stream(config, gate_value=1.0, up_value=1.0, down_value=1.0, n=n, k=k, block=block)
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_fp8(stream, config, block=block)
+
+    assert len(gate_up_banks) == config.num_layers
+    assert len(down_banks) == config.num_layers
+    for bank in gate_up_banks:
+        assert isinstance(bank, Fp8BlockExpertBank)
+        # gate_up fuses gate_proj+up_proj on the N axis -> N doubles.
+        assert bank.weight.shape == (config.num_experts, 2 * n, k)
+        assert bank.weight_scale_inv.shape == (config.num_experts, 2 * n // block, k // block)
+        assert bank.weight.dtype == torch.float8_e4m3fn
+    for bank in down_banks:
+        assert bank.weight.shape == (config.num_experts, n, k)
+        assert bank.weight_scale_inv.shape == (config.num_experts, n // block, k // block)
+
+
+def test_packed_bank_round_trips_to_the_known_fixture_value():
+    config = SimpleNamespace(num_layers=1, num_experts=2)
+    n, k, block = 8, 16, 8
+    stream = _expert_stream(config, gate_value=2.0, up_value=2.0, down_value=-3.0, n=n, k=k, block=block)
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_fp8(stream, config, block=block)
+
+    for e in range(config.num_experts):
+        down = dequantize_block_fp8(
+            down_banks[0].weight[e], down_banks[0].weight_scale_inv[e], block=block, out_dtype=torch.float32
+        )
+        torch.testing.assert_close(down, torch.full((n, k), -3.0), atol=0.05, rtol=0.05)
+
+        gate_up = dequantize_block_fp8(
+            gate_up_banks[0].weight[e], gate_up_banks[0].weight_scale_inv[e], block=block, out_dtype=torch.float32
+        )
+        torch.testing.assert_close(gate_up, torch.full((2 * n, k), 2.0), atol=0.05, rtol=0.05)
+
+
+def test_gate_up_concatenation_preserves_two_independently_quantized_halves():
+    """A real test of the concat axis, not a trivial no-op: gate_proj and
+    up_proj are quantized with DIFFERENT values, so the fused bank's two
+    halves must dequantize back to their own distinct source values."""
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    n, k, block = 8, 16, 8
+    stream = _expert_stream(config, gate_value=1.5, up_value=-2.5, down_value=0.5, n=n, k=k, block=block)
+
+    gate_up_banks, _down_banks = stream_moe_expert_sources_fp8(stream, config, block=block)
+    bank = gate_up_banks[0]
+
+    fused = dequantize_block_fp8(bank.weight[0], bank.weight_scale_inv[0], block=block, out_dtype=torch.float32)
+    # gate/up were concatenated on the N (dim 0) axis, so the two halves split
+    # along rows.
+    assert fused.shape == (2 * n, k)
+    gate_half, up_half = fused[:n], fused[n:]
+    torch.testing.assert_close(gate_half, torch.full((n, k), 1.5), atol=0.05, rtol=0.05)
+    torch.testing.assert_close(up_half, torch.full((n, k), -2.5), atol=0.05, rtol=0.05)
+
+
+def test_gate_proj_n_not_multiple_of_block_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    n, k, block = 8, 16, 8
+
+    def stream():
+        for proj, value in (("gate_proj", 1.0), ("up_proj", 1.0), ("down_proj", 1.0)):
+            # Fabricate an N=5 projection directly (not a multiple of block=8)
+            # -- quantize_block_fp8 itself pads internally, but the *stored*
+            # weight shape here is what stream_moe_expert_sources_fp8 checks.
+            weight, scale = _fp8_projection(5, k, value, block=block)
+            prefix = f"model.layers.0.mlp.experts.0.{proj}"
+            yield prefix + ".weight", weight
+            yield prefix + ".weight_scale_inv", scale
+
+    with pytest.raises(ValueError, match="not a multiple of block"):
+        stream_moe_expert_sources_fp8(stream(), config, block=block)
+
+
+def test_missing_layer_raises():
+    config = SimpleNamespace(num_layers=2, num_experts=1)
+    n, k, block = 8, 8, 8
+
+    def stream():
+        # only layer 0, layer 1 never appears
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            weight, scale = _fp8_projection(n, k, 1.0, block=block)
+            prefix = "model.layers.0.mlp.experts.0." + proj
+            yield prefix + ".weight", weight
+            yield prefix + ".weight_scale_inv", scale
+
+    with pytest.raises(ValueError, match="Missing/incomplete block-FP8 MoE expert bank"):
+        stream_moe_expert_sources_fp8(stream(), config, block=block)
+
+
+def test_unexpected_key_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    with pytest.raises(ValueError, match="Unexpected block-FP8 expert weight key"):
+        stream_moe_expert_sources_fp8(iter([("not.a.fp8.key", torch.zeros(1))]), config)
+
+
+def test_finalizes_each_layer_as_soon_as_it_completes():
+    """Mirrors the real fix from GPTQ's issue #145: streaming layer 0 to
+    completion must release its raw buffer before layer 1 is even seen, not
+    wait for the whole generator to be exhausted."""
+    config = SimpleNamespace(num_layers=2, num_experts=1)
+    n, k, block = 8, 8, 8
+
+    def stream():
+        for layer in range(2):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                weight, scale = _fp8_projection(n, k, 1.0, block=block)
+                prefix = f"model.layers.{layer}.mlp.experts.0.{proj}"
+                yield prefix + ".weight", weight
+                yield prefix + ".weight_scale_inv", scale
+
+    import freetoken.models.weight as weight_mod
+
+    original_finalize = weight_mod._finalize_fp8_bank
+    call_order = []
+
+    def spy(by_expert, num_experts, *, fuse, layer, block):
+        call_order.append((layer, "gate_up" if fuse else "down"))
+        return original_finalize(by_expert, num_experts, fuse=fuse, layer=layer, block=block)
+
+    weight_mod._finalize_fp8_bank = spy
+    try:
+        weight_mod.stream_moe_expert_sources_fp8(stream(), config, block=block)
+    finally:
+        weight_mod._finalize_fp8_bank = original_finalize
+
+    layer0_calls = [c for c in call_order if c[0] == 0]
+    layer1_calls = [c for c in call_order if c[0] == 1]
+    assert len(layer0_calls) == 2
+    assert len(layer1_calls) == 2
+    assert call_order.index(layer1_calls[0]) > call_order.index(layer0_calls[-1])


### PR DESCRIPTION
## Summary

Wires block-FP8 (DeepSeek-V3 / sglang / vLLM's public `w8a8_block_fp8` convention) into the packed offload-bank machinery (ADR 0002) already built for GPTQ-Int4 (issues #135-#138), so a block-FP8-quantized MoE checkpoint's routed-expert weights stay packed in host RAM and dequantize lazily, per-expert, at compute time -- never eagerly exploding host RAM the way a full dequant-on-load would (issue #134).

Closes #152 (part of epic #140, child of #134).

## What changed

- **`python/freetoken/models/weight.py`**: `Fp8BlockExpertBank` (frozen dataclass: `weight` fp8 + `weight_scale_inv`) and `stream_moe_expert_sources_fp8`, mirroring `stream_moe_expert_sources_gptq`'s incremental per-`(layer, bank)` finalization -- never buffers more than one layer's raw per-expert tensors at once (the RAM-blowup bug class issue #145 found and fixed for GPTQ is avoided here from the start). `load_moe_expert_sources` now dispatches `checkpoint_quant_method(model_path) == "fp8"` to this streamer.
- **Real key spelling verified, not assumed**: fetched `deepseek-ai/DeepSeek-V3`'s real `config.json` (`quantization_config == {"quant_method": "fp8", "fmt": "e4m3", "activation_scheme": "dynamic", "weight_block_size": [128, 128]}`) and `model.safetensors.index.json` from HuggingFace -- confirms `model.layers.{L}.mlp.experts.{e}.{gate_proj|up_proj|down_proj}.{weight,weight_scale_inv}` is the real per-expert key shape, exactly the spelling assumed in issue #152's own body. (Also checked `RedHatAI/Mixtral-8x7B-Instruct-v0.1-FP8` first -- that one turned out to be per-tensor `compressed-tensors` FP8, not block-FP8, so it wasn't useful for this; DeepSeek-V3 itself is the real block-FP8 reference.)
- **`python/freetoken/moe/offload_cache.py`**: registers `_BANK_SCHEMAS["fp8_block"]` (`weight_gate_up`, `scale_gate_up`, `weight_down`, `scale_down` -- 4 banks; unlike GPTQ's `g_idx`, block-FP8 has no side tensor shared across experts, so nothing needs `extra_metadata`). `SlotWeightAccessor` gains an `elif self.quant_format == "fp8_block":` branch calling `dequantize_block_fp8`, dequantizing to the activation dtype passed to `__init__` -- **not** the checkpoint's own stored `weight_scale_inv` dtype, the exact dtype bug class issue #138 found for GPTQ (fp16 scales vs bf16 activations crashed matmul).
- **`python/freetoken/models/loader.py`**: `_attach_offload_cache` detects `Fp8BlockExpertBank` the same way it detects `GptqExpertBank` and wires `quant_format="fp8_block"`.
- **`qwen3_moe/__init__.py` + `qwen3_5_moe/__init__.py`**: `_forward_hybrid` forces `fetch_frac = 1.0` for `"fp8_block"` too (alongside `"gptq_int4"`) -- the CPU hybrid-split half has no dequant-and-cache logic for any packed format yet, so both packed formats ride pure offload for now (both model files carry this duplicated logic already, so both got the same fix).

## Test plan

Synthetic/hand-built block-FP8 fixtures on CPU (issue #152's own test strategy -- no small real block-FP8 MoE checkpoint is available memory-cheaply to validate against yet), mirroring the GPTQ test suite's structure and naming closely:

- [x] `tests/test_weight_fp8_banks.py` -- packed-bank builder (shapes, round-trip to known fixture values via `dequantize_block_fp8`, gate/up concat correctness, N-not-multiple-of-block rejection, missing-layer/unexpected-key errors, incremental per-layer finalization)
- [x] `tests/test_moe_offload_fp8_schema.py` -- schema registration, `set_bank_sources`/`materialize_layer`/`copy_missing`/`rebuild` against the new schema, strictly-additive check that `bf16`/`gptq_int4` are unaffected
- [x] `tests/test_moe_slot_weight_accessor_fp8.py` -- `SlotWeightAccessor` dequant-at-compute round-trip, dtype-not-scale-dtype bug regression test, shape convention, per-slot memoization, default block-size behavior
- [x] `tests/test_moe_hybrid_fp8_exclusion.py` -- `_forward_hybrid` routing (fp8_block never reaches the CPU split; bf16 still splits normally)
- [x] Full suite green in `.venv` (torch-free): `205 passed, 48 skipped, 14 deselected`
- [x] Full suite green in `.venv-xpu` (`-m "not xpu"`): `399 passed, 1 skipped, 75 deselected`, plus 1 pre-existing failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`) verified to also fail identically on `main` before this change -- not caused by this PR, not fixed here (out of scope)

## What's verified vs. assumed

- **Verified against real checkpoint bytes**: the block-FP8 per-expert key spelling (`.weight` + `.weight_scale_inv`), `quant_method == "fp8"`, and `weight_block_size == [128, 128]`, all read directly from `deepseek-ai/DeepSeek-V3`'s real `config.json`/`model.safetensors.index.json` on HuggingFace.
- **Assumed, not yet validated against real checkpoint bytes**: the actual dequantized *values* -- per issue #152's own risk note, no small/cheap real block-FP8 MoE checkpoint has been identified yet, so this is provisionally correct (round-trips against `dequantize_block_fp8` on synthetic fixtures) but not proven the way GPTQ's final validation was (against `tiny-random/qwen3.5-moe`). A real or HF-hosted-test block-FP8 MoE checkpoint would be needed to fully validate, per the issue's own explicit scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve