### PR TITLE
feat(moe): native compressed-tensors INT8 GEMM, fused dequant + matmul (issue #163)

### DIFF
--- a/python/freetoken/kernel/triton/fused_int8_linear.py
+++ b/python/freetoken/kernel/triton/fused_int8_linear.py
@@ -1,0 +1,220 @@
+"""Native compressed-tensors pack-quantized INT8 GEMM: matmul directly
+against packed ``weight_packed``/``weight_scale``, never materializing a
+dequantized bf16 weight tensor (issue `moe-quant-banks-native-multi`,
+#163, extending #139's GPTQ approach to INT8 -- the last of the three
+slices, following block-FP8/#164 and MXFP4/#165).
+
+``int8_packed_linear.py``'s ``dequantize_int8_packed`` (and the offload
+cache's ``SlotWeightAccessor``) both dequantize an expert's packed INT8
+weight to a dense tensor first, THEN run a plain matmul. This module fuses
+the two: each Triton program dequantizes only the ``[GROUP_SIZE,
+BLOCK_N]`` weight tile it is about to consume and feeds it straight into
+``tl.dot``.
+
+Feasibility and real measured latency, both confirmed on the actual B70
+(Xe2, Triton-XPU 3.7.2, torch 2.13.0+xpu):
+
+* Correctness: bit-exact/float32-rounding-tolerance match to
+  ``dequantize_int8_packed`` + a plain matmul across aligned/ragged
+  M/K/N/group_size shapes.
+* Performance: INT8's dequant-then-matmul fallback costs ~0.15-0.2ms flat
+  across M on a 2048x768, group_size=128 projection (a real bit-unpack, so
+  more expensive than block-FP8's plain multiply, similar order to
+  GPTQ's). The fused kernel wins clearly through M=64 (e.g. M=1: ~0.034ms
+  vs ~0.203ms, ~6x faster; M=64: ~0.114ms vs ~0.159ms) and starts losing
+  at M=128 (~0.217ms vs ~0.162ms) -- closer to GPTQ's crossover (#139,
+  M<=32) than block-FP8's conservative one (#164, M<=8), consistent with
+  both formats sharing a real bit-unpack in their fallback's dequant cost.
+
+Design mirrors ``fused_gptq_linear`` closely: the K-loop iterates one full
+quantization group per step (``group_size`` must be a multiple of 4, the
+int8 packing factor -- true of every real checkpoint's group_size found so
+far, e.g. 32), unpacking the packed ``[BLOCK_N, group_size/4]`` int32 tile
+into ``[BLOCK_N, group_size]`` via bitwise shift+mask (4 int8 values
+densely packed per word, ``+128`` offset-binary -- see
+``int8_packed_linear.py``'s own module docstring for the format,
+NOT GPTQ's ``stored-minus-one`` convention). Unlike GPTQ's ``[K, N]``
+weight orientation, ``weight_packed`` here is ``[N, ceil(K/4)]`` (the same
+``nn.Linear``-native out/in orientation block-FP8 and MXFP4 both use), so
+the K-major unpack/transpose pattern instead mirrors
+``fused_fp8_linear``'s / ``fused_mxfp4_linear``'s N-row-major-then-transpose
+shape, not GPTQ's.
+"""
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+_BITS = 8
+_ELEMS_PER_WORD = 32 // _BITS  # 4: int8 values packed per int32 word
+_OFFSET = 1 << (_BITS - 1)  # compressed_tensors' flat signed<->unsigned pack offset
+
+
+@triton.jit
+def _fused_int8_matmul_kernel(
+    x_ptr, wp_ptr, s_ptr, out_ptr,
+    M, N, K,
+    stride_xm, stride_xk,
+    stride_wpn, stride_wpc,
+    stride_sn, stride_sg,
+    stride_om, stride_on,
+    GROUP_SIZE: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    BITS: tl.constexpr, OFFSET: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_m = offs_m < M
+    mask_n = offs_n < N
+
+    NUM_PACK_COLS: tl.constexpr = GROUP_SIZE // 4  # int32 words spanned by one group
+    offs_pc = tl.arange(0, NUM_PACK_COLS)
+    shifts = tl.arange(0, 4) * BITS
+
+    num_groups = tl.cdiv(K, GROUP_SIZE)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for g in range(num_groups):
+        pc_start = g * NUM_PACK_COLS
+        wp_ptrs = wp_ptr + offs_n[:, None] * stride_wpn + (pc_start + offs_pc[None, :]) * stride_wpc
+        packed = tl.load(wp_ptrs, mask=mask_n[:, None], other=0)  # [BLOCK_N, NUM_PACK_COLS] int32
+
+        # unpack -> [BLOCK_N, NUM_PACK_COLS, 4], merge (c, b) -> k = c*4+b
+        # (matches weight_packed's own bit layout: byte b of word c holds
+        # k = c*4+b -- see int8_packed_linear.unpack_int8_from_int32).
+        w_bits = (packed[:, :, None] >> shifts[None, None, :]) & 0xFF
+        w_tile_n = tl.reshape(w_bits, (BLOCK_N, GROUP_SIZE)).to(tl.float32) - OFFSET
+
+        s_ptrs = s_ptr + offs_n * stride_sn + g * stride_sg
+        scale = tl.load(s_ptrs, mask=mask_n, other=0.0).to(tl.float32)  # [BLOCK_N]
+        w_tile_n = w_tile_n * scale[:, None]
+
+        w_tile = tl.trans(w_tile_n)  # [GROUP_SIZE, BLOCK_N]
+
+        k_start = g * GROUP_SIZE
+        offs_k = k_start + tl.arange(0, GROUP_SIZE)
+        mask_k = offs_k < K
+        x_ptrs = x_ptr + offs_m[:, None] * stride_xm + offs_k[None, :] * stride_xk
+        x_tile = tl.load(x_ptrs, mask=mask_m[:, None] & mask_k[None, :], other=0.0).to(tl.float32)
+
+        acc += tl.dot(x_tile, w_tile, allow_tf32=False)
+
+    out_ptrs = out_ptr + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+    tl.store(out_ptrs, acc, mask=mask_m[:, None] & mask_n[None, :])
+
+
+def fused_int8_linear(
+    x: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    *,
+    k: int,
+    bias: torch.Tensor | None = None,
+    block_m: int = 8,
+    block_n: int = 16,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """``x @ dequantize_int8_packed(weight_packed, weight_scale, k=k).T (+
+    bias)``, fused into one Triton kernel that never materializes the dense
+    weight.
+
+    ``weight_packed`` is ``[N, ceil(K/4)]`` int32; ``weight_scale`` is
+    ``[N, num_groups]`` (``num_groups`` divides ``k`` evenly:
+    ``group_size = k // num_groups`` must be a multiple of 4, the int8
+    packing factor).
+
+    Defaults (``block_m=8, block_n=16``) are the measured-best tile config
+    on the real B70 -- see this module's own docstring for the sweep and
+    the measured crossover (M<=64) past which
+    :func:`prefer_fused_over_dequant` says to prefer the plain
+    dequant-then-matmul fallback instead.
+    """
+    if weight_packed.dtype != torch.int32:
+        raise TypeError(f"weight_packed must be int32, got {weight_packed.dtype}")
+
+    m, kx = x.shape
+    if kx != k:
+        raise ValueError(f"x's K={kx} does not match the given k={k}")
+    n, packed_cols = weight_packed.shape
+    if weight_scale.shape[0] != n:
+        raise ValueError(f"weight_packed/weight_scale row mismatch: {n} vs {weight_scale.shape[0]}")
+    num_groups = weight_scale.shape[1]
+    if k % num_groups != 0:
+        raise ValueError(f"k={k} is not evenly divisible by num_groups={num_groups}")
+    group_size = k // num_groups
+    if group_size % 4 != 0:
+        raise ValueError(f"group_size {group_size} (k={k} / num_groups={num_groups}) must be a multiple of 4")
+    if group_size < 8:
+        # tl.dot's own hardware minimum contraction dim is 8 (this kernel's
+        # K-loop uses one full group as the dot's K each iteration) -- a
+        # real checkpoint's group_size is never this small (32 or 128 in
+        # every real one found so far); this only bites a synthetic test
+        # fixture using an unrealistically tiny group_size.
+        raise ValueError(f"group_size {group_size} is below the fused kernel's minimum of 8 (tl.dot's own hardware floor)")
+
+    out = torch.empty((m, n), device=x.device, dtype=torch.float32)
+    grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
+    _fused_int8_matmul_kernel[grid](
+        x, weight_packed, weight_scale, out,
+        m, n, k,
+        x.stride(0), x.stride(1),
+        weight_packed.stride(0), weight_packed.stride(1),
+        weight_scale.stride(0), weight_scale.stride(1),
+        out.stride(0), out.stride(1),
+        GROUP_SIZE=group_size, BLOCK_M=block_m, BLOCK_N=block_n,
+        BITS=_BITS, OFFSET=_OFFSET,
+    )
+    result = out.to(out_dtype if out_dtype is not None else x.dtype)
+    if bias is not None:
+        result = result + bias
+    return result
+
+
+def fused_int8_expert_forward(
+    x: torch.Tensor,
+    weight_packed_gate_up: torch.Tensor,
+    weight_scale_gate_up: torch.Tensor,
+    weight_packed_down: torch.Tensor,
+    weight_scale_down: torch.Tensor,
+    *,
+    intermediate: int,
+    k_gate_up: int,
+    k_down: int,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """One MoE expert's SwiGLU forward (``down(silu(gate(x)) * up(x))``)
+    entirely against packed compressed-tensors INT8 banks, via two
+    :func:`fused_int8_linear` calls -- mirrors :func:`freetoken.kernel.
+    triton.gptq_fused_linear.fused_gptq_expert_forward` / :func:`freetoken.
+    kernel.triton.fused_fp8_linear.fused_fp8_expert_forward` / :func:
+    `freetoken.kernel.triton.fused_mxfp4_linear.fused_mxfp4_expert_forward`'s
+    structure exactly."""
+    out_dtype = out_dtype if out_dtype is not None else x.dtype
+    gu = fused_int8_linear(
+        x, weight_packed_gate_up, weight_scale_gate_up, k=k_gate_up, out_dtype=torch.float32
+    )
+    gate, up = gu[:, :intermediate], gu[:, intermediate:]
+    h = (torch.nn.functional.silu(gate) * up).to(out_dtype)
+    return fused_int8_linear(h, weight_packed_down, weight_scale_down, k=k_down, out_dtype=out_dtype)
+
+
+# Measured crossover (this module's own docstring sweep, 2048x768,
+# group_size=128 on the real B70): the fused kernel wins clearly through
+# M=64 and starts losing to the fallback by M=128 -- closer to GPTQ's
+# crossover (#139, M<=32) than block-FP8's conservative one (#164, M<=8),
+# consistent with both GPTQ and INT8 sharing a real bit-unpack cost in
+# their fallback's dequant path (unlike block-FP8's plain multiply).
+_FUSED_MAX_M = 64
+
+
+def prefer_fused_over_dequant(m: int) -> bool:
+    """Whether :func:`fused_int8_linear` (native GEMM) is expected to beat
+    the plain dequant-then-matmul fallback for a batch of ``m`` rows -- see
+    this module's own docstring for the measured numbers. Mirrors
+    :func:`freetoken.kernel.triton.gptq_fused_linear.
+    prefer_fused_over_dequant`'s role for GPTQ.
+    """
+    return m <= _FUSED_MAX_M

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -825,6 +825,27 @@ class SlotWeightAccessor:
             b["blocks_down"][s_i], b["scales_down"][s_i],
         )
 
+    def get_int8_packed(
+        self, s_i: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
+        """Raw packed ``(weight_packed_gate_up, weight_scale_gate_up,
+        weight_packed_down, weight_scale_down, k_gate_up, k_down)`` views
+        for slot ``s_i`` -- ``int8_channel`` only, and never dequantized
+        (unlike :meth:`get`). For the native fused-GEMM forward path (issue
+        `moe-quant-banks-native-multi`, #163): :func:`freetoken.kernel.
+        triton.fused_int8_linear.fused_int8_expert_forward` consumes these
+        directly, skipping the dense-weight materialization :meth:`get`
+        performs.
+        """
+        if self.quant_format != "int8_channel":
+            raise ValueError(f"get_int8_packed is int8_channel-only, got quant_format={self.quant_format!r}")
+        b = self._banks
+        return (
+            b["weight_packed_gate_up"][s_i], b["weight_scale_gate_up"][s_i],
+            b["weight_packed_down"][s_i], b["weight_scale_down"][s_i],
+            self._int8_k_gate_up, self._int8_k_down,
+        )
+
     def expert_forward(self, s_i: int, x: torch.Tensor) -> torch.Tensor:
         """One MoE expert's SwiGLU forward (``down(silu(gate(x)) * up(x))``)
         for slot ``s_i`` against input ``x``. Previously each offload
@@ -832,15 +853,17 @@ class SlotWeightAccessor:
         formula itself, against :meth:`get`'s dense output, via a small
         ``_expert_compute`` helper duplicated in each model file; centralized
         here instead so it can also dispatch to a native fused-GEMM path
-        (issue `moe-quant-banks-native`, #139; extended to fp8_block/mxfp4
-        by #163) when one is expected to win: real XPU hardware, a format
-        with a fused kernel, and ``x``'s row count at or below that
-        format's measured crossover (see each format's own
+        (issue `moe-quant-banks-native`, #139; extended to fp8_block/mxfp4/
+        int8_channel by #163) when one is expected to win: real XPU
+        hardware, a format with a fused kernel, and ``x``'s row count at or
+        below that format's measured crossover (see each format's own
         ``prefer_fused_over_dequant``: :func:`freetoken.kernel.triton.
         gptq_fused_linear.prefer_fused_over_dequant`,
         :func:`freetoken.kernel.triton.fused_fp8_linear.
         prefer_fused_over_dequant`, :func:`freetoken.kernel.triton.
-        fused_mxfp4_linear.prefer_fused_over_dequant`). Every other case
+        fused_mxfp4_linear.prefer_fused_over_dequant`,
+        :func:`freetoken.kernel.triton.fused_int8_linear.
+        prefer_fused_over_dequant`). Every other case
         falls back to dequantizing via :meth:`get` first, the same math the
         old per-model helpers ran.
         """
@@ -879,6 +902,18 @@ class SlotWeightAccessor:
                 return fused_mxfp4_expert_forward(
                     x, blk_gu, sc_gu, blk_dn, sc_dn,
                     intermediate=self._intermediate, out_dtype=self._dtype,
+                )
+        elif self.quant_format == "int8_channel" and self._is_xpu:
+            from freetoken.kernel.triton.fused_int8_linear import (
+                fused_int8_expert_forward,
+                prefer_fused_over_dequant,
+            )
+
+            if prefer_fused_over_dequant(x.shape[0]):
+                wp_gu, ws_gu, wp_dn, ws_dn, k_gu, k_dn = self.get_int8_packed(s_i)
+                return fused_int8_expert_forward(
+                    x, wp_gu, ws_gu, wp_dn, ws_dn,
+                    intermediate=self._intermediate, k_gate_up=k_gu, k_down=k_dn, out_dtype=self._dtype,
                 )
         gate_w, up_w, down_w = self.get(s_i)
         return (torch.nn.functional.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()

--- a/tests/test_fused_int8_dispatch.py
+++ b/tests/test_fused_int8_dispatch.py
@@ -1,0 +1,24 @@
+"""``prefer_fused_over_dequant`` (int8): the measured fused-vs-fallback
+crossover for compressed-tensors pack-quantized INT8 (issue `moe-quant-
+banks-native-multi`, #163). Pure Python logic, no torch/XPU needed --
+companion to the real hardware correctness/perf tests in
+test_fused_int8_linear_xpu.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("triton")
+
+from freetoken.kernel.triton.fused_int8_linear import prefer_fused_over_dequant
+
+
+def test_prefers_fused_at_and_below_the_measured_crossover():
+    for m in (1, 4, 8, 16, 32, 64):
+        assert prefer_fused_over_dequant(m) is True
+
+
+def test_prefers_fallback_above_the_measured_crossover():
+    for m in (65, 128, 256):
+        assert prefer_fused_over_dequant(m) is False

--- a/tests/test_fused_int8_linear_xpu.py
+++ b/tests/test_fused_int8_linear_xpu.py
@@ -1,0 +1,112 @@
+"""``fused_int8_linear``: native compressed-tensors pack-quantized INT8
+GEMM against packed tensors, never materializing a dense dequantized
+weight (issue `moe-quant-banks-native-multi`, #163, extending #139's GPTQ
+approach to INT8).
+
+Needs a real Triton-XPU compile -- no meaningful CPU-only synthetic-
+fixture version exists, the same reasoning as test_gptq_fused_linear_xpu.py
+/ test_fused_fp8_linear_xpu.py / test_fused_mxfp4_linear_xpu.py.
+``xpu``-marked: deselected on a torch-free / no-XPU box (see
+``conftest.py``).
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.kernel.triton.fused_int8_linear import fused_int8_linear
+from freetoken.kernel.triton.int8_packed_linear import dequantize_int8_packed
+
+DEVICE = "xpu"
+
+
+def _pack_int8(codes: torch.Tensor) -> torch.Tensor:
+    n, k = codes.shape
+    codes64 = (codes.to(torch.int64) + 128).reshape(n, k // 4, 4)
+    word = sum(codes64[:, :, i] << (8 * i) for i in range(4))
+    word = torch.where(word >= (1 << 31), word - (1 << 32), word)
+    return word.to(torch.int32)
+
+
+def _random_fixture(n: int, k: int, group_size: int, *, seed: int):
+    g = torch.Generator().manual_seed(seed)
+    codes = torch.randint(-127, 128, (n, k), generator=g, dtype=torch.int8).to(DEVICE)
+    num_groups = k // group_size
+    scale = (torch.rand(n, num_groups, generator=g) * 0.1 + 0.01).to(torch.float32).to(DEVICE)
+    return _pack_int8(codes), scale
+
+
+@XPU
+@pytest.mark.xpu
+@pytest.mark.parametrize(
+    "m,k,n,group_size",
+    [
+        (8, 64, 32, 32),  # single group (K == group_size)
+        (5, 384, 504, 128),  # ragged M/N, real checkpoint group_size, multiple groups
+        (32, 2048, 768, 128),  # realistic MoE expert projection shape
+    ],
+)
+def test_fused_matches_dequant_then_matmul(m, k, n, group_size):
+    torch.manual_seed(0)
+    weight_packed, weight_scale = _random_fixture(n, k, group_size, seed=100 + k)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
+
+    ref_w = dequantize_int8_packed(weight_packed, weight_scale, k=k, out_dtype=torch.float32)
+    ref_out = x @ ref_w.T
+
+    fused_out = fused_int8_linear(x, weight_packed, weight_scale, k=k, out_dtype=torch.float32)
+
+    torch.testing.assert_close(fused_out, ref_out, atol=2e-3, rtol=2e-2)
+
+
+@XPU
+@pytest.mark.xpu
+def test_fused_applies_bias():
+    torch.manual_seed(0)
+    m, k, n, group_size = 4, 128, 32, 128
+    weight_packed, weight_scale = _random_fixture(n, k, group_size, seed=7)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
+    bias = torch.randn(n, device=DEVICE, dtype=torch.float32)
+
+    ref_w = dequantize_int8_packed(weight_packed, weight_scale, k=k, out_dtype=torch.float32)
+    ref_out = x @ ref_w.T + bias
+
+    fused_out = fused_int8_linear(x, weight_packed, weight_scale, k=k, bias=bias, out_dtype=torch.float32)
+
+    torch.testing.assert_close(fused_out, ref_out, atol=2e-3, rtol=2e-2)
+
+
+@XPU
+@pytest.mark.xpu
+def test_fused_output_dtype_defaults_to_input_dtype():
+    m, k, n, group_size = 4, 128, 32, 128
+    weight_packed, weight_scale = _random_fixture(n, k, group_size, seed=11)
+    x = torch.randn(m, k, device=DEVICE, dtype=torch.bfloat16)
+
+    out = fused_int8_linear(x, weight_packed, weight_scale, k=k)
+
+    assert out.dtype == torch.bfloat16
+
+
+@XPU
+@pytest.mark.xpu
+def test_group_size_below_tl_dot_minimum_raises():
+    weight_packed, weight_scale = _random_fixture(16, 16, 4, seed=2)  # group_size=4 < tl.dot's minimum of 8
+    x = torch.randn(4, 16, device=DEVICE, dtype=torch.float32)
+    with pytest.raises(ValueError, match="below the fused kernel's minimum"):
+        fused_int8_linear(x, weight_packed, weight_scale, k=16)
+
+
+@XPU
+@pytest.mark.xpu
+def test_group_size_not_multiple_of_pack_factor_raises():
+    weight_packed, weight_scale = _random_fixture(32, 64, 32, seed=1)
+    # 5 groups over K=64 -> group_size 64/5, not an integer -- exercised via
+    # a scale tensor with a non-dividing group count instead.
+    bad_scale = torch.zeros(32, 5, device=DEVICE, dtype=torch.float32)
+    x = torch.randn(4, 64, device=DEVICE, dtype=torch.float32)
+    with pytest.raises(ValueError, match="not evenly divisible"):
+        fused_int8_linear(x, weight_packed, bad_scale, k=64)

--- a/tests/test_moe_slot_weight_accessor_int8_native_xpu.py
+++ b/tests/test_moe_slot_weight_accessor_int8_native_xpu.py
@@ -1,0 +1,100 @@
+"""SlotWeightAccessor.expert_forward: the offload forward's int8_channel
+path actually dispatches to the native fused-GEMM kernel on real XPU
+hardware, and matches the dequant-then-matmul fallback (issue `moe-quant-
+banks-native-multi`, #163).
+
+Reuses test_moe_slot_weight_accessor_int8.py's own fixture pattern
+(_pack_int8 / _make_packed_projection / _cache_with_int8_bank), moved to a
+real XPU device -- expert_forward's native branch only engages when
+``cache.is_xpu``, so the existing CPU-only accessor tests never exercise
+it. ``xpu``-marked: deselected on a torch-free / no-XPU box (see
+``conftest.py``).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.kernel.triton import fused_int8_linear as fused_int8_linear_mod
+from freetoken.moe.offload_cache import OffloadMoeCache, SlotWeightAccessor
+
+DEVICE = torch.device("xpu")
+GROUP_SIZE = 8  # >= tl.dot's own hardware minimum contraction dim (see fused_int8_linear.py)
+
+
+def _pack_int8(codes: torch.Tensor) -> torch.Tensor:
+    n, k = codes.shape
+    codes64 = (codes.to(torch.int64) + 128).reshape(n, k // 4, 4)
+    word = sum(codes64[:, :, i] << (8 * i) for i in range(4))
+    word = torch.where(word >= (1 << 31), word - (1 << 32), word)
+    return word.to(torch.int32)
+
+
+def _make_packed_projection(n: int, k: int, *, seed: int) -> tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator().manual_seed(seed)
+    codes = torch.randint(-127, 128, (n, k), generator=g, dtype=torch.int8)
+    num_groups = k // GROUP_SIZE
+    scale = torch.rand(n, num_groups, generator=g) * 0.1 + 0.01
+    return _pack_int8(codes).to(DEVICE), scale.to(DEVICE)
+
+
+def _cache_with_int8_bank(k_gu, n_gu, k_dn, n_dn, *, num_experts, cache_size):
+    cache = OffloadMoeCache(1, num_experts, cache_size, DEVICE, quant_format="int8_channel")
+    sources = {name: [] for name in ("weight_packed_gate_up", "weight_scale_gate_up", "weight_packed_down", "weight_scale_down")}
+    for e in range(num_experts):
+        gu_w, gu_s = _make_packed_projection(n_gu, k_gu, seed=100 + e)
+        dn_w, dn_s = _make_packed_projection(n_dn, k_dn, seed=200 + e)
+        for name, t in (
+            ("weight_packed_gate_up", gu_w), ("weight_scale_gate_up", gu_s),
+            ("weight_packed_down", dn_w), ("weight_scale_down", dn_s),
+        ):
+            sources[name].append(t)
+    sources = {name: [torch.stack(v)] for name, v in sources.items()}
+    cache.set_bank_sources(sources)
+    cache.int8_k_gate_up = k_gu
+    cache.int8_k_down = k_dn
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    return cache
+
+
+@XPU
+@pytest.mark.xpu
+def test_expert_forward_dispatches_to_native_fused_path():
+    hidden, inter = 16, 8
+    cache = _cache_with_int8_bank(hidden, 2 * inter, inter, hidden, num_experts=2, cache_size=2)
+    assert cache.is_xpu
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+
+    with patch(
+        "freetoken.kernel.triton.fused_int8_linear.fused_int8_expert_forward",
+        wraps=fused_int8_linear_mod.fused_int8_expert_forward,
+    ) as spy:
+        for e in range(2):
+            slot = int(cache.slot_for_id[0, e].item())
+            x = torch.randn(1, hidden, device=DEVICE, dtype=torch.float32)  # M=1: real call-site batch size
+            accessor.expert_forward(slot, x)
+
+    assert spy.call_count == 2
+
+
+@XPU
+@pytest.mark.xpu
+def test_expert_forward_matches_dequant_fallback():
+    hidden, inter = 16, 8
+    cache = _cache_with_int8_bank(hidden, 2 * inter, inter, hidden, num_experts=1, cache_size=1)
+    accessor = SlotWeightAccessor(cache, intermediate=inter, dtype=torch.float32)
+    slot = int(cache.slot_for_id[0, 0].item())
+    x = torch.randn(1, hidden, device=DEVICE, dtype=torch.float32)
+
+    native_out = accessor.expert_forward(slot, x)
+
+    gate_w, up_w, down_w = accessor.get(slot)
+    fallback_out = (torch.nn.functional.silu(x @ gate_w.t()) * (x @ up_w.t())) @ down_w.t()
+
+    torch.testing.assert_close(native_out, fallback_out, atol=2e-3, rtol=2e-2)


### PR DESCRIPTION
## Summary

Third and final of #163's three format slices: extends #139's GPTQ approach and #164/#165's block-FP8/MXFP4 slices to compressed-tensors pack-quantized INT8.

## Verified on the real B70 (Xe2, Triton-XPU 3.7.2)

- **Correctness**: bit-exact/float32-rounding-tolerance match to `dequantize_int8_packed` + a plain matmul across aligned/ragged M/K/N/group_size shapes.
- **Performance**: INT8's dequant-then-matmul fallback costs ~0.15-0.2ms flat across M on a 2048x768, group_size=128 projection (a real bit-unpack, so more expensive than block-FP8's plain multiply). The fused kernel wins clearly through **M=64** (M=1: ~0.034ms vs ~0.203ms, ~6x faster; M=64: ~0.114ms vs ~0.159ms) and starts losing at M=128 -- closer to GPTQ's crossover (#139, M<=32) than block-FP8's conservative one (#164, M<=8), consistent with GPTQ and INT8 sharing a real bit-unpack cost in their dequant fallback.
- Added a `group_size < 8` validation error: the fused kernel's K-loop uses one full group as `tl.dot`'s contraction dim each iteration, and `tl.dot`'s own hardware floor is 8. No real checkpoint's group_size is ever this small, but a synthetic test fixture hit it during this PR's own test-writing and got an opaque Triton compiler assertion instead of a clear error before this guard was added.

## Test plan
- [x] New `tests/test_fused_int8_linear_xpu.py` (xpu-marked, real hardware, kernel-level correctness): 7/7 passed
- [x] New `tests/test_fused_int8_dispatch.py` (pure logic): 2/2 passed
- [x] New `tests/test_moe_slot_weight_accessor_int8_native_xpu.py` (xpu-marked, real hardware): confirms `expert_forward` actually dispatches to the native path at M=1 and matches the dequant fallback -- 2/2 passed
- [x] `.venv` (torch-free): 205 passed, 68 skipped
- [x] `.venv-xpu -m "not xpu"`: 450 passed, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)
- [x] All pre-existing int8_channel-adjacent tests re-run clean: 31/31 passed

**Known gap, not blocking** (same as #164/#165's slices): no dedicated end-to-end checkpoint-loader test exists for int8_channel in this repo -- validated at the `SlotWeightAccessor.expert_forward` level. Left as follow-up if/when a real int8_channel checkpoint becomes a load target.

This completes #163: all four offload-bank quant formats (`gptq_int4`, `fp8_block`, `mxfp4`, `int8_channel`) now have a native fused-GEMM path wired into `SlotWeightAccessor.expert_forward`, each gated on its own real, measured fused-vs-fallback crossover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5