### PR TITLE
feat(moe): wire native GPTQ GEMM into the offload forward path (issue #139)

### DIFF
--- a/python/freetoken/kernel/triton/gptq_fused_linear.py
+++ b/python/freetoken/kernel/triton/gptq_fused_linear.py
@@ -196,6 +196,40 @@ def fused_gptq_linear(
     return result
 
 
+def fused_gptq_expert_forward(
+    x: torch.Tensor,
+    qweight_gate_up: torch.Tensor,
+    qzeros_gate_up: torch.Tensor,
+    scales_gate_up: torch.Tensor,
+    qweight_down: torch.Tensor,
+    qzeros_down: torch.Tensor,
+    scales_down: torch.Tensor,
+    *,
+    group_size: int,
+    intermediate: int,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """One MoE expert's SwiGLU forward (``down(silu(gate(x)) * up(x))``)
+    entirely against packed GPTQ banks, via two :func:`fused_gptq_linear`
+    calls -- never materializing a dense gate/up/down weight (issue #139).
+
+    Same math as the plain-tensor ``_expert_compute`` helper duplicated in
+    ``qwen3_moe``/``qwen3_5_moe`` (``down(silu(gate(x)) * up(x))``, gate/up
+    fused as one bank whose output columns split ``[0:intermediate]`` /
+    ``[intermediate:2*intermediate]``), but each of the two GEMMs runs
+    fused against the packed tensors from
+    :meth:`freetoken.moe.offload_cache.SlotWeightAccessor.get_gptq_packed`
+    instead of a pre-dequantized dense weight.
+    """
+    out_dtype = out_dtype if out_dtype is not None else x.dtype
+    gu = fused_gptq_linear(
+        x, qweight_gate_up, qzeros_gate_up, scales_gate_up, group_size=group_size, out_dtype=torch.float32
+    )
+    gate, up = gu[:, :intermediate], gu[:, intermediate:]
+    h = (torch.nn.functional.silu(gate) * up).to(out_dtype)
+    return fused_gptq_linear(h, qweight_down, qzeros_down, scales_down, group_size=group_size, out_dtype=out_dtype)
+
+
 # Measured crossover (this module's own docstring sweep, 2048x768,
 # group_size=128 on the real B70): the fused kernel wins clearly through
 # M=32 and starts losing to the fallback by M=64. Not re-measured per

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1043,15 +1043,6 @@ def _rope_for_positions(
     return cos, sin
 
 
-def _expert_compute(gate_w, up_w, down_w, x):
-    """Run one expert on a [t, H] input using *detached* projection weights
-    (the offload bank rows, in [out, in] weight orientation): gate/up are
-    [I, H], down is [H, I], so each projection is ``x @ w.t()``. Returns
-    ``down(silu(gate(x)) * up(x))``."""
-    inter = gate_w.shape[0]
-    return (F.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()
-
-
 class _Qwen35MoE:
     """A Qwen3.5/3.6 MoE block: a 256-way top-8 router + an always-on shared
     expert. The router + shared expert are dense (on the device); the routed
@@ -1588,12 +1579,8 @@ class _Qwen35MoE:
         # loop. index_add_ accumulates exactly as `out[sel] += ...` did.
         for j, s_i, rows in groups:
             idx = torch.tensor(rows, dtype=torch.long, device=dev)
-            gate_w, up_w, down_w = slot_weights.get(s_i)
-            y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(
-                gate_w,
-                up_w,
-                down_w,
-                flat.index_select(0, idx),
+            y = top_w.index_select(0, idx)[:, j, None] * slot_weights.expert_forward(
+                s_i, flat.index_select(0, idx)
             )
             out.index_add_(0, idx, y)
         # NB: we do NOT write the slot ids back into top_idx here (the old code did

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -333,29 +333,6 @@ class _Qwen3Attention(nn.Module):
         return self.o_proj(out.transpose(0, 1).contiguous().reshape(bsz, -1))
 
 
-def _expert_compute(gate_w: torch.Tensor, up_w: torch.Tensor, down_w: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-    """Run one expert on a [t, H] input using *detached* projection weights.
-
-    The expert weights live in the host-offload banks (ADR 0002) and are handed
-    in as plain tensors (views of the XPU slot pool), so this is a hand-rolled
-    SwiGLU -- not an ``nn.Linear`` -- over the gathered per-expert input:
-    ``down(silu(gate(x)) * up(x))``. The bank rows are stored in *weight*
-    orientation (``[out, in]``, matching ``nn.Linear.weight``): gate/up are
-    ``[I, H]`` and down is ``[H, I]``. The projection is therefore
-    ``x @ w.t()`` -- the same ``F.linear`` form the in-VRAM ``_Qwen3Expert``
-    uses -- so the math is identical to the resident path, which the reference
-    test compares against.
-    """
-    # gate_w [I, H], up_w [I, H], down_w [H, I]; x [t, H].
-    # Every projection is ``x @ w.t()`` (F.linear form). The down step is
-    # ``h @ down_w.t()`` (NOT ``down_w.t() @ h``): in this torch XPU build the
-    # ``@`` operator requires ``left.cols == right.rows``, so the leading
-    # ``[t, *]`` operand must be on the left. ``h @ down_w.t()`` is exactly
-    # ``F.linear(h, down_w)`` -- the in-VRAM expert's down projection.
-    inter = gate_w.shape[0]
-    return (F.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()
-
-
 class _Qwen3Expert(nn.Module):
     """A single MoE expert: gate/up/down projections (SwiGLU).
 
@@ -646,12 +623,8 @@ class _Qwen3MoE(nn.Module):
         #    the loop).
         for j, s_i, rows in groups:
             idx = torch.tensor(rows, dtype=torch.long, device=dev)
-            gate_w, up_w, down_w = slot_weights.get(s_i)
-            y = top_w.index_select(0, idx)[:, j, None] * _expert_compute(
-                gate_w,
-                up_w,
-                down_w,
-                flat.index_select(0, idx),
+            y = top_w.index_select(0, idx)[:, j, None] * slot_weights.expert_forward(
+                s_i, flat.index_select(0, idx)
             )
             out.index_add_(0, idx, y)
         return out

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -697,6 +697,7 @@ class SlotWeightAccessor:
         self.quant_format = getattr(cache, "quant_format", "bf16")
         self._intermediate = intermediate
         self._dtype = dtype
+        self._is_xpu = bool(getattr(cache, "is_xpu", False))
         self._cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         if self.quant_format == "gptq_int4":
             self._banks = dict(zip(cache.bank_schema, cache.bank_views()))
@@ -761,9 +762,58 @@ class SlotWeightAccessor:
         else:
             self._gu, self._dn = cache.bank_views()
 
+    def get_gptq_packed(
+        self, s_i: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        """Raw packed ``(qweight_gate_up, qzeros_gate_up, scales_gate_up,
+        qweight_down, qzeros_down, scales_down, group_size)`` views for slot
+        ``s_i`` -- ``gptq_int4`` only, and never dequantized (unlike
+        :meth:`get`). For the native fused-GEMM forward path (issue
+        `moe-quant-banks-native`, #139): :func:`freetoken.kernel.triton.
+        gptq_fused_linear.fused_gptq_expert_forward` consumes these directly,
+        skipping the dense-weight materialization :meth:`get` performs.
+        """
+        if self.quant_format != "gptq_int4":
+            raise ValueError(f"get_gptq_packed is gptq_int4-only, got quant_format={self.quant_format!r}")
+        b = self._banks
+        return (
+            b["qweight_gate_up"][s_i], b["qzeros_gate_up"][s_i], b["scales_gate_up"][s_i],
+            b["qweight_down"][s_i], b["qzeros_down"][s_i], b["scales_down"][s_i],
+            self._group_size,
+        )
+
+    def expert_forward(self, s_i: int, x: torch.Tensor) -> torch.Tensor:
+        """One MoE expert's SwiGLU forward (``down(silu(gate(x)) * up(x))``)
+        for slot ``s_i`` against input ``x``. Previously each offload
+        forward call site (``qwen3_moe``/``qwen3_5_moe``) ran this same
+        formula itself, against :meth:`get`'s dense output, via a small
+        ``_expert_compute`` helper duplicated in each model file; centralized
+        here instead so it can also dispatch to the native fused-GEMM path
+        (issue `moe-quant-banks-native`, #139) when that is expected to win:
+        ``gptq_int4``, real XPU hardware, and ``x``'s row count at or below
+        the measured crossover (see :func:`freetoken.kernel.triton.
+        gptq_fused_linear.prefer_fused_over_dequant`). Every other case
+        falls back to dequantizing via :meth:`get` first, the same math the
+        old per-model helpers ran.
+        """
+        if self.quant_format == "gptq_int4" and self._is_xpu:
+            from freetoken.kernel.triton.gptq_fused_linear import (
+                fused_gptq_expert_forward,
+                prefer_fused_over_dequant,
+            )
+
+            if prefer_fused_over_dequant(x.shape[0]):
+                qw_gu, qz_gu, s_gu, qw_dn, qz_dn, s_dn, group_size = self.get_gptq_packed(s_i)
+                return fused_gptq_expert_forward(
+                    x, qw_gu, qz_gu, s_gu, qw_dn, qz_dn, s_dn,
+                    group_size=group_size, intermediate=self._intermediate, out_dtype=self._dtype,
+                )
+        gate_w, up_w, down_w = self.get(s_i)
+        return (torch.nn.functional.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()
+
     def get(self, s_i: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """``(gate_w, up_w, down_w)`` for slot ``s_i``, in ``[out, in]``
-        weight orientation (matching ``nn.Linear.weight`` / ``_expert_compute``'s
+        weight orientation (matching ``nn.Linear.weight`` / :meth:`expert_forward`'s
         expected shape) -- gate/up are ``[I, H]``, down is ``[H, I]``."""
         if self.quant_format == "bf16":
             i = self._intermediate

--- a/tests/test_qwen35_gptq_native_fused_xpu.py
+++ b/tests/test_qwen35_gptq_native_fused_xpu.py
@@ -1,0 +1,111 @@
+"""End-to-end: the offload forward's GPTQ-Int4 path actually dispatches to
+the native fused-GEMM kernel on real XPU hardware, and produces the same
+generated tokens as the dequant-then-matmul path (issue `moe-quant-banks-
+native`, #139).
+
+Reuses ``test_qwen35_gptq_e2e_loader.py``'s tiny synthetic GPTQ checkpoint
+fixture (issue #138's own small-fabricated-checkpoint approach) -- this
+proves the wiring end-to-end without the real 22.73GB Qwen3.5-35B-A3B-
+GPTQ-Int4 checkpoint, which isn't loaded locally right now (RAM-constrained
+box). Drives a full ``Engine`` (mirrors test_moe_fused_xpu.py's own
+CPU-vs-XPU comparison pattern) rather than the lower-level ``_drive_prefill``
+helper, which hardcodes a CPU-only KV cache. ``xpu``-marked: deselected on a
+torch-free / no-XPU box (see ``conftest.py``); the CPU forward this fixture
+already exercises in test_qwen35_gptq_e2e_loader.py is untouched by this
+wiring (SlotWeightAccessor.expert_forward only takes the native path when
+``cache.is_xpu``).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.kernel.triton import gptq_fused_linear
+
+from tests.test_qwen35_gptq_e2e_loader import V, qwen35_gptq_ckpt  # noqa: F401
+
+_PROMPT_IDS = [1, 2, 3, 4, 5]
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _engine_config(model_path: str, device: torch.device) -> EngineConfig:
+    return EngineConfig(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=device,
+        attention_backend="auto",
+        moe_backend="offload",
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+        num_page_override=64,
+    )
+
+
+def _add_prompt(engine: Engine, output_len: int) -> None:
+    engine.add_request(
+        Req(
+            input_ids=list(_PROMPT_IDS),
+            table_idx=0,
+            cached_len=0,
+            output_len=output_len,
+            uid=0,
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+            cache_handle=None,
+        )
+    )
+
+
+@XPU
+@pytest.mark.xpu
+def test_native_fused_path_is_actually_dispatched(qwen35_gptq_ckpt):
+    with patch(
+        "freetoken.kernel.triton.gptq_fused_linear.fused_gptq_expert_forward",
+        wraps=gptq_fused_linear.fused_gptq_expert_forward,
+    ) as spy:
+        engine = Engine(_engine_config(qwen35_gptq_ckpt, torch.device("xpu")))
+        assert engine.model.moe_cache.is_xpu
+        _add_prompt(engine, output_len=3)
+        tokens = engine.generate()
+
+    assert spy.call_count > 0, "native fused path was never dispatched -- SlotWeightAccessor.expert_forward fell through to the dequant fallback"
+    assert len(tokens[0]) == 3
+    assert all(0 <= t < V for t in tokens[0])
+
+
+@XPU
+@pytest.mark.xpu
+def test_native_fused_path_matches_dequant_fallback_tokens(qwen35_gptq_ckpt):
+    """Same checkpoint, same prompt: the native path and the dequant-then-
+    matmul fallback must produce identical greedy tokens."""
+    native_engine = Engine(_engine_config(qwen35_gptq_ckpt, torch.device("xpu")))
+    _add_prompt(native_engine, output_len=4)
+    native_tokens = native_engine.generate()
+    reset_global_ctx()
+
+    # SlotWeightAccessor.expert_forward imports prefer_fused_over_dequant
+    # lazily from gptq_fused_linear on each call, so patching it there is
+    # what actually forces the dequant fallback path here.
+    with patch("freetoken.kernel.triton.gptq_fused_linear.prefer_fused_over_dequant", lambda m: False):
+        fallback_engine = Engine(_engine_config(qwen35_gptq_ckpt, torch.device("xpu")))
+        _add_prompt(fallback_engine, output_len=4)
+        fallback_tokens = fallback_engine.generate()
+
+    assert native_tokens == fallback_tokens, (
+        f"native fused path diverged from the dequant fallback: {native_tokens} != {fallback_tokens}"
+    )


### PR DESCRIPTION
## Summary

Completes #139's remaining scope. `SlotWeightAccessor` previously always dequantized a resident expert's packed GPTQ weights to a dense tensor before the forward's own matmul (`get()` + a small `_expert_compute` helper duplicated in `qwen3_moe/__init__.py` and `qwen3_5_moe/__init__.py`).

Adds `SlotWeightAccessor.expert_forward(s_i, x)`, centralizing that SwiGLU math in one place, dispatching to the native fused kernel (`fused_gptq_expert_forward`, from #160/#161) when it's expected to win: real XPU hardware, `gptq_int4`, and `x`'s row count within the measured crossover (`prefer_fused_over_dequant`). Both model files' offload forward loops now call this instead of `get()` + the old per-model `_expert_compute` helper, which is now dead code and removed.

Every call site in both files already batches strictly **one row per (expert, slot, top-k column)** -- see the loop's own "EXPERT-MAJOR order" comment -- so this is exactly M=1, the fused kernel's strongest measured win (~4x faster than the dequant fallback).

## Verification

End-to-end on the real B70, against `test_qwen35_gptq_e2e_loader.py`'s existing tiny synthetic GPTQ checkpoint fixture (issue #138's own small-fabricated-checkpoint approach -- no real 22.73GB checkpoint needed, consistent with the current RAM constraint):
- A spied `fused_gptq_expert_forward` call confirms the native path actually dispatches during a real `generate()` run.
- The same prompt with the native path forced off (`prefer_fused_over_dequant` patched to always return `False`) produces **identical greedy tokens** to the native path.

The CPU-only forward `test_qwen35_gptq_e2e_loader.py` already exercises is untouched (`expert_forward` only takes the native path when `cache.is_xpu`).

**Known gap**: no dedicated end-to-end GPTQ fixture exists for the base `qwen3_moe` (non-3.5) architecture in this repo (issue #138 only ever targeted the real Qwen3.5-35B-A3B-GPTQ-Int4 checkpoint) -- that file's identical call-site edit is covered structurally (py_compile, full non-xpu suite) but not by a real-hardware GPTQ forward test the way `qwen3_5_moe`'s is here.

## Test plan
- [x] New `tests/test_qwen35_gptq_native_fused_xpu.py` (xpu-marked, real hardware): 2/2 passed
- [x] `.venv` (torch-free): 205 passed, 59 skipped
- [x] `.venv-xpu -m "not xpu"`: 444 passed, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)
- [x] Focused xpu-marked re-run of every GPTQ-adjacent test file (dispatch, kernel, e2e loader, native wiring, hybrid exclusion, slot accessor): 20/20 passed
- [x] Confirmed `test_moe_cache_budget_xpu.py`'s one OOM failure (seen when the full `-m xpu` suite was run in one process) reproduces identically on a clean `main` checkout -- pre-existing, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5