### PR TITLE
fix(models): qwen3_5_moe's iter_weights dropped block-FP8/MXFP4/INT8 experts' own component tensors

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -60,6 +60,20 @@ _MTP_PREFIX = "mtp."
 # _dequantize_gptq_stream is a no-op passthrough for a plain bf16 checkpoint.
 _GPTQ_SUFFIXES = (".qweight", ".qzeros", ".scales", ".g_idx")
 
+# Component suffixes unique to the other three packed quant formats' own
+# per-expert component tensors (block-FP8's weight_scale_inv, issue #152;
+# compressed-tensors INT8's weight_packed/weight_scale/weight_shape, issue
+# #154) -- unlike GPTQ's four, these formats' own ".weight" component is
+# NOT included here (it correctly matches _expert_source_names' plain
+# ".weight"-suffixed routed set already, see is_quant_component's own
+# comment below for why only the suffixes _expert_source_names has no
+# entry for need this bypass).
+_OTHER_QUANT_SUFFIXES = (".weight_scale_inv", ".weight_packed", ".weight_scale", ".weight_shape")
+# MXFP4's own component "suffix" is fused onto the projection name with an
+# underscore, not a dot (e.g. "...gate_up_proj_blocks"), issue #153's real
+# checkpoint spelling -- see _parse_mxfp4_expert_key's own docstring.
+_MXFP4_SUFFIXES = ("_blocks", "_scales")
+
 # The one checkpoint weight that the routed-expert bank fabricator expects to be
 # an *untransposed* [n_experts, hidden, inter] (see qwen3_moe._transpose_down):
 # the down proj of a routed expert. The shared expert's down proj is a *dense*
@@ -343,14 +357,33 @@ def iter_weights(
             else raw_name
         )
         is_gptq_component = bank_only and name.endswith(_GPTQ_SUFFIXES)
-        if is_gptq_component:
-            # A raw GPTQ component's name (e.g. "...gate_proj.qweight") is
-            # never in `routed` (which only ever holds "...gate_proj.weight"
-            # spellings) -- classify by the same ".experts." substring the
-            # no-config fallback below already uses. Real routed-expert keys
-            # always carry ".experts." (the shared expert does not: it is
-            # "mlp.shared_expert.*", a different substring), so this is exact,
-            # not a heuristic weakening.
+        # A raw packed-quant component's name -- ANY of the four formats'
+        # own component suffixes, not just GPTQ's -- is never in `routed`
+        # (:func:`_expert_source_names` only ever generates the plain
+        # ".weight"-suffixed dense spelling, one entry per expert/proj; it
+        # has no idea block-FP8 ships a second ".weight_scale_inv" tensor,
+        # INT8 ships three differently-named ones, or MXFP4 fuses its
+        # component onto the projection name with an underscore instead of
+        # a dot). Found the same way the GPTQ case originally was: a real
+        # (if tiny) non-GPTQ quantized checkpoint's forward silently lost
+        # its scale tensors here, producing incomplete banks with an opaque
+        # "missing" error several layers away from this actual cause. Each
+        # format's own ".weight" component (present for GPTQ-less formats
+        # too) is NOT in this bypass -- it already matches `routed`'s plain
+        # spelling correctly, so only the suffixes `routed` has no entry
+        # for at all need the same ".experts."-substring classification
+        # GPTQ's own components already use.
+        is_quant_component = bank_only and (
+            is_gptq_component
+            or name.endswith(_OTHER_QUANT_SUFFIXES)
+            or name.endswith(_MXFP4_SUFFIXES)
+        )
+        if is_quant_component:
+            # Real routed-expert keys always carry ".experts." (the shared
+            # expert does not: it is "mlp.shared_expert.*", a different
+            # substring), so this is exact, not a heuristic weakening --
+            # the same reasoning the no-config fallback below already
+            # relies on.
             expert = ".experts." in name
         elif routed is not None:
             expert = name in routed
@@ -363,11 +396,16 @@ def iter_weights(
             continue
         if not include_non_moe and not expert:
             continue
-        # Never dtype-cast a raw GPTQ component: qweight/qzeros/g_idx are
-        # int32 and scales carries its own real dtype -- casting any of them
-        # to a requested bf16/fp16 dense dtype would silently corrupt the
-        # packed bits, not "convert" them.
-        if dtype is not None and not is_gptq_component and tensor.dtype != dtype:
+        # Never dtype-cast a raw packed-quant component: GPTQ's
+        # qweight/qzeros/g_idx and INT8's weight_packed/weight_shape are
+        # int32/int64, MXFP4's blocks/scales are uint8 -- casting any of
+        # these to a requested bf16/fp16 dense dtype would silently
+        # corrupt the packed bits, not "convert" them (a real numeric
+        # dtype like FP8's own weight/weight_scale_inv would merely be
+        # reinterpreted, not corrupted, by such a cast, but is still
+        # excluded here for the same "never touch a packed component's
+        # dtype before the format-specific streamer parses it" discipline).
+        if dtype is not None and not is_quant_component and tensor.dtype != dtype:
             tensor = tensor.to(dtype)
         # Routed experts stream to host (offload banks); the rest (dense: the
         # shared expert, linear-attention weights, embeddings, norms, lm_head)

--- a/tests/test_qwen35_fp8_e2e_loader.py
+++ b/tests/test_qwen35_fp8_e2e_loader.py
@@ -1,0 +1,142 @@
+"""End-to-end: load_model() wires a block-FP8-quantized checkpoint's experts
+into a real "fp8_block" OffloadMoeCache and runs a forward step (issue
+`moe-quant-banks-native-multi`, #163's own noted coverage gap: block-FP8
+had only SlotWeightAccessor-level XPU coverage, not a full checkpoint-
+loader test the way GPTQ's #138 has).
+
+Mirrors test_qwen35_gptq_e2e_loader.py's own approach exactly -- a small
+(few-KB) fabricated block-FP8 checkpoint, not a real multi-GB one, proving
+the load_moe_expert_sources -> _attach_offload_cache -> SlotWeightAccessor
+wiring is correct before ever touching real hardware / a real checkpoint
+at scale. Real block-FP8 checkpoints (DeepSeek-V3) use a different model
+architecture (deepseek_v3, not yet ported -- see issue #21) than this
+fixture's qwen3_5_moe shell; that's fine, since block-FP8's own
+quant_method/key-spelling detection in load_moe_expert_sources is
+architecture-independent (it dispatches purely off quantization_config +
+per-expert key spelling, not the model type) -- this test's job is to
+prove FreeToken's OWN loader wiring is correct, not that a real Qwen3.5
+checkpoint ships in this format.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.fp8_block_linear import quantize_block_fp8
+from freetoken.models.loader import load_model
+
+from tests.test_qwen35_gptq_e2e_loader import _drive_prefill
+
+H, I, E, V, L = 64, 128, 4, 64, 1
+# stream_moe_expert_sources_fp8's own dispatch (load_moe_expert_sources)
+# hardcodes block=128 (never reads it from the checkpoint's own
+# quantization_config.weight_block_size) -- I (moe_intermediate_size) must
+# be a multiple of it so the gate_proj/up_proj N-axis fuse-concat's own
+# alignment check (see _finalize_fp8_bank) doesn't reject this fixture.
+BLOCK = 128
+NH, NKV, HD = 4, 2, 16
+Q_PROJ_DIM = NH * HD * 2
+O_PROJ_DIM = NH * HD
+KV_PROJ_DIM = NKV * HD
+
+
+def _fp8_expert_weights() -> dict:
+    """One full-attention layer's dense weights (unquantized -- attention is
+    excluded from FP8 quantization, matching the real DeepSeek-V3 convention)
+    plus block-FP8-packed routed experts and a plain (unquantized) shared
+    expert -- mirrors _qwen35_gptq_weights' own structure exactly."""
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+        "model.language_model.layers.0.self_attn.q_proj.weight": torch.randn(Q_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.k_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.v_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.o_proj.weight": torch.randn(H, O_PROJ_DIM),
+        "model.language_model.layers.0.self_attn.q_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.self_attn.k_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(E, H),
+        "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.up_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(H, I),
+        "model.language_model.layers.0.mlp.shared_expert_gate.weight": torch.randn(1, H),
+    }
+    for e in range(E):
+        base = f"model.language_model.layers.0.mlp.experts.{e}"
+        for proj, n, k in (("gate_proj", I, H), ("up_proj", I, H), ("down_proj", H, I)):
+            dense = torch.randn(n, k) * ((e + 1) * 0.1)  # distinguishable per-expert magnitude
+            weight_fp8, scale = quantize_block_fp8(dense, block=BLOCK)
+            w[f"{base}.{proj}.weight"] = weight_fp8
+            w[f"{base}.{proj}.weight_scale_inv"] = scale
+    return w
+
+
+@pytest.fixture(scope="module")
+def qwen35_fp8_ckpt(tmp_path_factory):
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_fp8")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NKV,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": HD,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "activation_scheme": "dynamic",
+            "weight_block_size": [BLOCK, BLOCK],
+        },
+    }
+    weights = _fp8_expert_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+def test_load_model_builds_an_fp8_block_offload_cache(qwen35_fp8_ckpt):
+    model, _ = load_model(qwen35_fp8_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+
+    cache = model.moe_cache
+    assert cache.quant_format == "fp8_block"
+    assert set(cache.bank_sources) == {
+        "weight_gate_up", "scale_gate_up", "weight_down", "scale_down",
+    }
+
+
+def test_fp8_checkpoint_forward_step_produces_finite_logits(qwen35_fp8_ckpt):
+    """The real point of this test (mirrors #138's own for GPTQ): a
+    block-FP8-quantized checkpoint's forward pass runs end-to-end --
+    SlotWeightAccessor dequantizes the resident packed experts on the fly,
+    reading from the cache load_moe_expert_sources/_attach_offload_cache
+    actually built."""
+    model, _ = load_model(qwen35_fp8_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+    seq = torch.randint(0, V, (5,))
+    T = seq.shape[0]
+    logits, _ = _drive_prefill(model, seq, T)
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits).all()

--- a/tests/test_qwen35_int8_e2e_loader.py
+++ b/tests/test_qwen35_int8_e2e_loader.py
@@ -1,0 +1,165 @@
+"""End-to-end: load_model() wires a compressed-tensors pack-quantized
+INT8 checkpoint's experts into a real "int8_channel" OffloadMoeCache and
+runs a forward step (issue `moe-quant-banks-native-multi`, #163's own
+noted coverage gap: int8_channel had only SlotWeightAccessor-level XPU
+coverage, not a full checkpoint-loader test the way GPTQ's #138 has).
+
+Mirrors test_qwen35_gptq_e2e_loader.py's / test_qwen35_fp8_e2e_loader.py's
+/ test_qwen35_mxfp4_e2e_loader.py's own approach -- a small (few-KB)
+fabricated INT8 checkpoint, not a real one. Real compressed-tensors INT8
+checkpoints (rj1013/gemma-4-26B-A4B-it_q8) use a different model
+architecture (gemma-4, not yet ported -- see issue #20) than this
+fixture's qwen3_5_moe shell; see test_qwen35_fp8_e2e_loader.py's own
+docstring for why that's fine.
+
+Real int8_channel checkpoint keys carry NO ``mlp.`` segment (unlike
+GPTQ/FP8's ``...mlp.experts...``): ``...layers.{L}.experts.{e}.{proj}
+.{weight_packed|weight_scale|weight_shape}`` -- see
+``_parse_int8_expert_key``'s own docstring in weight.py.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.loader import load_model
+
+from tests.test_qwen35_gptq_e2e_loader import _drive_prefill
+
+H, I, E, V, L = 64, 32, 4, 64, 1
+GROUP_SIZE = 32
+
+
+def _pack_int8(codes: torch.Tensor) -> torch.Tensor:
+    """``[N, K]`` int8 codes -> ``[N, K // 4]`` int32, compressed-tensors'
+    dense num_bits=8 packing (byte i of each word = element word*4+i,
+    stored as ``code + 128``) -- see int8_packed_linear.py's own module
+    docstring for the format."""
+    n, k = codes.shape
+    codes64 = (codes.to(torch.int64) + 128).reshape(n, k // 4, 4)
+    word = sum(codes64[:, :, i] << (8 * i) for i in range(4))
+    word = torch.where(word >= (1 << 31), word - (1 << 32), word)
+    return word.to(torch.int32)
+
+
+def _int8_projection(n: int, k: int, *, seed: int):
+    g = torch.Generator().manual_seed(seed)
+    codes = torch.randint(-127, 128, (n, k), generator=g, dtype=torch.int8)
+    num_groups = k // GROUP_SIZE
+    scale = (torch.rand(n, num_groups, generator=g) * 0.1 + 0.01).to(torch.float32)
+    weight_shape = torch.tensor([n, k], dtype=torch.int64)
+    return _pack_int8(codes), scale, weight_shape
+
+
+def _int8_expert_weights() -> dict:
+    """One full-attention layer's dense weights (unquantized) plus
+    compressed-tensors pack-quantized-INT8 routed experts (per-expert raw
+    layout, the real checkpoint's own shape) and a plain (unquantized)
+    shared expert."""
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+        "model.language_model.layers.0.self_attn.q_proj.weight": torch.randn(4 * 16 * 2, H),
+        "model.language_model.layers.0.self_attn.k_proj.weight": torch.randn(2 * 16, H),
+        "model.language_model.layers.0.self_attn.v_proj.weight": torch.randn(2 * 16, H),
+        "model.language_model.layers.0.self_attn.o_proj.weight": torch.randn(H, 4 * 16),
+        "model.language_model.layers.0.self_attn.q_norm.weight": torch.randn(16),
+        "model.language_model.layers.0.self_attn.k_norm.weight": torch.randn(16),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(E, H),
+        "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.up_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(H, I),
+        "model.language_model.layers.0.mlp.shared_expert_gate.weight": torch.randn(1, H),
+    }
+    for e in range(E):
+        base = f"model.language_model.layers.0.experts.{e}"  # no "mlp." -- real checkpoint's own spelling
+        for proj, n, k in (("gate_proj", I, H), ("up_proj", I, H), ("down_proj", H, I)):
+            weight_packed, weight_scale, weight_shape = _int8_projection(n, k, seed=100 * (e + 1) + hash(proj) % 7)
+            w[f"{base}.{proj}.weight_packed"] = weight_packed
+            w[f"{base}.{proj}.weight_scale"] = weight_scale
+            w[f"{base}.{proj}.weight_shape"] = weight_shape
+    return w
+
+
+@pytest.fixture(scope="module")
+def qwen35_int8_ckpt(tmp_path_factory):
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_int8")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": 16,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {
+            "quant_method": "compressed-tensors",
+            "config_groups": {
+                "group_0": {
+                    "format": "pack-quantized",
+                    "weights": {
+                        "num_bits": 8,
+                        "type": "int",
+                        "strategy": "group",
+                        "group_size": GROUP_SIZE,
+                        "symmetric": True,
+                        "actorder": "static",
+                    },
+                }
+            },
+        },
+    }
+    weights = _int8_expert_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+def test_load_model_builds_an_int8_channel_offload_cache(qwen35_int8_ckpt):
+    model, _ = load_model(qwen35_int8_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+
+    cache = model.moe_cache
+    assert cache.quant_format == "int8_channel"
+    assert cache.int8_k_gate_up == H
+    assert cache.int8_k_down == I
+    assert set(cache.bank_sources) == {
+        "weight_packed_gate_up", "weight_scale_gate_up", "weight_packed_down", "weight_scale_down",
+    }
+
+
+def test_int8_checkpoint_forward_step_produces_finite_logits(qwen35_int8_ckpt):
+    """The real point of this test (mirrors #138's own for GPTQ): a
+    compressed-tensors INT8-quantized checkpoint's forward pass runs
+    end-to-end -- SlotWeightAccessor dequantizes the resident packed
+    experts on the fly, reading from the cache
+    load_moe_expert_sources/_attach_offload_cache actually built."""
+    model, _ = load_model(qwen35_int8_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+    seq = torch.randint(0, V, (5,))
+    T = seq.shape[0]
+    logits, _ = _drive_prefill(model, seq, T)
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits).all()

--- a/tests/test_qwen35_mxfp4_e2e_loader.py
+++ b/tests/test_qwen35_mxfp4_e2e_loader.py
@@ -1,0 +1,138 @@
+"""End-to-end: load_model() wires an MXFP4-quantized checkpoint's experts
+into a real "mxfp4" OffloadMoeCache and runs a forward step (issue
+`moe-quant-banks-native-multi`, #163's own noted coverage gap: MXFP4 had
+only SlotWeightAccessor-level XPU coverage, not a full checkpoint-loader
+test the way GPTQ's #138 has).
+
+Mirrors test_qwen35_gptq_e2e_loader.py's / test_qwen35_fp8_e2e_loader.py's
+own approach -- a small (few-KB) fabricated MXFP4 checkpoint, not a real
+one, proving the load_moe_expert_sources -> _attach_offload_cache ->
+SlotWeightAccessor wiring is correct. Real MXFP4 checkpoints
+(openai/gpt-oss-20b) use a different model architecture (gpt_oss, not yet
+ported -- see issue #23) than this fixture's qwen3_5_moe shell; see
+test_qwen35_fp8_e2e_loader.py's own docstring for why that's fine (the
+dispatch is architecture-independent, keyed off quantization_config + key
+spelling).
+
+Unlike GPTQ/FP8's raw per-expert-indexed layout, a real MXFP4 checkpoint
+ships each (layer, projection, component) as ONE already-fused
+``[num_experts, ...]`` tensor (see stream_moe_expert_sources_mxfp4's own
+docstring) -- gate_proj/up_proj are already pre-fused into one
+``gate_up_proj`` tensor upstream too, so this fixture's weight-building
+looks structurally different from GPTQ's/FP8's per-expert loop.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kernel.triton.mxfp4_linear import quantize_mxfp4_blocks
+from freetoken.models.loader import load_model
+
+from tests.test_qwen35_gptq_e2e_loader import _drive_prefill
+
+H, I, E, V, L = 64, 32, 4, 64, 1
+NH, NKV, HD = 4, 2, 16
+Q_PROJ_DIM = NH * HD * 2
+O_PROJ_DIM = NH * HD
+KV_PROJ_DIM = NKV * HD
+
+
+def _mxfp4_expert_weights() -> dict:
+    """One full-attention layer's dense weights (unquantized -- attention is
+    excluded from MXFP4 quantization, matching the real gpt-oss convention)
+    plus MXFP4-packed routed experts (fused per-projection, not per-expert
+    -- see this module's own docstring) and a plain (unquantized) shared
+    expert."""
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+        "model.language_model.layers.0.self_attn.q_proj.weight": torch.randn(Q_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.k_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.v_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.o_proj.weight": torch.randn(H, O_PROJ_DIM),
+        "model.language_model.layers.0.self_attn.q_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.self_attn.k_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(E, H),
+        "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.up_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(H, I),
+        "model.language_model.layers.0.mlp.shared_expert_gate.weight": torch.randn(1, H),
+    }
+    base = "model.language_model.layers.0.mlp.experts"
+    gate_up_dense = torch.randn(E, 2 * I, H) * 0.3
+    down_dense = torch.randn(E, H, I) * 0.3
+    gu_blocks, gu_scales = quantize_mxfp4_blocks(gate_up_dense)
+    dn_blocks, dn_scales = quantize_mxfp4_blocks(down_dense)
+    w[f"{base}.gate_up_proj_blocks"] = gu_blocks
+    w[f"{base}.gate_up_proj_scales"] = gu_scales
+    w[f"{base}.down_proj_blocks"] = dn_blocks
+    w[f"{base}.down_proj_scales"] = dn_scales
+    return w
+
+
+@pytest.fixture(scope="module")
+def qwen35_mxfp4_ckpt(tmp_path_factory):
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_mxfp4")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NKV,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": HD,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {"quant_method": "mxfp4"},
+    }
+    weights = _mxfp4_expert_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+def test_load_model_builds_an_mxfp4_offload_cache(qwen35_mxfp4_ckpt):
+    model, _ = load_model(qwen35_mxfp4_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+
+    cache = model.moe_cache
+    assert cache.quant_format == "mxfp4"
+    assert set(cache.bank_sources) == {
+        "blocks_gate_up", "scales_gate_up", "blocks_down", "scales_down",
+    }
+
+
+def test_mxfp4_checkpoint_forward_step_produces_finite_logits(qwen35_mxfp4_ckpt):
+    """The real point of this test (mirrors #138's own for GPTQ): an
+    MXFP4-quantized checkpoint's forward pass runs end-to-end --
+    SlotWeightAccessor dequantizes the resident packed experts on the fly,
+    reading from the cache load_moe_expert_sources/_attach_offload_cache
+    actually built."""
+    model, _ = load_model(qwen35_mxfp4_ckpt, torch.device("cpu"), dtype=torch.float32, moe_backend="offload")
+    seq = torch.randint(0, V, (5,))
+    T = seq.shape[0]
+    logits, _ = _drive_prefill(model, seq, T)
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits).all()


### PR DESCRIPTION
## Summary

#163's PRs (#164/#165/#166) noted a real coverage gap: only GPTQ has an end-to-end checkpoint-loader test (issue #138 / `test_qwen35_gptq_e2e_loader.py`); block-FP8, MXFP4, and INT8 were only validated at the `SlotWeightAccessor` level. Building the missing e2e tests surfaced a **real bug** this gap had been hiding.

`qwen3_5_moe`'s `iter_weights` only special-cased GPTQ's own four component suffixes (`.qweight`/`.qzeros`/`.scales`/`.g_idx`) when classifying a bank-only-mode tensor as a routed expert or not. Every other quantized format's own components -- block-FP8's `weight_scale_inv`, MXFP4's fused `gate_up_proj_blocks`/`_scales` spelling, INT8's `weight_packed`/`weight_scale`/`weight_shape` -- fell through to exact-name matching against `_expert_source_names`' set, which only ever generates the plain `".weight"`-suffixed dense spelling. Result: a real FP8/MXFP4/INT8 checkpoint's scale/shape tensors were silently dropped before the format-specific streamer ever saw them, producing an opaque "Missing/incomplete MoE expert bank" error with no hint the real cause was several layers upstream in `iter_weights`' own filtering.

## Fix

Generalizes the bypass (`is_gptq_component` -> `is_quant_component`) to cover all four formats' own component suffixes, all classified via the same `".experts."` substring check GPTQ's already used -- and applies the same "never blanket dtype-cast a packed component" guard uniformly, since INT8's `weight_packed`/`weight_shape` (int32/int64) and MXFP4's `blocks`/`scales` (uint8) would suffer the same bit-corruption risk GPTQ's own components were already protected against.

`qwen3_moe` (the base, non-3.5 architecture)'s own `iter_weights` was already format-agnostic (a plain `".experts."` substring check, no GPTQ-specific special-casing at all) -- this bug was unique to `qwen3_5_moe`'s more complex remap/dequant-stream logic.

## New coverage

Adds the three missing e2e tests (`tests/test_qwen35_{fp8,mxfp4,int8}_e2e_loader.py`), mirroring `test_qwen35_gptq_e2e_loader.py`'s own small-fabricated-checkpoint approach exactly -- each confirms `load_model()` builds the right `OffloadMoeCache` quant_format/bank set and that a forward step produces finite logits.

## Test plan
- [x] New e2e tests: `test_load_model_builds_a_*_offload_cache` + `test_*_checkpoint_forward_step_produces_finite_logits` for fp8/mxfp4/int8 -- 6/6 passed
- [x] `test_qwen35_gptq_e2e_loader.py` (the pre-existing GPTQ e2e test, exercising the generalized bypass's GPTQ branch): 2/2 passed
- [x] `test_qwen35_gptq_native_fused_xpu.py`, `test_models_qwen35_loader.py`: 11/11 passed
- [x] `.venv` (torch-free): 205 passed, 71 skipped
- [x] `.venv-xpu -m "not xpu"`: 456 passed, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)
- [x] `SlotWeightAccessor`-level fp8/mxfp4/int8 native-fused XPU tests re-run clean: 7/7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5