### PR TITLE
fix(moe): correct INT8 offload banks to the real compressed-tensors format (issue #154)

### DIFF
--- a/python/freetoken/kernel/triton/int8_packed_linear.py
+++ b/python/freetoken/kernel/triton/int8_packed_linear.py
@@ -1,0 +1,125 @@
+"""Compressed-tensors ``pack-quantized`` INT8 weights: unpack / dequantize
+(issue `moe-quant-banks-int8`, #154).
+
+This is the format a REAL deployed MoE checkpoint actually uses --
+``rj1013/gemma-4-26B-A4B-it_q8`` (Gemma-4-26B-A4B, ``enable_moe_block: true``,
+``num_experts: 128``), verified directly against its real ``config.json`` and
+``model.safetensors.index.json``, and the raw safetensors tensor headers
+(fetched via HTTP range request, no full checkpoint download). Its per-expert
+keys are ``...experts.{e}.{gate_proj|up_proj|down_proj}.{weight_packed,
+weight_scale,weight_shape}`` -- three tensors, not the plain ``weight`` +
+``weight_scale`` this project's own earlier (wrong, unverified) guess
+assumed. See issue #154's own comment trail for the full correction.
+
+``python/freetoken/kernel/triton/int8_linear.py`` (the ORIGINAL, plain
+per-channel primitive -- unpacked ``torch.int8`` weight + one scale per row,
+no groups) stays as-is: it is a real, independently useful primitive in its
+own right (issue `quant-xpu`, #10's general scope), just not what this real
+checkpoint's on-disk bytes actually look like. This module is the one that
+matches real bytes.
+
+Format (per the ``compressed_tensors`` library's own
+``compressors.pack_quantized.helpers.pack_to_int32`` /
+``unpack_from_int32``, read directly from the pip package to confirm the bit
+layout rather than guessing):
+
+* ``weight_packed`` is ``[N, ceil(K/4)]`` ``int32`` (a ``[N, K]`` logical
+  ``int8`` tensor, ``N`` = out_features, ``K`` = in_features, packed along
+  the ``K`` axis). For ``num_bits=8`` (the only case this module
+  implements -- this project's only real target so far) packing is DENSE
+  and never splits an element across a word boundary (8 divides 32 evenly:
+  each int32 word holds exactly 4 int8 values, byte 0 = the lowest 8 bits =
+  the first (lowest-``k``) element of that word's 4). The stored byte value
+  is the signed int8 value shifted into unsigned range by a flat ``+128``
+  offset (``compressed_tensors``' own convention for ANY bit width, not an
+  8-bit-specific quirk) -- i.e. ``stored_byte = int8_value + 128``, undone
+  on read by a plain ``- 128``. This is arithmetic offset-binary encoding,
+  not GPTQ's ``stored - 1`` reserved-code convention -- do not conflate the
+  two; there is nothing to "+1 correct" here.
+* ``weight_scale`` is ``[N, num_groups]`` (``bf16`` in the real checkpoint,
+  but not guaranteed) -- one value per ``(output channel, group)`` pair.
+  ``num_groups = K // group_size``; sequential groups (``g_idx[k] = k //
+  group_size``), confirmed via ``compressed_tensors.quantization.quant_args
+  .ActivationOrdering``: this checkpoint's ``actorder: "static"`` is an
+  ALIAS for ``"weight"`` ordering (reordering only during calibration, not
+  applied to the saved weights) -- NOT ``"group"``/``"dynamic"`` ordering
+  (which WOULD require a separate ``g_idx`` permutation tensor). No such
+  tensor exists in the real checkpoint's index, consistent with this.
+  ``num_groups == 1`` (``group_size == K``) degenerates to pure per-channel
+  quantization -- the same storage mechanism serves both "channel" and
+  "group" ``quantization_config.config_groups.*.weights.strategy`` values
+  (verified against two different real checkpoints: a "channel"-strategy
+  one for dense attention layers, and this "group"-strategy one for MoE
+  experts), so this module handles both via the same code path.
+* ``weight_shape`` is ``[2]`` ``int64`` -- the real logical ``[N, K]``
+  (``out_features, in_features``), stored separately because it cannot
+  always be recovered from ``weight_packed``'s own shape alone (``K`` need
+  not be an exact multiple of 4, though it is for every real tensor found
+  so far).
+* No ``weight_zero_point`` tensor for a symmetric checkpoint (confirmed:
+  ``compressed_tensors.compressors.pack_quantized.base``'s own decompressor
+  reads ``state_dict.get("weight_zero_point", None)`` and only asserts it
+  is present for an ASYMMETRIC scheme) -- dequant is plain
+  ``weight_int8 * scale``, no zero-point subtraction.
+"""
+from __future__ import annotations
+
+import torch
+
+_BITS = 8  # this module only implements the 8-bit case (the real checkpoint's format)
+_ELEMS_PER_WORD = 32 // _BITS  # dense, no cross-word splitting at 8 bits
+_OFFSET = 1 << (_BITS - 1)  # compressed_tensors' flat signed<->unsigned pack offset
+
+
+def unpack_int8_from_int32(weight_packed: torch.Tensor, k: int) -> torch.Tensor:
+    """Unpack a ``[N, ceil(K/4)]`` int32-packed tensor into ``[N, K]`` int8.
+
+    ``k`` is the real logical ``K`` (from ``weight_shape``) -- the packed
+    tensor's own column count is ``ceil(K/4)``, which only recovers ``K``
+    exactly when ``K`` is itself a multiple of 4 (true of every real tensor
+    checked so far, but not asserted here as a universal guarantee).
+    """
+    if weight_packed.dtype != torch.int32:
+        raise TypeError(f"weight_packed must be int32, got {weight_packed.dtype}")
+    n, packed_cols = weight_packed.shape
+    # Byte i of each word (0..3) is element (word_col * 4 + i); masking after
+    # the shift makes this correct regardless of the shift being arithmetic
+    # (torch right-shifts a signed int32 tensor arithmetically) since only
+    # the low 8 bits survive the mask either way.
+    bytes_ = torch.stack(
+        [(weight_packed >> (8 * i)) & 0xFF for i in range(_ELEMS_PER_WORD)], dim=-1
+    )  # [N, packed_cols, 4]
+    unpacked = bytes_.reshape(n, packed_cols * _ELEMS_PER_WORD)[:, :k]
+    return (unpacked - _OFFSET).to(torch.int8)
+
+
+def dequantize_int8_packed(
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    *,
+    k: int,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Reconstruct the dense ``[N, K]`` weight from compressed-tensors
+    pack-quantized INT8 tensors.
+
+    ``weight_packed`` is ``[N, ceil(K/4)]`` int32; ``weight_scale`` is
+    ``[N, num_groups]`` (``num_groups`` divides ``K`` evenly: ``num_groups
+    == 1`` is pure per-channel, matching the real ``strategy: "channel"``
+    case; ``num_groups > 1`` is sequential-group, matching the real
+    ``strategy: "group"`` case -- both use this same formula).
+    """
+    n, packed_cols = weight_packed.shape
+    if weight_scale.shape[0] != n:
+        raise ValueError(
+            f"weight_packed/weight_scale row mismatch: {n} vs {weight_scale.shape[0]}"
+        )
+    num_groups = weight_scale.shape[1]
+    if k % num_groups != 0:
+        raise ValueError(f"K={k} is not evenly divisible by num_groups={num_groups}")
+    group_size = k // num_groups
+
+    unpacked = unpack_int8_from_int32(weight_packed, k)  # [N, K] int8
+    g_idx = torch.arange(k, device=weight_packed.device) // group_size
+    per_col_scale = weight_scale.to(torch.float32)[:, g_idx]  # [N, K]
+    return (unpacked.to(torch.float32) * per_col_scale).to(out_dtype)

--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -467,19 +467,35 @@ def _attach_offload_cache(
             }
         )
     elif is_int8:
-        # Four packed banks (issue moe-quant-banks-schema-int8's schema) --
+        # Four packed banks (issue moe-quant-banks-int8, #154's
+        # _BANK_SCHEMAS["int8_channel"] -- corrected to compressed-tensors'
+        # real pack-quantized format, verified against rj1013/
+        # gemma-4-26B-A4B-it_q8; see Int8ExpertBank's own docstring) --
         # every bank is one row per expert, so set_bank_sources' generic
-        # per-expert-row contract applies unchanged. Unlike gptq_int4 there
-        # is no shared per-projection side tensor (no g_idx equivalent): a
-        # per-channel scale is already one row per expert.
+        # per-expert-row contract applies unchanged. K (real logical
+        # in-features) is shared across every expert of a projection type
+        # (an architecture constant, gate_up's == hidden_size, down's ==
+        # moe_intermediate_size) -- set as two plain scalar cache attributes
+        # (SlotWeightAccessor refuses to guess them), the same pattern as
+        # gptq_group_size below, since K is derivable from the parsed model
+        # config rather than needing a per-layer extra_metadata side table.
         cache.set_bank_sources(
             {
-                "weight_gate_up": [b.weight for b in gate_up_banks],
-                "scale_gate_up": [b.scale for b in gate_up_banks],
-                "weight_down": [b.weight for b in down_banks],
-                "scale_down": [b.scale for b in down_banks],
+                "weight_packed_gate_up": [b.weight_packed for b in gate_up_banks],
+                "weight_scale_gate_up": [b.weight_scale for b in gate_up_banks],
+                "weight_packed_down": [b.weight_packed for b in down_banks],
+                "weight_scale_down": [b.weight_scale for b in down_banks],
             }
         )
+        gate_up_ks = {b.k for b in gate_up_banks}
+        down_ks = {b.k for b in down_banks}
+        if len(gate_up_ks) != 1 or len(down_ks) != 1:
+            raise ValueError(
+                f"int8_channel: K differs across layers -- gate_up {gate_up_ks}, down {down_ks} "
+                "(K is an architecture constant, expected identical across every layer)"
+            )
+        cache.int8_k_gate_up = next(iter(gate_up_ks))
+        cache.int8_k_down = next(iter(down_ks))
     elif is_gptq:
         # Six packed banks (issue moe-quant-banks-schema, #136's schema) --
         # every bank is one row per expert, so set_bank_sources' generic

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -210,14 +210,17 @@ def load_moe_expert_sources(
     # (verified: https://huggingface.co/openai/gpt-oss-20b/raw/main/config.json).
     if quant_method == "mxfp4":
         return stream_moe_expert_sources_mxfp4(src, config)
-    # NOTE (issue moe-quant-banks-int8, #154): stream_moe_expert_sources_int8
-    # exists and is tested directly, but no real per-channel-INT8 MoE
-    # checkpoint's quant_method spelling has been confirmed, so it is not
-    # wired into this dispatch yet -- a real INT8 checkpoint would fall
-    # through to the plain bf16 streamer below and fail there. Real gap, not
-    # a design choice; needs a real checkpoint to close (same reasoning
-    # issue #154's own body gives for not guessing the key spelling further
-    # than it already does).
+    # "compressed-tensors" (issue moe-quant-banks-int8, #154): this
+    # quant_method is shared across multiple bit-widths/strategies -- only
+    # dispatch to the INT8 streamer when checkpoint_is_int8_pack_quantized
+    # confirms num_bits=8/type="int"/format="pack-quantized" specifically
+    # (verified against rj1013/gemma-4-26B-A4B-it_q8's real config.json; see
+    # stream_moe_expert_sources_int8's docstring). Any other compressed-
+    # tensors scheme (e.g. INT4, a different FP8 variant) falls through to
+    # the plain bf16 streamer below and fails loudly there -- a real,
+    # not-yet-supported format, not silently mishandled as INT8.
+    if quant_method == "compressed-tensors" and checkpoint_is_int8_pack_quantized(model_path):
+        return stream_moe_expert_sources_int8(src, config)
     return stream_moe_expert_sources(src, config, dtype=dtype, layer_sink=layer_sink)
 
 
@@ -233,6 +236,63 @@ def checkpoint_quant_method(model_path: str) -> Optional[str]:
         text_config = raw.get("text_config")
         qc = text_config.get("quantization_config") if isinstance(text_config, dict) else None
     return qc.get("quant_method") if isinstance(qc, dict) else None
+
+
+def _compressed_tensors_weights_config(model_path: str) -> Optional[dict]:
+    """``quantization_config.config_groups.*.weights`` (the first group) from
+    a checkpoint using the ``compressed-tensors`` library's format, or
+    ``None`` if it has no such config. Shared helper for the ``int8_pack_
+    quantized`` checks below (issue `moe-quant-banks-int8`, #154)."""
+    hf_config = cached_load_hf_config(model_path)
+    raw = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    qc = raw.get("quantization_config")
+    if not isinstance(qc, dict):
+        text_config = raw.get("text_config")
+        qc = text_config.get("quantization_config") if isinstance(text_config, dict) else None
+    if not isinstance(qc, dict):
+        return None
+    config_groups = qc.get("config_groups")
+    if not isinstance(config_groups, dict) or not config_groups:
+        return None
+    group = next(iter(config_groups.values()))
+    if not isinstance(group, dict) or group.get("format") != "pack-quantized":
+        return None
+    weights = group.get("weights")
+    return weights if isinstance(weights, dict) else None
+
+
+def checkpoint_is_int8_pack_quantized(model_path: str) -> bool:
+    """Whether this checkpoint uses ``compressed-tensors``' ``pack-
+    quantized`` INT8 scheme (issue `moe-quant-banks-int8`, #154 -- verified
+    against ``rj1013/gemma-4-26B-A4B-it_q8``'s real ``config.json``):
+    ``num_bits: 8``, ``type: "int"``, ``format: "pack-quantized"``.
+
+    ``compressed-tensors``' own ``quant_method`` value (``"compressed-
+    tensors"``, from :func:`checkpoint_quant_method`) is shared across
+    multiple bit-widths/strategies (INT8, INT4, FP8 variants, ...) --
+    unlike GPTQ's or block-FP8's own dedicated ``quant_method`` strings
+    (``"gptq"``, ``"fp8"``), so a caller must inspect ``config_groups``
+    itself to confirm this specific scheme, not just check ``quant_method``
+    alone. Call this BEFORE :func:`checkpoint_int8_pack_quantized_group_size`
+    to distinguish "not this format" from "this format, per-channel"
+    (``group_size: null`` is a valid value of THIS format, not an absence
+    of it).
+    """
+    weights = _compressed_tensors_weights_config(model_path)
+    return weights is not None and weights.get("num_bits") == 8 and weights.get("type") == "int"
+
+
+def checkpoint_int8_pack_quantized_group_size(model_path: str) -> Optional[int]:
+    """``quantization_config.config_groups.*.weights.group_size`` for a
+    checkpoint :func:`checkpoint_is_int8_pack_quantized` has already
+    confirmed is a real ``compressed-tensors`` ``pack-quantized`` INT8
+    checkpoint. ``None`` means the checkpoint's own config literally sets
+    ``group_size: null`` -- pure per-channel (one group covering the whole
+    row), NOT "this function found no config" (call
+    :func:`checkpoint_is_int8_pack_quantized` first to rule that case out).
+    """
+    weights = _compressed_tensors_weights_config(model_path)
+    return weights.get("group_size") if weights is not None else None
 
 
 def checkpoint_gptq_group_size(model_path: str) -> int:
@@ -1199,15 +1259,34 @@ def stream_moe_expert_sources_mxfp4(
 
 @dataclass(frozen=True)
 class Int8ExpertBank:
-    """One MoE layer's packed per-channel-INT8 bank for one projection slot
-    (``gate_up`` or ``down``) -- the INT8 sibling of :class:`GptqExpertBank`
-    (issue `moe-quant-banks-int8`, #154, part of epic #140).
+    """One MoE layer's packed compressed-tensors ``pack-quantized`` INT8 bank
+    for one projection slot (``gate_up`` or ``down``) -- the INT8 sibling of
+    :class:`GptqExpertBank` (issue `moe-quant-banks-int8`, #154, part of
+    epic #140).
 
-    ``weight`` / ``scale`` hold one row per expert (``[E, ...]``, per-channel
-    symmetric INT8 -- see :mod:`freetoken.kernel.triton.int8_linear`). Unlike
-    GPTQ there is no shared per-projection side tensor (no ``g_idx``): a
-    per-channel scale is already ``[N]`` per expert, so it fits the plain
-    ``[E, ...]`` per-expert-row bank shape directly with nothing left over.
+    Corrected from an earlier, unverified draft (see issue #154's own
+    comment trail): confirmed against a REAL deployed MoE checkpoint,
+    ``rj1013/gemma-4-26B-A4B-it_q8`` (Gemma-4-26B-A4B, ``num_experts: 128``,
+    ``quantization_config.quant_method: "compressed-tensors"``,
+    ``format: "pack-quantized"``), and cross-checked bit-exact against the
+    real ``compressed_tensors`` pip package's own ``unpack_from_int32`` /
+    ``dequantize`` on that checkpoint's actual tensor bytes (fetched via
+    HTTP range request) -- not the plain unpacked-int8 format the earlier
+    draft guessed.
+
+    ``weight_packed`` / ``weight_scale`` hold one row per expert (``[E,
+    ...]``). ``weight_packed`` is ``[E, N, ceil(K/4)]`` int32 (4 int8 values
+    densely packed per word along the K axis -- see
+    :mod:`freetoken.kernel.triton.int8_packed_linear` for the full bit-layout
+    docs). ``weight_scale`` is ``[E, N, num_groups]``: ``num_groups == 1`` is
+    pure per-channel (this issue's original title), ``num_groups > 1`` is
+    sequential-group (the real checkpoint found uses ``group_size=32`` for
+    its MoE experts) -- both are the same on-disk mechanism, so one bank
+    shape covers both. ``k`` (the real logical in-features, from the
+    checkpoint's own ``weight_shape`` tensor) is shared across every expert
+    of one projection type within a layer (same rationale as GPTQ's shared
+    ``g_idx``: it is an architecture constant, not a per-expert value), so it
+    is carried once here rather than duplicated ``E`` times.
 
     Deliberately packed, never dequantized here -- same RAM-blowup rationale
     as :class:`GptqExpertBank` (issue #134): dequantization happens lazily,
@@ -1216,45 +1295,48 @@ class Int8ExpertBank:
     slot pool has fetched for the current step.
     """
 
-    weight: torch.Tensor  # [E, N, K] int8 ([out, in] orientation)
-    scale: torch.Tensor  # [E, N] fp32 -- one value per (expert, output channel)
+    weight_packed: torch.Tensor  # [E, N, ceil(K/4)] int32
+    weight_scale: torch.Tensor  # [E, N, num_groups]
+    k: int  # real logical in-features, shared across every expert/component here
 
 
-_INT8_COMPONENTS = ("weight", "weight_scale")
+_INT8_COMPONENTS = ("weight_packed", "weight_scale", "weight_shape")
 
 
 def _parse_int8_expert_key(key: str) -> Tuple[int, str, int, str] | None:
-    """Parse a per-channel-INT8-packed per-expert weight key into ``(layer,
-    proj, expert_id, component)``, or ``None`` if ``key`` is not one.
+    """Parse a compressed-tensors pack-quantized INT8 per-expert weight key
+    into ``(layer, proj, expert_id, component)``, or ``None`` if ``key`` is
+    not one.
 
-    Recognizes ``...layers.{L}.mlp.experts.{e}.{gate_proj|up_proj|down_proj}
-    .{weight|weight_scale}``. UNVERIFIED against a real checkpoint (issue
-    #154's own body: no small/cheap real per-channel-INT8 MoE checkpoint has
-    been identified yet, unlike GPTQ's ``_parse_gptq_expert_key`` which was
-    confirmed against ``Qwen/Qwen3.5-35B-A3B-GPTQ-Int4``) -- this spelling is
-    modeled on ``compressed-tensors``' own documented ``weight``/
-    ``weight_scale`` suffix convention (the same one its real, confirmed FP8
-    checkpoints use, e.g. ``nm-testing/Meta-Llama-3.1-8B-Instruct-FP8-hf``'s
-    ``mlp.down_proj.weight`` / ``mlp.down_proj.weight_scale``), extrapolated
-    to INT8's per-channel strategy and to MoE's per-expert key shape. Treat
-    as provisionally correct, not proven, until validated against a real
-    per-channel-INT8 MoE checkpoint.
+    Recognizes ``...layers.{L}.experts.{e}.{gate_proj|up_proj|down_proj}
+    .{weight_packed|weight_scale|weight_shape}`` -- confirmed against the
+    real ``rj1013/gemma-4-26B-A4B-it_q8`` checkpoint's own
+    ``model.safetensors.index.json`` on HuggingFace: e.g.
+    ``model.language_model.layers.1.experts.0.gate_proj.weight_packed`` is a
+    real key in its index. Note this real checkpoint has NO ``mlp.`` segment
+    between ``layers.{L}`` and ``experts`` (unlike GPTQ's ``layers.{L}.mlp.
+    experts.{e}...``) -- also tolerates an intervening ``mlp`` token (i.e.
+    ``layers.{L}.mlp.experts.{e}...``) since that is GPTQ's own real,
+    confirmed convention and a future INT8 checkpoint may follow it instead;
+    only the no-``mlp`` form is confirmed for INT8 specifically so far.
     """
     parts = key.split(".")
     if len(parts) < 2 or parts[-1] not in _INT8_COMPONENTS:
         return None
     component = parts[-1]
     body = parts[:-1]
-    if "mlp" not in body or "experts" not in body:
-        return None
-    try:
-        mlp_pos = body.index("mlp")
-        layer = int(body[mlp_pos - 1])
-    except (ValueError, IndexError):
-        return None
-    if body[mlp_pos + 1] != "experts":
+    if "experts" not in body:
         return None
     e_pos = body.index("experts")
+    if e_pos == 0:
+        return None
+    layer_pos = e_pos - 2 if body[e_pos - 1] == "mlp" else e_pos - 1
+    if layer_pos < 0:
+        return None
+    try:
+        layer = int(body[layer_pos])
+    except ValueError:
+        return None
     tail = body[e_pos + 1 :]
     if len(tail) != 2:
         return None
@@ -1272,15 +1354,19 @@ def stream_moe_expert_sources_int8(
     tensors: Iterator[Tuple[str, torch.Tensor]],
     config,
 ) -> Tuple[list, list]:
-    """Stream per-channel-INT8-packed per-expert weight tensors into packed
-    per-layer banks (issue `moe-quant-banks-int8`, #154) -- the INT8 sibling
-    of :func:`stream_moe_expert_sources_gptq`.
+    """Stream compressed-tensors pack-quantized INT8 per-expert weight
+    tensors into packed per-layer banks (issue `moe-quant-banks-int8`, #154)
+    -- the INT8 sibling of :func:`stream_moe_expert_sources_gptq`.
 
     ``gate_up`` fuses ``gate_proj`` + ``up_proj`` (the checkpoint stores them
-    as separate quantized tensors, not pre-fused): ``weight``/``scale``
-    concatenate along their ``N`` (output-channel, dim 0 in ``[N, K]``
-    orientation) axis -- both are per-row, so the fused rows stay correct
-    with no shared side tensor to reconcile (unlike GPTQ's ``g_idx``).
+    as separate quantized tensors, not pre-fused): ``weight_packed`` /
+    ``weight_scale`` concatenate along their ``N`` (output-channel, dim 0)
+    axis -- both are per-row, and packing/grouping is entirely along the
+    ORTHOGONAL ``K`` axis, so N-axis concatenation never crosses a group or
+    word boundary (unlike block-FP8's ``N``-axis blocking, #152, which does
+    need an alignment check here). ``k`` (from ``weight_shape``) must agree
+    between ``gate_proj`` and ``up_proj`` (both take the same hidden_size
+    input) -- asserted, not assumed.
 
     Returns ``(gate_up_banks, down_banks)``, each a list of ``num_layers``
     :class:`Int8ExpertBank`. Every tensor stays in its packed, quantized form
@@ -1346,8 +1432,8 @@ def _int8_bank_is_complete(
 ) -> bool:
     """True once every expert 0..num_experts-1 has all required projections
     (``gate_proj``+``up_proj`` for ``fuse=True``, else ``down_proj``), each
-    with both INT8 components -- i.e. this ``(layer, bank_name)`` is ready
-    for :func:`_finalize_int8_bank`."""
+    with all three INT8 components -- i.e. this ``(layer, bank_name)`` is
+    ready for :func:`_finalize_int8_bank`."""
     if set(by_expert) != set(range(num_experts)):
         return False
     required_projs = ("gate_proj", "up_proj") if fuse else ("down_proj",)
@@ -1358,6 +1444,14 @@ def _int8_bank_is_complete(
             if components is None or set(components) != set(_INT8_COMPONENTS):
                 return False
     return True
+
+
+def _int8_logical_k(weight_shape: torch.Tensor) -> int:
+    """The real logical in-features from a ``weight_shape`` tensor (``[2]``
+    int64, ``[out_features, in_features]`` -- see ``Int8ExpertBank``'s own
+    docstring for why this is stored separately from ``weight_packed``'s own
+    shape rather than derived from it)."""
+    return int(weight_shape[1].item())
 
 
 def _finalize_int8_bank(
@@ -1372,6 +1466,7 @@ def _finalize_int8_bank(
         raise ValueError(f"Layer {layer}: missing INT8 experts {missing}")
 
     per_expert_rows = []
+    k0 = None
     for e in range(num_experts):
         by_proj = by_expert[e]
         if fuse:
@@ -1379,23 +1474,38 @@ def _finalize_int8_bank(
             up = by_proj.get("up_proj")
             if gate is None or up is None:
                 raise ValueError(f"Layer {layer} expert {e}: missing gate_proj/up_proj INT8 components")
-            weight = torch.cat([gate["weight"], up["weight"]], dim=0)
-            scale = torch.cat([gate["weight_scale"], up["weight_scale"]], dim=0)
+            k_gate = _int8_logical_k(gate["weight_shape"])
+            k_up = _int8_logical_k(up["weight_shape"])
+            if k_gate != k_up:
+                raise ValueError(
+                    f"Layer {layer} expert {e}: gate_proj K={k_gate} != up_proj K={k_up} "
+                    "(both project the same hidden_size input; a mismatch means a wiring bug)"
+                )
+            k = k_gate
+            weight_packed = torch.cat([gate["weight_packed"], up["weight_packed"]], dim=0)
+            weight_scale = torch.cat([gate["weight_scale"], up["weight_scale"]], dim=0)
         else:
             down = by_proj.get("down_proj")
             if down is None:
                 raise ValueError(f"Layer {layer} expert {e}: missing down_proj INT8 components")
-            weight, scale = down["weight"], down["weight_scale"]
-        per_expert_rows.append((weight, scale))
+            k = _int8_logical_k(down["weight_shape"])
+            weight_packed, weight_scale = down["weight_packed"], down["weight_scale"]
+        if k0 is None:
+            k0 = k
+        elif k != k0:
+            raise ValueError(
+                f"Layer {layer}: expert {e}'s K={k} differs from expert 0's K={k0} "
+                "(K is an architecture constant, expected identical across every expert)"
+            )
+        per_expert_rows.append((weight_packed, weight_scale))
 
     # _stack_expert_rows (not torch.stack): the torch XPU build mishandles a
     # direct cat/stack of 2-D per-expert rows along a new leading dim (see
-    # _stack_expert_rows's own docstring). scale is 1-D per expert, so it is
-    # stacked with a plain torch.stack instead -- the workaround is only
-    # documented for the 2-D weight case.
+    # _stack_expert_rows's own docstring).
     return Int8ExpertBank(
-        weight=_stack_expert_rows([row[0] for row in per_expert_rows]),
-        scale=torch.stack([row[1] for row in per_expert_rows], dim=0),
+        weight_packed=_stack_expert_rows([row[0] for row in per_expert_rows]),
+        weight_scale=_stack_expert_rows([row[1] for row in per_expert_rows]),
+        k=k0,
     )
 
 

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -90,15 +90,26 @@ logger = init_logger(__name__)
 # genuinely one-row-per-expert, so (like gptq_int4) they fit
 # set_bank_sources/copy_missing/rebuild unchanged.
 #
-# "int8_channel" (issue moe-quant-banks-int8, #154): a per-channel-INT8
-# checkpoint packs each projection into two per-expert tensors -- an int8
-# weight plus one fp scale per output-channel row (see
-# freetoken.kernel.triton.int8_linear.dequantize_int8_channel) -- the
-# simplest of the three formats in #140 (a single scale per row, no group/
-# block structure like gptq_int4's g_idx/group_size). Unlike gptq_int4 there
-# is no shared per-projection side tensor at all: the scale is already one
-# row per expert ([E, N]), so all four banks below fit the plain [E, ...]
-# per-expert-row contract with nothing left over for extra_metadata.
+# "int8_channel" (issue moe-quant-banks-int8, #154): compressed-tensors'
+# "pack-quantized" INT8 scheme (verified against a real checkpoint,
+# rj1013/gemma-4-26B-A4B-it_q8 -- an EARLIER, unverified draft of this
+# format assumed plain unpacked int8 tensors; that was wrong, see issue
+# #154's own comment trail and freetoken.kernel.triton.int8_packed_linear's
+# module docstring for the full correction). Each projection packs into two
+# per-expert tensors -- weight_packed (int32, 4 int8 values densely packed
+# per word along K) + weight_scale (one value per (output channel, group)
+# pair; num_groups==1 degenerates to pure per-channel, the same mechanism
+# serves both) -- unlike gptq_int4 there is no shared per-projection side
+# tensor for either of these (packing/grouping is entirely along K, so an
+# N-axis expert-row concat never crosses a word or group boundary), but K
+# itself (the real logical in-features, from the checkpoint's own
+# weight_shape tensor) IS shared across every expert of one projection type
+# -- and, unlike GPTQ's group_size (checkpoint-wide but not derivable from
+# architecture dims alone), gate_up's K is always hidden_size and down's K
+# is always moe_intermediate_size, both architecture constants identical
+# across every MoE layer -- so SlotWeightAccessor reads them as two plain
+# scalar cache attributes (cache.int8_k_gate_up / cache.int8_k_down), the
+# same pattern as cache.gptq_group_size, not a per-layer side table.
 _BANK_SCHEMAS: dict[str, tuple[str, ...]] = {
     "bf16": ("gate_up", "down"),
     "gptq_int4": (
@@ -122,10 +133,10 @@ _BANK_SCHEMAS: dict[str, tuple[str, ...]] = {
         "scales_down",
     ),
     "int8_channel": (
-        "weight_gate_up",
-        "scale_gate_up",
-        "weight_down",
-        "scale_down",
+        "weight_packed_gate_up",
+        "weight_scale_gate_up",
+        "weight_packed_down",
+        "weight_scale_down",
     ),
 }
 
@@ -725,8 +736,28 @@ class SlotWeightAccessor:
             from freetoken.kernel.triton.fp8_block_linear import _BLOCK as _FP8_DEFAULT_BLOCK
 
             self._fp8_block = int(getattr(cache, "fp8_block_size", None) or _FP8_DEFAULT_BLOCK)
-        elif self.quant_format in ("mxfp4", "int8_channel"):
+        elif self.quant_format == "mxfp4":
             self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
+        elif self.quant_format == "int8_channel":
+            self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
+            # K (real logical in-features) is an architecture constant per
+            # projection type -- gate_up's is always hidden_size, down's is
+            # always moe_intermediate_size -- so, like gptq_group_size, the
+            # loader sets these once as plain scalar cache attributes rather
+            # than a per-layer side table. No default here on purpose (see
+            # the gptq_int4 branch above for the same "refuse to guess"
+            # rationale): the loader must set both before any int8_channel
+            # forward runs.
+            k_gate_up = getattr(cache, "int8_k_gate_up", None)
+            k_down = getattr(cache, "int8_k_down", None)
+            if k_gate_up is None or k_down is None:
+                raise ValueError(
+                    "OffloadMoeCache.int8_k_gate_up / int8_k_down are not set -- the loader "
+                    "must set them from the checkpoint's real weight_shape before any "
+                    "int8_channel forward pass runs (SlotWeightAccessor refuses to guess)"
+                )
+            self._int8_k_gate_up = int(k_gate_up)
+            self._int8_k_down = int(k_down)
         else:
             self._gu, self._dn = cache.bank_views()
 
@@ -763,14 +794,23 @@ class SlotWeightAccessor:
             self._cache[s_i] = result
             return result
         if self.quant_format == "int8_channel":
-            from freetoken.kernel.triton.int8_linear import dequantize_int8_channel as _dequant
+            from freetoken.kernel.triton.int8_packed_linear import dequantize_int8_packed as _dequant
 
             b = self._banks
-            # weight/scale are already in [out, in] / [out] orientation (per
-            # output channel = per row) -- no transpose needed, unlike GPTQ's
-            # dequant which returns [in, out] and must be .T'd.
-            gu_dense = _dequant(b["weight_gate_up"][s_i], b["scale_gate_up"][s_i], out_dtype=self._dtype)
-            dn_dense = _dequant(b["weight_down"][s_i], b["scale_down"][s_i], out_dtype=self._dtype)
+            # weight_packed/weight_scale are already in [out, in-packed] /
+            # [out, groups] orientation (per output channel = per row) -- no
+            # transpose needed, unlike GPTQ's dequant which returns [in, out]
+            # and must be .T'd. out_dtype is self._dtype (the model's
+            # activation dtype), NOT the checkpoint's own stored scale dtype
+            # -- the same dtype bug class issue #138 found for gptq_int4.
+            gu_dense = _dequant(
+                b["weight_packed_gate_up"][s_i], b["weight_scale_gate_up"][s_i],
+                k=self._int8_k_gate_up, out_dtype=self._dtype,
+            )
+            dn_dense = _dequant(
+                b["weight_packed_down"][s_i], b["weight_scale_down"][s_i],
+                k=self._int8_k_down, out_dtype=self._dtype,
+            )
             i = self._intermediate
             result = (gu_dense[0:i], gu_dense[i : 2 * i], dn_dense)
             self._cache[s_i] = result

--- a/tests/test_moe_offload_int8_schema.py
+++ b/tests/test_moe_offload_int8_schema.py
@@ -1,8 +1,15 @@
 """Tests for the ``int8_channel`` offload-cache bank schema (issue
 `moe-quant-banks-int8`, #154).
 
+Corrected from an earlier, unverified draft (plain unpacked int8 tensors) --
+the real bank shapes are ``weight_packed_*`` (int32, 4 int8 values packed
+per word along K) + ``weight_scale_*`` (one value per (output channel,
+group) pair), matching the real ``compressed-tensors`` pack-quantized
+format; see ``freetoken.kernel.triton.int8_packed_linear``'s module
+docstring for the full verification.
+
 Companion to test_moe_offload_cache.py / test_moe_offload_gptq_schema.py --
-small synthetic per-channel-INT8 fixtures, no real checkpoint, no XPU.
+small synthetic packed-INT8 fixtures, no real checkpoint, no XPU.
 """
 from __future__ import annotations
 
@@ -14,7 +21,7 @@ from freetoken.moe.offload_cache import _BANK_SCHEMAS, OffloadMoeCache
 
 DEVICE = torch.device("cpu")
 L, E, S = 2, 4, 8  # 2 layers, 4 experts, 8 slots
-K, N = 16, 8  # small in/out dims
+K, N, GROUP_SIZE = 16, 8, 4  # small in/out dims; K a multiple of both 4 and GROUP_SIZE
 
 
 def _packed_bank_sources():
@@ -30,26 +37,43 @@ def _packed_bank_sources():
         per_bank_layers = {name: [] for name in sources}
         for expert in range(E):
             t = tag(layer, expert)
+            code = t % 127
+            # 4 int8 `code` values packed per int32 word, matching
+            # compressed-tensors' own dense num_bits=8 packing (+128 offset).
+            word = sum((code + 128) << (8 * i) for i in range(4))
+            if word >= 1 << 31:
+                word -= 1 << 32
             for proj, n, k in (("gate_up", 2 * N, K), ("down", N, K)):
-                per_bank_layers[f"weight_{proj}"].append(torch.full((n, k), t % 127, dtype=torch.int8))
-                per_bank_layers[f"scale_{proj}"].append(torch.full((n,), float(t), dtype=torch.float32))
+                per_bank_layers[f"weight_packed_{proj}"].append(
+                    torch.full((n, k // 4), word, dtype=torch.int32)
+                )
+                per_bank_layers[f"weight_scale_{proj}"].append(
+                    torch.full((n, k // GROUP_SIZE), float(t), dtype=torch.float32)
+                )
         for name in sources:
             sources[name].append(torch.stack(per_bank_layers[name]))
     return sources
 
 
+def _cache_with_k(**kwargs):
+    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel", **kwargs)
+    cache.int8_k_gate_up = K
+    cache.int8_k_down = K
+    return cache
+
+
 def test_schema_registered():
     assert "int8_channel" in _BANK_SCHEMAS
     assert _BANK_SCHEMAS["int8_channel"] == (
-        "weight_gate_up",
-        "scale_gate_up",
-        "weight_down",
-        "scale_down",
+        "weight_packed_gate_up",
+        "weight_scale_gate_up",
+        "weight_packed_down",
+        "weight_scale_down",
     )
 
 
 def test_set_bank_sources_allocates_correctly_shaped_dtyped_device_caches():
-    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel")
+    cache = _cache_with_k()
     sources = _packed_bank_sources()
     cache.set_bank_sources(sources)
 
@@ -58,12 +82,12 @@ def test_set_bank_sources_allocates_correctly_shaped_dtyped_device_caches():
         dev_cache = cache.bank_caches[name]
         assert dev_cache.shape == (S, *host_row_shape)
         assert dev_cache.dtype == sources[name][0].dtype
-    assert cache.bank_caches["weight_gate_up"].dtype == torch.int8
-    assert cache.bank_caches["scale_gate_up"].dtype == torch.float32
+    assert cache.bank_caches["weight_packed_gate_up"].dtype == torch.int32
+    assert cache.bank_caches["weight_scale_gate_up"].dtype == torch.float32
 
 
 def test_materialize_and_copy_missing_moves_real_packed_bytes():
-    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel")
+    cache = _cache_with_k()
     sources = _packed_bank_sources()
     cache.set_bank_sources(sources)
 
@@ -74,18 +98,21 @@ def test_materialize_and_copy_missing_moves_real_packed_bytes():
         slot = int(cache.slot_for_id[0, expert].item())
         assert slot != -1
         expected_tag = 100 * 1 + 10 * (expert + 1)
+        expected_word = sum(((expected_tag % 127) + 128) << (8 * i) for i in range(4))
+        if expected_word >= 1 << 31:
+            expected_word -= 1 << 32
         torch.testing.assert_close(
-            cache.bank_caches["weight_gate_up"][slot],
-            torch.full_like(cache.bank_caches["weight_gate_up"][slot], expected_tag % 127),
+            cache.bank_caches["weight_packed_gate_up"][slot],
+            torch.full_like(cache.bank_caches["weight_packed_gate_up"][slot], expected_word),
         )
         torch.testing.assert_close(
-            cache.bank_caches["scale_down"][slot],
-            torch.full_like(cache.bank_caches["scale_down"][slot], float(expected_tag)),
+            cache.bank_caches["weight_scale_down"][slot],
+            torch.full_like(cache.bank_caches["weight_scale_down"][slot], float(expected_tag)),
         )
 
 
 def test_rebuild_resizes_int8_schema_pool():
-    cache = OffloadMoeCache(L, E, S, DEVICE, quant_format="int8_channel")
+    cache = _cache_with_k()
     cache.set_bank_sources(_packed_bank_sources())
     cache.materialize_layer(0)
     cache.copy_missing()

--- a/tests/test_moe_slot_weight_accessor_int8.py
+++ b/tests/test_moe_slot_weight_accessor_int8.py
@@ -3,11 +3,12 @@ abstracted over int8_channel (dequantize-at-compute, issue
 `moe-quant-banks-int8`, #154). Companion to
 test_moe_slot_weight_accessor.py (gptq_int4's own version, #137).
 
-Builds against the shape/bank-name contract registered in
-_BANK_SCHEMAS["int8_channel"] (weight/scale x {gate_up,down}, no extra
-side tensor -- unlike gptq_int4's g_idx, a per-channel scale is already one
-row per expert). CPU-only, small synthetic fixtures, no real checkpoint, no
-XPU.
+Corrected from an earlier, unverified draft (plain unpacked int8 tensors) --
+the real bank shapes are ``weight_packed_*`` (int32, packed via
+compressed-tensors' pack-quantized scheme) + ``weight_scale_*`` (one value
+per (output channel, group) pair), matching the real bit-exact-verified
+format in ``freetoken.kernel.triton.int8_packed_linear``. CPU-only, small
+synthetic fixtures, no real checkpoint, no XPU.
 """
 from __future__ import annotations
 
@@ -15,38 +16,53 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from freetoken.kernel.triton.int8_linear import dequantize_int8_channel
+from freetoken.kernel.triton.int8_packed_linear import dequantize_int8_packed
 from freetoken.moe.offload_cache import OffloadMoeCache, SlotWeightAccessor
 
 DEVICE = torch.device("cpu")
+GROUP_SIZE = 4  # small group size so group-vs-per-channel dequant is actually exercised
+
+
+def _pack_int8(codes: torch.Tensor) -> torch.Tensor:
+    """``[N, K]`` int8 codes -> ``[N, K // 4]`` int32, compressed-tensors'
+    dense num_bits=8 packing (byte i of each word = element word*4+i,
+    stored as ``code + 128``)."""
+    n, k = codes.shape
+    assert k % 4 == 0
+    codes32 = (codes.to(torch.int64) + 128).reshape(n, k // 4, 4)
+    word = sum(codes32[:, :, i] << (8 * i) for i in range(4))
+    word = torch.where(word >= (1 << 31), word - (1 << 32), word)
+    return word.to(torch.int32)
 
 
 def _make_packed_projection(n: int, k: int, *, seed: int) -> tuple[torch.Tensor, torch.Tensor]:
-    """A real (non-constant) small per-channel-INT8-packed ``[N, K]``
-    projection: weight codes and scales vary by row (derived from `seed`),
-    so a test can't accidentally pass by everything happening to be
-    uniform."""
+    """A real (non-constant) small packed-INT8 ``[N, K]`` projection: weight
+    codes and per-group scales vary by row/group (derived from `seed`), so a
+    test can't accidentally pass by everything happening to be uniform."""
     g = torch.Generator().manual_seed(seed)
-    weight = torch.randint(-127, 128, (n, k), generator=g, dtype=torch.int8)
-    scale = torch.rand(n, generator=g) * 0.1 + 0.01
-    return weight, scale
+    codes = torch.randint(-127, 128, (n, k), generator=g, dtype=torch.int8)
+    num_groups = k // GROUP_SIZE
+    scale = torch.rand(n, num_groups, generator=g) * 0.1 + 0.01
+    return _pack_int8(codes), scale
 
 
 def _cache_with_int8_bank(k_gu: int, n_gu: int, k_dn: int, n_dn: int, *, num_experts: int, cache_size: int):
     cache = OffloadMoeCache(1, num_experts, cache_size, DEVICE, quant_format="int8_channel")
-    sources = {name: [] for name in ("weight_gate_up", "scale_gate_up", "weight_down", "scale_down")}
-    projections = []  # keep the raw per-expert projections to check against
+    sources = {name: [] for name in ("weight_packed_gate_up", "weight_scale_gate_up", "weight_packed_down", "weight_scale_down")}
+    projections = []  # keep the raw per-expert packed projections to check against
     for e in range(num_experts):
         gu_w, gu_s = _make_packed_projection(n_gu, k_gu, seed=100 + e)
         dn_w, dn_s = _make_packed_projection(n_dn, k_dn, seed=200 + e)
         projections.append((gu_w, gu_s, dn_w, dn_s))
         for name, t in (
-            ("weight_gate_up", gu_w), ("scale_gate_up", gu_s),
-            ("weight_down", dn_w), ("scale_down", dn_s),
+            ("weight_packed_gate_up", gu_w), ("weight_scale_gate_up", gu_s),
+            ("weight_packed_down", dn_w), ("weight_scale_down", dn_s),
         ):
             sources[name].append(t)
     sources = {name: [torch.stack(v)] for name, v in sources.items()}  # -> [1 layer][E, ...]
     cache.set_bank_sources(sources)
+    cache.int8_k_gate_up = k_gu
+    cache.int8_k_down = k_dn
     cache.materialize_layer(0)
     cache.copy_missing()
     return cache, projections
@@ -65,8 +81,8 @@ def test_int8_get_matches_direct_dequant_for_each_expert():
         gate_w, up_w, down_w = accessor.get(slot)
         gu_w, gu_s, dn_w, dn_s = projections[e]
 
-        expected_gu = dequantize_int8_channel(gu_w, gu_s, out_dtype=torch.float32)
-        expected_dn = dequantize_int8_channel(dn_w, dn_s, out_dtype=torch.float32)
+        expected_gu = dequantize_int8_packed(gu_w, gu_s, k=hidden, out_dtype=torch.float32)
+        expected_dn = dequantize_int8_packed(dn_w, dn_s, k=inter, out_dtype=torch.float32)
 
         torch.testing.assert_close(gate_w, expected_gu[0:inter])
         torch.testing.assert_close(up_w, expected_gu[inter : 2 * inter])
@@ -84,8 +100,8 @@ def test_int8_get_dtype_matches_requested_dtype_not_scale_dtype():
         num_experts=1, cache_size=1,
     )
     # Force the scale bank to a dtype that must NOT leak into the output.
-    cache.bank_caches["scale_gate_up"] = cache.bank_caches["scale_gate_up"].to(torch.float16)
-    cache.bank_caches["scale_down"] = cache.bank_caches["scale_down"].to(torch.float16)
+    cache.bank_caches["weight_scale_gate_up"] = cache.bank_caches["weight_scale_gate_up"].to(torch.float16)
+    cache.bank_caches["weight_scale_down"] = cache.bank_caches["weight_scale_down"].to(torch.float16)
 
     accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.bfloat16)
     gate_w, up_w, down_w = accessor.get(0)
@@ -119,3 +135,16 @@ def test_int8_get_caches_per_slot_within_one_instance():
     second = accessor.get(0)
     for a, b in zip(first, second):
         assert a.data_ptr() == b.data_ptr()  # identical cached tensor object, not recomputed
+
+
+def test_missing_int8_k_raises():
+    """SlotWeightAccessor refuses to guess -- mirrors gptq_int4's own
+    gptq_group_size "refuse to guess" test."""
+    cache = OffloadMoeCache(1, 1, 1, DEVICE, quant_format="int8_channel")
+    sources = {name: [torch.zeros(1, *shape)] for name, shape in (
+        ("weight_packed_gate_up", (4, 4)), ("weight_scale_gate_up", (4, 4)),
+        ("weight_packed_down", (4, 4)), ("weight_scale_down", (4, 4)),
+    )}
+    cache.set_bank_sources(sources)
+    with pytest.raises(ValueError, match="int8_k_gate_up"):
+        SlotWeightAccessor(cache, intermediate=2, dtype=torch.float32)

--- a/tests/test_weight_int8_banks.py
+++ b/tests/test_weight_int8_banks.py
@@ -1,11 +1,18 @@
-"""``stream_moe_expert_sources_int8``: packed per-channel-INT8 expert banks
-stay packed (issue `moe-quant-banks-int8`, #154, part of epic #140).
+"""``stream_moe_expert_sources_int8``: packed compressed-tensors
+pack-quantized INT8 expert banks stay packed (issue `moe-quant-banks-int8`,
+#154, part of epic #140).
 
-CPU-only, synthetic fixtures -- the whole point of this issue is that these
-banks are NEVER dequantized here (that happens lazily, per-expert, at
+Corrected from an earlier, unverified draft (plain unpacked int8 tensors) --
+this format (int32-packed, group-aware dequant, a separate ``weight_shape``
+tensor) was verified bit-exact against the real ``compressed_tensors``
+library on a real checkpoint's actual tensor bytes
+(``rj1013/gemma-4-26B-A4B-it_q8``); see ``int8_packed_linear.py``'s module
+docstring for the full verification. This file uses small hand-packed
+CPU-only fixtures -- the whole point of this issue is that these banks are
+NEVER dequantized here at load time (that happens lazily, per-expert, at
 compute time via ``SlotWeightAccessor``); the round-trip check below
-dequantizes only for test verification, via the already-shipped
-``dequantize_int8_channel`` (#130).
+dequantizes only for test verification, via the already-verified
+``dequantize_int8_packed``.
 """
 from __future__ import annotations
 
@@ -15,36 +22,58 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from freetoken.kernel.triton.int8_linear import dequantize_int8_channel
+from freetoken.kernel.triton.int8_packed_linear import dequantize_int8_packed
 from freetoken.models.weight import Int8ExpertBank, stream_moe_expert_sources_int8
 
 
-def _int8_projection(k: int, n: int, *, code: int, scale: float):
-    """A small, real (not random-garbage) per-channel-INT8-packed
-    projection: every row uses the same int8 code / scale, so the
-    dequantized value is a known constant: ``scale * code``."""
-    weight = torch.full((n, k), code, dtype=torch.int8)
-    scale_t = torch.full((n,), scale, dtype=torch.float32)
-    return weight, scale_t
+def _pack_int8_row(codes: list[int]) -> int:
+    """4 int8 codes -> one packed int32 word (byte 0 = codes[0], matching
+    compressed_tensors' own dense num_bits=8 packing -- see
+    int8_packed_linear.py's module docstring)."""
+    word = 0
+    for i, c in enumerate(codes):
+        assert -128 <= c < 128
+        word |= (c + 128) << (8 * i)
+    if word >= 1 << 31:
+        word -= 1 << 32
+    return word
+
+
+def _int8_projection(k: int, n: int, group_size: int, *, code: int, scale: float):
+    """A small, real (not random-garbage) pack-quantized INT8 projection:
+    every element uses the same int8 code / scale, so the dequantized value
+    is a known constant: ``scale * code``. ``k`` must be a multiple of 4
+    (dense packing, no partial words -- every real tensor checked so far is)
+    and of ``group_size``."""
+    assert k % 4 == 0 and k % group_size == 0
+    num_groups = k // group_size
+    packed_row = [_pack_int8_row([code] * 4) for _ in range(k // 4)]
+    weight_packed = torch.tensor([packed_row] * n, dtype=torch.int32)
+    weight_scale = torch.full((n, num_groups), scale, dtype=torch.float32)
+    weight_shape = torch.tensor([n, k], dtype=torch.int64)
+    return weight_packed, weight_scale, weight_shape
 
 
 def _expert_stream(config, *, gate_kwargs, up_kwargs, down_kwargs):
     """Yield ``(name, tensor)`` pairs for every expert of every layer, in the
-    UNVERIFIED assumed per-expert INT8 key spelling (see
-    ``_parse_int8_expert_key``'s docstring)."""
+    real per-expert INT8 key spelling (no ``mlp.`` segment -- verified
+    against ``rj1013/gemma-4-26B-A4B-it_q8``'s real
+    ``model.safetensors.index.json``; see ``_parse_int8_expert_key``'s
+    docstring)."""
     for layer in range(config.num_layers):
         for e in range(config.num_experts):
             for proj, kwargs in (("gate_proj", gate_kwargs), ("up_proj", up_kwargs), ("down_proj", down_kwargs)):
-                weight, scale = _int8_projection(**kwargs)
-                prefix = f"model.layers.{layer}.mlp.experts.{e}.{proj}"
-                yield prefix + ".weight", weight
-                yield prefix + ".weight_scale", scale
+                weight_packed, weight_scale, weight_shape = _int8_projection(**kwargs)
+                prefix = f"model.language_model.layers.{layer}.experts.{e}.{proj}"
+                yield prefix + ".weight_packed", weight_packed
+                yield prefix + ".weight_scale", weight_scale
+                yield prefix + ".weight_shape", weight_shape
 
 
 def test_packed_bank_shapes_match_the_documented_contract():
     config = SimpleNamespace(num_layers=2, num_experts=3)
-    k, n = 16, 8
-    kwargs = dict(k=k, n=n, code=5, scale=0.5)
+    k, n, group_size = 16, 8, 4
+    kwargs = dict(k=k, n=n, group_size=group_size, code=5, scale=0.5)
     stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
 
     gate_up_banks, down_banks = stream_moe_expert_sources_int8(stream, config)
@@ -54,28 +83,35 @@ def test_packed_bank_shapes_match_the_documented_contract():
     for bank in gate_up_banks:
         assert isinstance(bank, Int8ExpertBank)
         # gate_up fuses gate_proj+up_proj on the N (row/output-channel) axis -> N doubles.
-        assert bank.weight.shape == (config.num_experts, 2 * n, k)
-        assert bank.scale.shape == (config.num_experts, 2 * n)
-        assert bank.weight.dtype == torch.int8
-        assert bank.scale.dtype == torch.float32
+        assert bank.weight_packed.shape == (config.num_experts, 2 * n, k // 4)
+        assert bank.weight_scale.shape == (config.num_experts, 2 * n, k // group_size)
+        assert bank.weight_packed.dtype == torch.int32
+        assert bank.weight_scale.dtype == torch.float32
+        assert bank.k == k
     for bank in down_banks:
-        assert bank.weight.shape == (config.num_experts, n, k)
-        assert bank.scale.shape == (config.num_experts, n)
+        assert bank.weight_packed.shape == (config.num_experts, n, k // 4)
+        assert bank.weight_scale.shape == (config.num_experts, n, k // group_size)
+        assert bank.k == k
 
 
 def test_packed_bank_round_trips_to_the_known_fixture_value():
     config = SimpleNamespace(num_layers=1, num_experts=2)
-    k, n = 16, 8
-    kwargs = dict(k=k, n=n, code=5, scale=0.5)  # -> 0.5 * 5 = 2.5
+    k, n, group_size = 16, 8, 4
+    kwargs = dict(k=k, n=n, group_size=group_size, code=5, scale=0.5)  # -> 0.5 * 5 = 2.5
     stream = _expert_stream(config, gate_kwargs=kwargs, up_kwargs=kwargs, down_kwargs=kwargs)
 
     gate_up_banks, down_banks = stream_moe_expert_sources_int8(stream, config)
 
     for e in range(config.num_experts):
-        down = dequantize_int8_channel(down_banks[0].weight[e], down_banks[0].scale[e], out_dtype=torch.float32)
+        down = dequantize_int8_packed(
+            down_banks[0].weight_packed[e], down_banks[0].weight_scale[e], k=down_banks[0].k, out_dtype=torch.float32
+        )
         torch.testing.assert_close(down, torch.full((n, k), 2.5))
 
-        gate_up = dequantize_int8_channel(gate_up_banks[0].weight[e], gate_up_banks[0].scale[e], out_dtype=torch.float32)
+        gate_up = dequantize_int8_packed(
+            gate_up_banks[0].weight_packed[e], gate_up_banks[0].weight_scale[e],
+            k=gate_up_banks[0].k, out_dtype=torch.float32,
+        )
         torch.testing.assert_close(gate_up, torch.full((2 * n, k), 2.5))
 
 
@@ -84,16 +120,16 @@ def test_gate_up_concatenation_preserves_two_independently_quantized_halves():
     up_proj are quantized with DIFFERENT codes/scales, so the fused bank's
     two halves must dequantize back to their own distinct source values."""
     config = SimpleNamespace(num_layers=1, num_experts=1)
-    k, n = 16, 8
-    gate_kwargs = dict(k=k, n=n, code=3, scale=0.25)  # -> 0.75
-    up_kwargs = dict(k=k, n=n, code=10, scale=1.0)  # -> 10.0
-    down_kwargs = dict(k=k, n=n, code=5, scale=0.5)
+    k, n, group_size = 16, 8, 4
+    gate_kwargs = dict(k=k, n=n, group_size=group_size, code=3, scale=0.25)  # -> 0.75
+    up_kwargs = dict(k=k, n=n, group_size=group_size, code=10, scale=1.0)  # -> 10.0
+    down_kwargs = dict(k=k, n=n, group_size=group_size, code=5, scale=0.5)
     stream = _expert_stream(config, gate_kwargs=gate_kwargs, up_kwargs=up_kwargs, down_kwargs=down_kwargs)
 
     gate_up_banks, _down_banks = stream_moe_expert_sources_int8(stream, config)
     bank = gate_up_banks[0]
 
-    fused = dequantize_int8_channel(bank.weight[0], bank.scale[0], out_dtype=torch.float32)
+    fused = dequantize_int8_packed(bank.weight_packed[0], bank.weight_scale[0], k=bank.k, out_dtype=torch.float32)
     # gate/up were concatenated on the N (row, dim=0) axis, so the two halves
     # split along rows.
     assert fused.shape == (2 * n, k)
@@ -102,17 +138,82 @@ def test_gate_up_concatenation_preserves_two_independently_quantized_halves():
     torch.testing.assert_close(up_half, torch.full((n, k), 10.0))
 
 
+def test_group_boundaries_use_the_correct_scale_per_group():
+    """Two groups (group_size=4, k=8) with DIFFERENT per-group scales on the
+    SAME row -- proves group indexing (not just per-row scaling) is real,
+    not degenerated to the per-channel case by the fixture."""
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+    k, n, group_size = 8, 4, 4
+    packed_row = [_pack_int8_row([5] * 4), _pack_int8_row([5] * 4)]  # code=5 in both groups
+    weight_packed = torch.tensor([packed_row] * n, dtype=torch.int32)
+    # group 0 (cols 0-3): scale 0.5 -> 2.5; group 1 (cols 4-7): scale 2.0 -> 10.0
+    weight_scale = torch.tensor([[0.5, 2.0]] * n, dtype=torch.float32)
+    weight_shape = torch.tensor([n, k], dtype=torch.int64)
+
+    def stream():
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            prefix = f"model.language_model.layers.0.experts.0.{proj}"
+            yield prefix + ".weight_packed", weight_packed
+            yield prefix + ".weight_scale", weight_scale
+            yield prefix + ".weight_shape", weight_shape
+
+    gate_up_banks, down_banks = stream_moe_expert_sources_int8(stream(), config)
+    down = dequantize_int8_packed(down_banks[0].weight_packed[0], down_banks[0].weight_scale[0], k=k, out_dtype=torch.float32)
+    torch.testing.assert_close(down[:, :4], torch.full((n, 4), 2.5))
+    torch.testing.assert_close(down[:, 4:], torch.full((n, 4), 10.0))
+
+
+def test_k_mismatch_across_experts_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=2)
+
+    def stream():
+        for e, k in enumerate((8, 16)):  # expert 0 vs expert 1 disagree
+            kwargs = dict(k=k, n=4, group_size=k, code=5, scale=0.5)
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                weight_packed, weight_scale, weight_shape = _int8_projection(**kwargs)
+                prefix = f"model.language_model.layers.0.experts.{e}.{proj}"
+                yield prefix + ".weight_packed", weight_packed
+                yield prefix + ".weight_scale", weight_scale
+                yield prefix + ".weight_shape", weight_shape
+
+    with pytest.raises(ValueError, match="K=.*differs from expert 0"):
+        stream_moe_expert_sources_int8(stream(), config)
+
+
+def test_gate_up_k_mismatch_raises():
+    config = SimpleNamespace(num_layers=1, num_experts=1)
+
+    def stream():
+        gate_packed, gate_scale, gate_shape = _int8_projection(k=8, n=4, group_size=8, code=5, scale=0.5)
+        up_packed, up_scale, up_shape = _int8_projection(k=16, n=4, group_size=16, code=5, scale=0.5)
+        down_packed, down_scale, down_shape = _int8_projection(k=8, n=4, group_size=8, code=5, scale=0.5)
+        prefix = "model.language_model.layers.0.experts.0"
+        yield prefix + ".gate_proj.weight_packed", gate_packed
+        yield prefix + ".gate_proj.weight_scale", gate_scale
+        yield prefix + ".gate_proj.weight_shape", gate_shape
+        yield prefix + ".up_proj.weight_packed", up_packed
+        yield prefix + ".up_proj.weight_scale", up_scale
+        yield prefix + ".up_proj.weight_shape", up_shape
+        yield prefix + ".down_proj.weight_packed", down_packed
+        yield prefix + ".down_proj.weight_scale", down_scale
+        yield prefix + ".down_proj.weight_shape", down_shape
+
+    with pytest.raises(ValueError, match="gate_proj K=.*!= up_proj K="):
+        stream_moe_expert_sources_int8(stream(), config)
+
+
 def test_missing_layer_raises():
     config = SimpleNamespace(num_layers=2, num_experts=1)
-    kwargs = dict(k=8, n=8, code=5, scale=0.5)
+    kwargs = dict(k=8, n=8, group_size=8, code=5, scale=0.5)
 
     def stream():
         # only layer 0, layer 1 never appears
         for proj in ("gate_proj", "up_proj", "down_proj"):
-            weight, scale = _int8_projection(**kwargs)
-            prefix = f"model.layers.0.mlp.experts.0.{proj}"
-            yield prefix + ".weight", weight
-            yield prefix + ".weight_scale", scale
+            weight_packed, weight_scale, weight_shape = _int8_projection(**kwargs)
+            prefix = f"model.language_model.layers.0.experts.0.{proj}"
+            yield prefix + ".weight_packed", weight_packed
+            yield prefix + ".weight_scale", weight_scale
+            yield prefix + ".weight_shape", weight_shape
 
     with pytest.raises(ValueError, match="Missing/incomplete INT8 MoE expert bank"):
         stream_moe_expert_sources_int8(stream(), config)
@@ -129,15 +230,16 @@ def test_finalizes_each_layer_as_soon_as_it_completes():
     layer 0 to completion must release its raw buffer before layer 1 is even
     seen, not wait for the whole generator to be exhausted."""
     config = SimpleNamespace(num_layers=2, num_experts=1)
-    kwargs = dict(k=8, n=8, code=5, scale=0.5)
+    kwargs = dict(k=8, n=8, group_size=8, code=5, scale=0.5)
 
     def stream():
         for layer in range(2):
             for proj in ("gate_proj", "up_proj", "down_proj"):
-                weight, scale = _int8_projection(**kwargs)
-                prefix = f"model.layers.{layer}.mlp.experts.0.{proj}"
-                yield prefix + ".weight", weight
-                yield prefix + ".weight_scale", scale
+                weight_packed, weight_scale, weight_shape = _int8_projection(**kwargs)
+                prefix = f"model.language_model.layers.{layer}.experts.0.{proj}"
+                yield prefix + ".weight_packed", weight_packed
+                yield prefix + ".weight_scale", weight_scale
+                yield prefix + ".weight_shape", weight_shape
 
     import freetoken.models.weight as weight_mod
 


### PR DESCRIPTION
## Summary

PR #155's original INT8 MoE offload bank implementation assumed the wrong on-disk format -- a plain unpacked `torch.int8` weight + per-channel scale, based on an unverified AI-assistant claim about a checkpoint's key naming. That checkpoint (`88plug/Qwen3-Omni-30B-A3B-W8A16`) turned out to not even have quantized MoE experts (BF16 on disk despite the name), and the assumed format doesn't match how any real deployed INT8 MoE checkpoint actually stores weights.

Direct verification against a real deployed checkpoint's actual `config.json`, `model.safetensors.index.json`, and raw safetensors tensor bytes (`rj1013/gemma-4-26B-A4B-it_q8`, fetched via HTTP range request, no download) found the real format is `compressed-tensors`' `pack-quantized` scheme:
- `weight_packed`: `[N, ceil(K/4)]` int32, 4 int8 values densely packed per word, `+128` offset-binary encoding (not GPTQ's convention -- do not conflate the two)
- `weight_scale`: `[N, num_groups]`, one value per `(output channel, group)` pair, sequential groups (`num_groups==1` degenerates to pure per-channel)
- `weight_shape`: `[2]` int64, the true logical `[N, K]` (not always recoverable from `weight_packed`'s own shape)

This was cross-checked bit-exact against the real `compressed_tensors` pip package's own `unpack_from_int32`/`dequantize` on the checkpoint's actual tensor bytes.

## Changes
- `Int8ExpertBank`, `_parse_int8_expert_key`, `stream_moe_expert_sources_int8` rebuilt around the real 3-tensor-per-projection format
- New `int8_packed_linear.py` (`unpack_int8_from_int32`, `dequantize_int8_packed`) -- the original `int8_linear.py` primitive stays as-is, a real independently-useful plain-per-channel primitive (issue #10's scope), just not what this checkpoint's bytes look like
- `int8_channel` bank schema, loader wiring, and `SlotWeightAccessor`'s dequant branch updated to the new bank names/shapes
- All 4 INT8 test files rewritten against the corrected API (hybrid CPU/PCIe exclusion test needed no change)

Full findings were posted to issue #154 (reopened after PR #155's auto-close) before this rework began.

## Test plan
- [x] `.venv` (torch-free): 205 passed, 56 skipped
- [x] `.venv-xpu -m "not xpu"`: 442 passed, 1 skipped, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQVhsUeDoaGusbYPuEkdve