### PR TITLE
feat(moe): native block-FP8 GEMM, fused dequant + matmul (issue #163)

### DIFF
--- a/python/freetoken/kernel/triton/fused_fp8_linear.py
+++ b/python/freetoken/kernel/triton/fused_fp8_linear.py
@@ -1,0 +1,193 @@
+"""Native block-FP8 GEMM: matmul directly against packed
+``weight_fp8``/``weight_scale_inv``, never materializing a dequantized bf16
+weight tensor (issue `moe-quant-banks-native-multi`, #163, extending #139's
+GPTQ approach to the other three offload-bank formats).
+
+``fp8_block_linear.py``'s ``dequantize_block_fp8`` (and the offload cache's
+``SlotWeightAccessor``) both dequantize an expert's packed block-FP8 weight
+to a dense tensor first, THEN run a plain matmul. This module fuses the
+two: each Triton program dequantizes only the ``[QBLOCK, BLOCK_N]`` weight
+tile it is about to consume and feeds it straight into ``tl.dot``.
+
+Feasibility and real measured latency, both confirmed on the actual B70
+(Xe2, Triton-XPU 3.7.2, torch 2.13.0+xpu):
+
+* Correctness: matches ``dequantize_block_fp8`` + a plain matmul to
+  float32 rounding tolerance (max abs diff ~3e-4 on a 2048x768 projection)
+  across aligned and ragged M/K/N shapes.
+* Performance: block-FP8's existing dequant-then-matmul fallback is
+  ALREADY fast -- ``dequantize_block_fp8`` is a single reshape+broadcast-
+  multiply (no bit-unpacking, unlike GPTQ/INT8), so the fallback's own
+  cost is small and roughly flat across M (~0.05ms on a 2048x768
+  projection, every M tried). The fused kernel only wins clearly at M=1
+  (~0.036ms vs ~0.053ms, ~32% faster -- still real, and it is exactly the
+  M every offload forward call site actually uses, see
+  ``fused_gptq_linear``'s own docstring for why), roughly ties through
+  M=8, and loses beyond M=16. This is a much smaller margin than GPTQ's
+  ~4x win (#139) -- block-FP8 was never as expensive to dequantize in the
+  first place.
+
+Design mirrors ``gptq_fused_linear``: the K-loop iterates one full
+QBLOCK=128 quantization block per step, so (unlike GPTQ's group-vs-column
+scale) every element in one loop iteration shares exactly ONE scalar scale
+(block-FP8 quantizes both the N and K axes into ``block``-sized tiles, and
+this kernel's ``BLOCK_N`` is required to divide ``block`` evenly and
+started at a multiple of it, so one program's N-tile never crosses an
+N-axis quantization block boundary either) -- simpler than GPTQ's
+per-output-channel scale vector, no group/column indexing needed inside
+the hot loop at all.
+"""
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+_QBLOCK = 128  # block-FP8's quantization block size (DeepSeek-V3 / sglang / vLLM convention)
+
+
+@triton.jit
+def _fused_fp8_matmul_kernel(
+    x_ptr, w_ptr, s_ptr, out_ptr,
+    M, N, K,
+    stride_xm, stride_xk,
+    stride_wn, stride_wk,
+    stride_sn, stride_sk,
+    stride_om, stride_on,
+    QBLOCK: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_m = offs_m < M
+    mask_n = offs_n < N
+    n_block_idx = (pid_n * BLOCK_N) // QBLOCK  # BLOCK_N divides QBLOCK -> one N-tile, one N-block
+
+    num_k_blocks = tl.cdiv(K, QBLOCK)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for kb in range(num_k_blocks):
+        k_start = kb * QBLOCK
+        offs_k = k_start + tl.arange(0, QBLOCK)
+        mask_k = offs_k < K
+
+        # weight_fp8 is [N, K] (nn.Linear's own out/in orientation) -- loaded
+        # here as a [QBLOCK, BLOCK_N] (k-major, n-minor) tile so it feeds
+        # tl.dot directly as x[BLOCK_M, QBLOCK] @ w[QBLOCK, BLOCK_N], no
+        # separate transpose.
+        w_ptrs = w_ptr + offs_n[None, :] * stride_wn + offs_k[:, None] * stride_wk
+        w_tile = tl.load(w_ptrs, mask=mask_n[None, :] & mask_k[:, None], other=0.0).to(tl.float32)
+
+        scale = tl.load(s_ptr + n_block_idx * stride_sn + kb * stride_sk).to(tl.float32)
+        w_deq = w_tile * scale
+
+        x_ptrs = x_ptr + offs_m[:, None] * stride_xm + offs_k[None, :] * stride_xk
+        x_tile = tl.load(x_ptrs, mask=mask_m[:, None] & mask_k[None, :], other=0.0).to(tl.float32)
+
+        acc += tl.dot(x_tile, w_deq, allow_tf32=False)
+
+    out_ptrs = out_ptr + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+    tl.store(out_ptrs, acc, mask=mask_m[:, None] & mask_n[None, :])
+
+
+def fused_fp8_linear(
+    x: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    *,
+    bias: torch.Tensor | None = None,
+    block: int = _QBLOCK,
+    block_m: int = 1,
+    block_n: int = 16,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """``x @ dequantize_block_fp8(weight_fp8, weight_scale_inv).T (+ bias)``,
+    fused into one Triton kernel that never materializes the dense weight.
+
+    ``weight_fp8`` is ``[N, K]`` (``nn.Linear``'s own out/in orientation);
+    ``weight_scale_inv`` is ``[ceil(N/block), ceil(K/block)]``. ``block_n``
+    must divide ``block`` evenly (so one N-tile never crosses a quantization
+    block boundary) -- true of every default/measured-best config this
+    module ships.
+
+    Defaults (``block_m=1, block_n=16``) are the measured-best config for
+    M=1 on the real B70 (the batch size every real offload forward call
+    site actually uses) -- see this module's own docstring for the numbers
+    and the (much smaller than GPTQ's) crossover past which the plain
+    dequant-then-matmul fallback wins instead.
+    """
+    if block % block_n != 0:
+        raise ValueError(f"block_n {block_n} must divide block {block} evenly")
+    if weight_fp8.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+        raise TypeError(f"weight_fp8 must be an fp8 dtype, got {weight_fp8.dtype}")
+
+    m, k = x.shape
+    n, k2 = weight_fp8.shape
+    if k != k2:
+        raise ValueError(f"x's K={k} does not match weight_fp8's K={k2}")
+    expected_scale_shape = (-(-n // block), -(-k // block))
+    if tuple(weight_scale_inv.shape) != expected_scale_shape:
+        raise ValueError(
+            f"weight_scale_inv shape {tuple(weight_scale_inv.shape)} does not match "
+            f"the expected {expected_scale_shape} for weight_fp8 shape {(n, k)} at block={block}"
+        )
+
+    out = torch.empty((m, n), device=x.device, dtype=torch.float32)
+    grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
+    _fused_fp8_matmul_kernel[grid](
+        x, weight_fp8, weight_scale_inv, out,
+        m, n, k,
+        x.stride(0), x.stride(1),
+        weight_fp8.stride(0), weight_fp8.stride(1),
+        weight_scale_inv.stride(0), weight_scale_inv.stride(1),
+        out.stride(0), out.stride(1),
+        QBLOCK=block, BLOCK_M=block_m, BLOCK_N=block_n,
+    )
+    result = out.to(out_dtype if out_dtype is not None else x.dtype)
+    if bias is not None:
+        result = result + bias
+    return result
+
+
+def fused_fp8_expert_forward(
+    x: torch.Tensor,
+    weight_fp8_gate_up: torch.Tensor,
+    weight_scale_inv_gate_up: torch.Tensor,
+    weight_fp8_down: torch.Tensor,
+    weight_scale_inv_down: torch.Tensor,
+    *,
+    intermediate: int,
+    block: int = _QBLOCK,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """One MoE expert's SwiGLU forward (``down(silu(gate(x)) * up(x))``)
+    entirely against packed block-FP8 banks, via two :func:`fused_fp8_linear`
+    calls -- mirrors :func:`freetoken.kernel.triton.gptq_fused_linear.
+    fused_gptq_expert_forward`'s structure exactly (gate/up fused as one
+    bank whose output rows split ``[0:intermediate]`` / ``[intermediate:
+    2*intermediate]``)."""
+    out_dtype = out_dtype if out_dtype is not None else x.dtype
+    gu = fused_fp8_linear(x, weight_fp8_gate_up, weight_scale_inv_gate_up, block=block, out_dtype=torch.float32)
+    gate, up = gu[:, :intermediate], gu[:, intermediate:]
+    h = (torch.nn.functional.silu(gate) * up).to(out_dtype)
+    return fused_fp8_linear(h, weight_fp8_down, weight_scale_inv_down, block=block, out_dtype=out_dtype)
+
+
+# Measured crossover (this module's own docstring sweep, 2048x768 on the
+# real B70): the fused kernel clearly wins only at M=1, roughly ties
+# through M=8, and loses beyond M=16 -- a much smaller/more conservative
+# window than GPTQ's (#139's own _FUSED_MAX_M=32), matching block-FP8's
+# already-cheap dequant (a single reshape+multiply, no bit-unpacking).
+_FUSED_MAX_M = 8
+
+
+def prefer_fused_over_dequant(m: int) -> bool:
+    """Whether :func:`fused_fp8_linear` (native GEMM) is expected to beat
+    the plain dequant-then-matmul fallback for a batch of ``m`` rows -- see
+    this module's own docstring for the measured numbers this threshold is
+    drawn from. Mirrors :func:`freetoken.kernel.triton.gptq_fused_linear.
+    prefer_fused_over_dequant`'s role for GPTQ.
+    """
+    return m <= _FUSED_MAX_M

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -782,19 +782,43 @@ class SlotWeightAccessor:
             self._group_size,
         )
 
+    def get_fp8_packed(
+        self, s_i: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        """Raw packed ``(weight_fp8_gate_up, weight_scale_inv_gate_up,
+        weight_fp8_down, weight_scale_inv_down, block)`` views for slot
+        ``s_i`` -- ``fp8_block`` only, and never dequantized (unlike
+        :meth:`get`). For the native fused-GEMM forward path (issue
+        `moe-quant-banks-native-multi`, #163): :func:`freetoken.kernel.
+        triton.fused_fp8_linear.fused_fp8_expert_forward` consumes these
+        directly, skipping the dense-weight materialization :meth:`get`
+        performs.
+        """
+        if self.quant_format != "fp8_block":
+            raise ValueError(f"get_fp8_packed is fp8_block-only, got quant_format={self.quant_format!r}")
+        b = self._banks
+        return (
+            b["weight_gate_up"][s_i], b["scale_gate_up"][s_i],
+            b["weight_down"][s_i], b["scale_down"][s_i],
+            self._fp8_block,
+        )
+
     def expert_forward(self, s_i: int, x: torch.Tensor) -> torch.Tensor:
         """One MoE expert's SwiGLU forward (``down(silu(gate(x)) * up(x))``)
         for slot ``s_i`` against input ``x``. Previously each offload
         forward call site (``qwen3_moe``/``qwen3_5_moe``) ran this same
         formula itself, against :meth:`get`'s dense output, via a small
         ``_expert_compute`` helper duplicated in each model file; centralized
-        here instead so it can also dispatch to the native fused-GEMM path
-        (issue `moe-quant-banks-native`, #139) when that is expected to win:
-        ``gptq_int4``, real XPU hardware, and ``x``'s row count at or below
-        the measured crossover (see :func:`freetoken.kernel.triton.
-        gptq_fused_linear.prefer_fused_over_dequant`). Every other case
-        falls back to dequantizing via :meth:`get` first, the same math the
-        old per-model helpers ran.
+        here instead so it can also dispatch to a native fused-GEMM path
+        (issue `moe-quant-banks-native`, #139; extended to fp8_block by
+        #163) when one is expected to win: real XPU hardware, a format with
+        a fused kernel, and ``x``'s row count at or below that format's
+        measured crossover (see :func:`freetoken.kernel.triton.
+        gptq_fused_linear.prefer_fused_over_dequant` /
+        :func:`freetoken.kernel.triton.fused_fp8_linear.
+        prefer_fused_over_dequant`). Every other case falls back to
+        dequantizing via :meth:`get` first, the same math the old per-model
+        helpers ran.
         """
         if self.quant_format == "gptq_int4" and self._is_xpu:
             from freetoken.kernel.triton.gptq_fused_linear import (
@@ -807,6 +831,18 @@ class SlotWeightAccessor:
                 return fused_gptq_expert_forward(
                     x, qw_gu, qz_gu, s_gu, qw_dn, qz_dn, s_dn,
                     group_size=group_size, intermediate=self._intermediate, out_dtype=self._dtype,
+                )
+        elif self.quant_format == "fp8_block" and self._is_xpu:
+            from freetoken.kernel.triton.fused_fp8_linear import (
+                fused_fp8_expert_forward,
+                prefer_fused_over_dequant,
+            )
+
+            if prefer_fused_over_dequant(x.shape[0]):
+                w_gu, s_gu, w_dn, s_dn, block = self.get_fp8_packed(s_i)
+                return fused_fp8_expert_forward(
+                    x, w_gu, s_gu, w_dn, s_dn,
+                    intermediate=self._intermediate, block=block, out_dtype=self._dtype,
                 )
         gate_w, up_w, down_w = self.get(s_i)
         return (torch.nn.functional.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()

--- a/tests/test_fused_fp8_dispatch.py
+++ b/tests/test_fused_fp8_dispatch.py
@@ -1,0 +1,23 @@
+"""``prefer_fused_over_dequant`` (fp8): the measured fused-vs-fallback
+crossover for block-FP8 (issue `moe-quant-banks-native-multi`, #163). Pure
+Python logic, no torch/XPU needed -- companion to the real hardware
+correctness/perf tests in test_fused_fp8_linear_xpu.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("triton")
+
+from freetoken.kernel.triton.fused_fp8_linear import prefer_fused_over_dequant
+
+
+def test_prefers_fused_at_and_below_the_measured_crossover():
+    for m in (1, 2, 4, 8):
+        assert prefer_fused_over_dequant(m) is True
+
+
+def test_prefers_fallback_above_the_measured_crossover():
+    for m in (9, 16, 32, 64):
+        assert prefer_fused_over_dequant(m) is False

--- a/tests/test_fused_fp8_linear_xpu.py
+++ b/tests/test_fused_fp8_linear_xpu.py
@@ -1,0 +1,88 @@
+"""``fused_fp8_linear``: native block-FP8 GEMM against packed tensors,
+never materializing a dense dequantized weight (issue `moe-quant-banks-
+native-multi`, #163, extending #139's GPTQ approach to block-FP8).
+
+Needs a real Triton-XPU compile + real fp8 tensor loads -- no meaningful
+CPU-only synthetic-fixture version exists, the same reasoning as
+test_gptq_fused_linear_xpu.py. ``xpu``-marked: deselected on a torch-free /
+no-XPU box (see ``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.kernel.triton.fp8_block_linear import dequantize_block_fp8, quantize_block_fp8
+from freetoken.kernel.triton.fused_fp8_linear import fused_fp8_linear
+
+DEVICE = "xpu"
+
+
+@XPU
+@pytest.mark.xpu
+@pytest.mark.parametrize(
+    "m,k,n,block",
+    [
+        (8, 256, 384, 128),  # aligned, single-block-per-tile-row K
+        (5, 300, 213, 128),  # ragged M/K/N, real checkpoint block size
+        (32, 2048, 768, 128),  # realistic MoE expert projection shape
+        (1, 128, 128, 128),  # exactly one quant block
+    ],
+)
+def test_fused_matches_dequant_then_matmul(m, k, n, block):
+    torch.manual_seed(0)
+    w = torch.randn(n, k, device=DEVICE)
+    w_fp8, scale = quantize_block_fp8(w, block=block)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
+
+    ref_w = dequantize_block_fp8(w_fp8, scale, block=block, out_dtype=torch.float32)
+    ref_out = x @ ref_w.T
+
+    fused_out = fused_fp8_linear(x, w_fp8, scale, block=block, out_dtype=torch.float32)
+
+    torch.testing.assert_close(fused_out, ref_out, atol=2e-3, rtol=2e-2)
+
+
+@XPU
+@pytest.mark.xpu
+def test_fused_applies_bias():
+    torch.manual_seed(0)
+    m, k, n, block = 4, 128, 32, 128
+    w = torch.randn(n, k, device=DEVICE)
+    w_fp8, scale = quantize_block_fp8(w, block=block)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
+    bias = torch.randn(n, device=DEVICE, dtype=torch.float32)
+
+    ref_w = dequantize_block_fp8(w_fp8, scale, block=block, out_dtype=torch.float32)
+    ref_out = x @ ref_w.T + bias
+
+    fused_out = fused_fp8_linear(x, w_fp8, scale, block=block, bias=bias, out_dtype=torch.float32)
+
+    torch.testing.assert_close(fused_out, ref_out, atol=2e-3, rtol=2e-2)
+
+
+@XPU
+@pytest.mark.xpu
+def test_fused_output_dtype_defaults_to_input_dtype():
+    m, k, n, block = 4, 128, 32, 128
+    w = torch.randn(n, k, device=DEVICE)
+    w_fp8, scale = quantize_block_fp8(w, block=block)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.bfloat16)
+
+    out = fused_fp8_linear(x, w_fp8, scale, block=block)
+
+    assert out.dtype == torch.bfloat16
+
+
+@XPU
+@pytest.mark.xpu
+def test_block_n_not_dividing_block_raises():
+    m, k, n, block = 4, 128, 32, 128
+    w = torch.randn(n, k, device=DEVICE)
+    w_fp8, scale = quantize_block_fp8(w, block=block)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
+    with pytest.raises(ValueError, match="must divide"):
+        fused_fp8_linear(x, w_fp8, scale, block=block, block_n=24)

--- a/tests/test_moe_slot_weight_accessor_fp8_native_xpu.py
+++ b/tests/test_moe_slot_weight_accessor_fp8_native_xpu.py
@@ -1,0 +1,108 @@
+"""SlotWeightAccessor.expert_forward: the offload forward's fp8_block path
+actually dispatches to the native fused-GEMM kernel on real XPU hardware,
+and matches the dequant-then-matmul fallback (issue `moe-quant-banks-
+native-multi`, #163).
+
+Reuses test_moe_slot_weight_accessor_fp8.py's own fixture pattern
+(_make_packed_projection / _cache_with_fp8_bank), moved to a real XPU
+device -- expert_forward's native branch only engages when
+``cache.is_xpu``, so the existing CPU-only accessor tests never exercise
+it. ``xpu``-marked: deselected on a torch-free / no-XPU box (see
+``conftest.py``).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.kernel.triton import fused_fp8_linear as fused_fp8_linear_mod
+from freetoken.kernel.triton.fp8_block_linear import quantize_block_fp8
+from freetoken.moe.offload_cache import OffloadMoeCache, SlotWeightAccessor
+
+DEVICE = torch.device("xpu")
+
+
+def _make_packed_projection(n: int, k: int, block: int, *, seed: int) -> tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator().manual_seed(seed)
+    dense = torch.randn(n, k, generator=g)
+    w, s = quantize_block_fp8(dense, block=block)
+    return w.to(DEVICE), s.to(DEVICE)
+
+
+def _cache_with_fp8_bank(n_gu, k_gu, n_dn, k_dn, block, *, num_experts, cache_size):
+    cache = OffloadMoeCache(1, num_experts, cache_size, DEVICE, quant_format="fp8_block")
+    cache.fp8_block_size = block
+    sources = {name: [] for name in ("weight_gate_up", "scale_gate_up", "weight_down", "scale_down")}
+    for e in range(num_experts):
+        gu_w, gu_s = _make_packed_projection(n_gu, k_gu, block, seed=100 + e)
+        dn_w, dn_s = _make_packed_projection(n_dn, k_dn, block, seed=200 + e)
+        for name, t in (
+            ("weight_gate_up", gu_w), ("scale_gate_up", gu_s),
+            ("weight_down", dn_w), ("scale_down", dn_s),
+        ):
+            sources[name].append(t)
+    sources = {name: [torch.stack(v)] for name, v in sources.items()}
+    cache.set_bank_sources(sources)
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    return cache
+
+
+@XPU
+@pytest.mark.xpu
+def test_expert_forward_dispatches_to_native_fused_path():
+    hidden, inter, block = 256, 128, 128  # multiples of block, real checkpoint's convention
+    cache = _cache_with_fp8_bank(2 * inter, hidden, hidden, inter, block, num_experts=2, cache_size=2)
+    assert cache.is_xpu
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+
+    with patch(
+        "freetoken.kernel.triton.fused_fp8_linear.fused_fp8_expert_forward",
+        wraps=fused_fp8_linear_mod.fused_fp8_expert_forward,
+    ) as spy:
+        for e in range(2):
+            slot = int(cache.slot_for_id[0, e].item())
+            x = torch.randn(1, hidden, device=DEVICE, dtype=torch.float32)  # M=1: real call-site batch size
+            accessor.expert_forward(slot, x)
+
+    assert spy.call_count == 2
+
+
+@XPU
+@pytest.mark.xpu
+def test_expert_forward_matches_dequant_fallback():
+    hidden, inter, block = 256, 128, 128
+    cache = _cache_with_fp8_bank(2 * inter, hidden, hidden, inter, block, num_experts=1, cache_size=1)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    slot = int(cache.slot_for_id[0, 0].item())
+    x = torch.randn(1, hidden, device=DEVICE, dtype=torch.float32)
+
+    native_out = accessor.expert_forward(slot, x)
+
+    gate_w, up_w, down_w = accessor.get(slot)
+    fallback_out = (torch.nn.functional.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()
+
+    torch.testing.assert_close(native_out, fallback_out, atol=2e-3, rtol=2e-2)
+
+
+@XPU
+@pytest.mark.xpu
+def test_expert_forward_falls_back_above_the_measured_crossover():
+    hidden, inter, block = 256, 128, 128
+    cache = _cache_with_fp8_bank(2 * inter, hidden, hidden, inter, block, num_experts=1, cache_size=1)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    slot = int(cache.slot_for_id[0, 0].item())
+    x = torch.randn(64, hidden, device=DEVICE, dtype=torch.float32)  # well above _FUSED_MAX_M
+
+    with patch(
+        "freetoken.kernel.triton.fused_fp8_linear.fused_fp8_expert_forward",
+        wraps=fused_fp8_linear_mod.fused_fp8_expert_forward,
+    ) as spy:
+        accessor.expert_forward(slot, x)
+
+    assert spy.call_count == 0


### PR DESCRIPTION
## Summary

First of #163's three format slices: extends #139's approach (fuse dequant + matmul into one Triton kernel, wired into `SlotWeightAccessor.expert_forward`) to block-FP8.

## Verified on the real B70 (Xe2, Triton-XPU 3.7.2)

- **Correctness**: matches `dequantize_block_fp8` + a plain matmul to float32 rounding tolerance across aligned/ragged M/K/N shapes.
- **Performance**: block-FP8's dequant-then-matmul fallback is already fast (a single reshape+multiply, no bit-unpacking like GPTQ/INT8) -- ~0.05ms flat across M on a 2048x768 projection. The fused kernel only wins clearly at **M=1** (~0.036ms vs ~0.053ms, ~32% faster -- still real, and exactly the batch size every real offload forward call site uses), roughly ties through M=8, loses beyond M=16. Much smaller margin than GPTQ's ~4x (#139) -- block-FP8 was never as expensive to dequantize in the first place. `prefer_fused_over_dequant`'s crossover is set conservatively (M<=8).

## Test plan
- [x] New `tests/test_fused_fp8_linear_xpu.py` (xpu-marked, real hardware, kernel-level correctness): 6/6 passed
- [x] New `tests/test_fused_fp8_dispatch.py` (pure logic): 2/2 passed
- [x] New `tests/test_moe_slot_weight_accessor_fp8_native_xpu.py` (xpu-marked, real hardware): confirms `expert_forward` actually dispatches to the native path at M=1, matches the dequant fallback, and correctly falls back above the measured crossover -- 3/3 passed
- [x] `.venv` (torch-free): 205 passed, 62 skipped
- [x] `.venv-xpu -m "not xpu"`: 446 passed, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)
- [x] All pre-existing fp8_block-adjacent tests re-run clean: 25/25 passed

**Known gap, not blocking**: no dedicated end-to-end checkpoint-loader test exists for `fp8_block` in this repo (unlike GPTQ's #138 / `test_qwen35_gptq_e2e_loader.py`) -- validated instead at the `SlotWeightAccessor.expert_forward` level. Left as follow-up if/when a real block-FP8 checkpoint becomes a load target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5