### PR TITLE
fix(engine): concurrent multi-request decode corrupted KV via shared page_table rows (issue #173)

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -144,6 +144,14 @@ class Engine:
             num_pages = max(config.num_page_override, default_num_pages)
         else:
             num_pages = default_num_pages
+        # +1 page of slack: MHAKVCache (issue #173) reserves slot 0 as a
+        # dummy/padding slot, so the pool's real allocatable capacity is one
+        # page short of `num_pages * page_size` slots -- without this, the
+        # LAST request admitted up to max_running_req would fail to allocate
+        # its full max_seq_len-sized row (confirmed directly: a 2-running-req
+        # pool sized to exactly fit 2 full rows raised "KV pool full" on the
+        # second admission).
+        num_pages += 1
         self.page_size = config.page_size
         self.max_seq_len = max_seq_len
         self.max_running_req = config.max_running_req
@@ -155,14 +163,19 @@ class Engine:
             dtype=dtype or torch.bfloat16,
         )
 
-        # Page table: [max_running_req+1, max_seq_len] identity slot map
-        # (slot `pos` holds the token at position `pos`); +1 row so table_idx
-        # 0..max_running_req are all valid.
+        # Page table: [max_running_req+1, max_seq_len] slot map, +1 row so
+        # table_idx 0..max_running_req are all valid (the scheduler only ever
+        # hands out 0..max_running_req-1 -- see Scheduler._free_slots -- so
+        # row max_running_req is a padding row, never allocated). Rows start
+        # all-zero (pointing at MHAKVCache's reserved slot 0) and are filled
+        # with a REAL, disjoint slot run per request at admission time
+        # (add_request), not a shared identity map -- see issue
+        # `engine-kv-addressing` (#173): every row pointing at the SAME slot
+        # range let two concurrently-decoding requests silently corrupt each
+        # other's KV.
         self.page_table = torch.zeros(
             (self.max_running_req + 1, max_seq_len), dtype=torch.int64, device=device
         )
-        for r in range(self.page_table.shape[0]):
-            self.page_table[r, :max_seq_len] = torch.arange(max_seq_len, device=device)
         self.kv_cache.attach_page_table(self.page_table)
 
         # Attention backend (reference pure-torch GQA under "auto").
@@ -327,22 +340,42 @@ class Engine:
         preserved -- and the assigned row is stored back on ``req``. Raises
         :class:`RuntimeError` when the request cap is reached so a caller can
         reject the request cleanly.
+
+        Also allocates this row's own disjoint KV-pool slot run (issue
+        `engine-kv-addressing`, #173) -- a chunked prompt's later
+        continuations reuse this SAME table_idx/allocation for the rest of
+        the request's lifetime (see ``scheduler/prefill.py``'s own
+        continuation handling), so one allocation here covers the whole
+        request; :meth:`_free_slot` releases it when the request finishes.
         """
         pending = make_pending_req(req.uid, req.input_ids, req.sampling_params, req.cache_handle)
         uid = self.scheduler.add(pending)
         req.uid = uid
         req.table_idx = pending._table_idx  # noqa: SLF001
+        self._allocate_slot(req.table_idx)
         return req
+
+    def _allocate_slot(self, table_idx: int) -> None:
+        """Give page-table row ``table_idx`` its own disjoint KV-pool slot
+        run, real per-request isolation instead of the old shared identity
+        map (issue #173)."""
+        num_pages = -(-self.max_seq_len // self.page_size)  # ceil
+        slots = self.kv_cache.allocate(table_idx, num_pages=num_pages)
+        self.page_table[table_idx, : self.max_seq_len] = slots[: self.max_seq_len]
 
     def abort_request(self, uid: int) -> bool:
         """Free a request's page slot and drop it from the scheduler (any phase)."""
-        return self.scheduler.abort(uid)
+        before = set(self.scheduler._free_slots)  # noqa: SLF001
+        ok = self.scheduler.abort(uid)
+        if ok:
+            for table_idx in set(self.scheduler._free_slots) - before:  # noqa: SLF001
+                self._free_slot(table_idx)
+        return ok
 
     def _free_slot(self, table_idx: int) -> None:
-        # Restore the identity slot map for a freed row (no-op on the reference
-        # pool, which re-derives the slot from the position; kept for symmetry
-        # with a paged pool that may need to clear a row on release).
-        pass
+        # Return this row's KV-pool slot run so a later request admitted to
+        # the same table_idx can allocate a fresh one (issue #173).
+        self.kv_cache.free(table_idx)
 
     # -- the loop -------------------------------------------------------------
 
@@ -485,8 +518,16 @@ class Engine:
 
         # Record the step in the scheduler: promote finished prefills into the
         # decode set, refresh the decode set, and free the rows of requests that
-        # completed (hit max_tokens / eos).
+        # completed (hit max_tokens / eos). Diff the scheduler's own free-list
+        # before/after (rather than trusting `finished` above, which only
+        # reflects THIS step's stop-condition checks) so the KV-pool release
+        # exactly matches whichever table_idx rows the scheduler itself
+        # actually freed (issue #173) -- the single source of truth for row
+        # lifetime.
+        before = set(self.scheduler._free_slots)  # noqa: SLF001
         self.scheduler.complete(batch)
+        for table_idx in set(self.scheduler._free_slots) - before:  # noqa: SLF001
+            self._free_slot(table_idx)
         return ForwardOutput(next_token_ids=next_ids, finished=finished, reqs=list(batch.reqs))
 
     def generate(self, max_steps: int | None = None) -> List[List[int]]:
@@ -586,10 +627,17 @@ class Engine:
     def _rebuild_kv_pool(self, num_pages: int) -> None:
         """Rebuild the paged KV pool + page table + scheduler page budget.
 
-        Called by :meth:`rebuild_cache` after the split is re-planned. The page
-        table is re-identity-mapped for the new size and the scheduler's page
-        budget + max-pages are updated so it schedules against the new pool.
+        Called by :meth:`rebuild_cache` after the split is re-planned. This
+        replaces the pool with a brand-new, empty one (no in-flight request's
+        actual KV bytes survive a rebuild -- a pre-existing limitation of the
+        elastic-VRAM feature, not something this fixes); the fresh page table
+        starts all-zero (no rows allocated), matching a freshly-constructed
+        engine's own state. The scheduler's page budget + max-pages are
+        updated so it schedules against the new pool.
         """
+        # +1 page of slack for MHAKVCache's reserved slot 0 -- see the same
+        # comment at construction time (issue #173).
+        num_pages += 1
         self.kv_cache = create_kv_pool(
             self.config.model_config,
             page_size=self.page_size,
@@ -600,8 +648,6 @@ class Engine:
         self.page_table = torch.zeros(
             (self.max_running_req + 1, self.max_seq_len), dtype=torch.int64, device=self.device
         )
-        for r in range(self.page_table.shape[0]):
-            self.page_table[r, : self.max_seq_len] = torch.arange(self.max_seq_len, device=self.device)
         self.kv_cache.attach_page_table(self.page_table)
         self.ctx.kv_cache = self.kv_cache
         self.ctx.page_table = self.page_table

--- a/python/freetoken/kvcache/base.py
+++ b/python/freetoken/kvcache/base.py
@@ -214,10 +214,22 @@ class BaseKVCachePool:
 def create_kv_pool(model_config, page_size: int, num_pages: int, device, dtype) -> BaseKVCachePool:
     """Build the engine's KV pool from a parsed ModelConfig.
 
-    (The production pool family -- radix / hybrid-SWA -- is a separate issue;
-    the Intel engine loop uses this flat paged pool.)
+    Builds :class:`~freetoken.kvcache.mha_pool.MHAKVCache` (real per-request
+    free-list page allocation), not the plain :class:`BaseKVCachePool` --
+    issue `engine-kv-addressing` (#173) found that the flat pool's identity
+    ``page_table`` (every row mapped to the SAME slot range) makes two
+    requests decoding concurrently at overlapping relative positions read
+    and write the exact same ``k_buffer``/``v_buffer`` slots, silently
+    corrupting each other's attention context. ``MHAKVCache`` keeps the
+    exact same buffer layout the attention backends read; it only adds the
+    free-list allocator ``engine.py`` uses to give each request its own
+    disjoint slot run. (The radix / hybrid-SWA prefix-cache family is a
+    separate issue, #12/#32 -- this only fixes per-request isolation, not
+    cross-request page reuse.)
     """
-    return BaseKVCachePool(model_config, page_size, num_pages, device, dtype)
+    from .mha_pool import MHAKVCache
+
+    return MHAKVCache(model_config, page_size, num_pages, device, dtype)
 
 
 __all__ = ["BaseKVCachePool", "BaseCacheHandle", "create_kv_pool"]

--- a/python/freetoken/scheduler/scheduler.py
+++ b/python/freetoken/scheduler/scheduler.py
@@ -183,6 +183,20 @@ class Scheduler:
         # never freed; a decode request that just hit its stop condition was in
         # running_before and is dropped from running_after, so its row is freed.
         freed = [req.table_idx for req in running_before.keys() - running_after.keys()]
+        # A request that finishes ENTIRELY within its own prefill step (e.g.
+        # output_len small enough that the very first sampled token already
+        # satisfies max_device_len) never enters running_before at all --
+        # filter_reqs() above adds it to the decode set and immediately drops
+        # it again (can_decode is False) within this SAME call, so the
+        # before/after diff never observes it. Found via a real test (issue
+        # `engine-kv-addressing`, #173): a single-token-output request's
+        # table_idx was never returned to the free list, leaking it forever.
+        # Scan the batch directly for any aborted request the diff missed.
+        seen = set(freed)
+        for req in batch.reqs:
+            if req.aborted and req.table_idx not in seen:
+                freed.append(req.table_idx)
+                seen.add(req.table_idx)
         if freed:
             self._free_slots.extend(freed)
             self._free_slots.sort()

--- a/tests/test_engine_concurrent_kv_isolation.py
+++ b/tests/test_engine_concurrent_kv_isolation.py
@@ -1,0 +1,100 @@
+"""Two concurrently-decoding requests must not share KV pool slots (issue
+`engine-kv-addressing`, #173).
+
+Before this fix, the engine's page table mapped every request's row to the
+SAME slot range (``page_table[r, :] = torch.arange(max_seq_len)`` for every
+``r``), so two requests decoding at overlapping relative positions read and
+wrote the exact same ``k_buffer``/``v_buffer`` rows -- confirmed directly
+(not just read from code) before landing the fix: a fresh ``Engine`` with
+``max_running_req=2`` and two admitted requests had
+``engine.page_table[0, :5] == engine.page_table[1, :5]`` (identical
+tensors). ``create_kv_pool`` now builds ``MHAKVCache`` (real per-request
+free-list allocation) and the engine allocates each request its own
+disjoint slot run at admission (``Engine._allocate_slot``), freeing it on
+completion (``Engine._free_slot``).
+
+Reuses test_engine_loop.py's own tiny-checkpoint fixture (dummy-fabricated
+MoE experts, real dense weights) -- CPU-only, no XPU dependency.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.engine.engine import Engine
+
+from tests.test_engine_loop import DEVICE, _engine_config, _write_tiny_checkpoint
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _make_req(uid: int, ids: list[int], output_len: int) -> Req:
+    return Req(
+        input_ids=list(ids),
+        table_idx=0,
+        cached_len=0,
+        output_len=output_len,
+        uid=uid,
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+        cache_handle=None,
+    )
+
+
+def test_two_concurrent_requests_get_disjoint_page_table_rows(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+    engine.add_request(_make_req(0, [1, 2, 3], 3))
+    engine.add_request(_make_req(1, [4, 5, 6, 7], 3))
+
+    row0 = engine.page_table[0, :4]
+    row1 = engine.page_table[1, :4]
+    assert not torch.equal(row0, row1), "both requests' rows point at the same KV slots"
+    # No slot appears in both rows at all (not just "not identical" -- truly disjoint).
+    assert set(row0.tolist()).isdisjoint(set(row1.tolist()))
+
+
+def test_concurrent_decode_does_not_corrupt_a_request_own_kv(tmp_path):
+    """The real regression this issue guards against: request 0's own K/V
+    values, after decoding CONCURRENTLY alongside request 1, must be
+    bit-identical to what request 0 alone would have written -- request 0
+    is admitted first in both runs, so it deterministically gets the same
+    first slot range either way (a fresh free-list, FIFO allocation), which
+    is what makes this a valid apples-to-apples comparison."""
+    model_path = _write_tiny_checkpoint(tmp_path)
+
+    reset_global_ctx()
+    engine_alone = Engine(_engine_config(model_path, device=DEVICE))
+    engine_alone.add_request(_make_req(0, [1, 2, 3], 3))
+    engine_alone.step()  # one prefill step is enough to populate k_buffer
+    k_alone = engine_alone.kv_cache.k_buffer.clone()
+    slots_alone = engine_alone.page_table[0, :3].clone()
+
+    reset_global_ctx()
+    engine_concurrent = Engine(_engine_config(model_path, device=DEVICE))
+    engine_concurrent.add_request(_make_req(0, [1, 2, 3], 3))
+    engine_concurrent.add_request(_make_req(1, [4, 5, 6, 7], 3))
+    engine_concurrent.step()
+    k_concurrent = engine_concurrent.kv_cache.k_buffer.clone()
+    slots_concurrent = engine_concurrent.page_table[0, :3].clone()
+
+    assert torch.equal(slots_alone, slots_concurrent), "request 0's own slot allocation changed"
+    torch.testing.assert_close(k_alone[:, slots_alone.long()], k_concurrent[:, slots_concurrent.long()])
+
+
+def test_finished_request_frees_its_slot_for_reuse(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+    engine.add_request(_make_req(0, [1, 2, 3], 1))  # output_len=1 -> finishes after 1 decode step
+    engine.generate()
+
+    assert not engine.kv_cache.is_allocated(0), "a finished request's KV slots were never freed"
+
+    # A fresh request reusing table_idx 0 must be able to allocate again.
+    engine.add_request(_make_req(1, [4, 5], 1))
+    assert engine.kv_cache.is_allocated(0)

--- a/tests/test_kvcache_mha_pool.py
+++ b/tests/test_kvcache_mha_pool.py
@@ -129,11 +129,13 @@ def test_write_read_kv_roundtrip_through_page_table():
     assert torch.all(got_k2 == 0)
 
 
-def test_create_kv_pool_factory_still_returns_flat_pool():
-    # The hero factory is unchanged by this issue: it still builds the flat
-    # identity pool, NOT MHAKVCache -- so wiring MHAKVCache in must be explicit.
+def test_create_kv_pool_factory_returns_mha_pool():
+    # Issue `engine-kv-addressing` (#173): the flat identity pool's shared
+    # page_table (every row -> the SAME slot range) let two requests
+    # decoding concurrently at overlapping positions corrupt each other's
+    # KV. create_kv_pool -- the engine's own factory -- now builds
+    # MHAKVCache, which gives each request a real, disjoint slot run.
     pool = create_kv_pool(
         _ModelConfig(), page_size=2, num_pages=8, device=torch.device("cpu"), dtype=torch.float32
     )
-    assert isinstance(pool, MHAKVCache.__mro__[1])  # the flat BaseKVCachePool
-    assert not isinstance(pool, MHAKVCache)
+    assert isinstance(pool, MHAKVCache)


### PR DESCRIPTION
## Summary

Found while scoping #32/#12 (semantic-cache / kvcache): the live engine's KV pool wrote each token via `out_loc = pos` (the token's position within its OWN request, no per-request offset) and read via `page_table[table_idx, pos]` -- but `page_table` was initialized IDENTICALLY for every row (`page_table[r, :] = arange(max_seq_len)` for every `r`).

**Confirmed directly**, not just read from code: a live `Engine` with `max_running_req=2` and two admitted requests had `engine.page_table[0, :5] == engine.page_table[1, :5]` (literally the same tensor). Two requests decoding concurrently at overlapping relative positions read and wrote the exact same `k_buffer`/`v_buffer` slots. No existing test caught this -- every test that calls `add_request` in the whole suite adds exactly one request per `Engine` instance.

## Fix

`create_kv_pool` now builds `MHAKVCache` (`kvcache/mha_pool.py`, real free-list per-request page allocation -- already implemented and tested in isolation, just never wired into the live engine) instead of the flat identity-mapped `BaseKVCachePool`. `Engine.add_request` allocates each request's own disjoint slot run at admission; `Engine._free_slot` (previously dead code, a no-op) now actually releases it, wired at every point a request's row returns to the scheduler's free list -- diffed against the scheduler's own `_free_slots` before/after each call so the KV-pool release exactly matches whatever the scheduler itself freed.

Also required +1 page of pool capacity at both pool-construction sites: `MHAKVCache` reserves slot 0 as a dummy/padding slot, so the pool's real allocatable capacity is one page short of what the old identity-map sizing assumed (confirmed directly: a 2-running-req pool sized to exactly fit 2 full rows raised "KV pool full" on the second admission before this fix).

## A second bug this surfaced

Writing this fix's own regression test surfaced a second, related but distinct pre-existing bug: `Scheduler.complete()`'s row-freeing logic only detects a request *leaving* the decode set (a before/after diff), so a request that finishes ENTIRELY within its own prefill step (output_len small enough that the first sampled token already satisfies `max_device_len`) never enters the decode set at all -- its `table_idx` leaked forever. Confirmed directly (the free list never got it back). `Scheduler.complete()` now also scans the batch directly for any aborted request the diff missed.

## Verification

Not just structural: request 0's own K/V values, decoded CONCURRENTLY alongside a second request, are bit-identical to the same request decoded alone (`tests/test_engine_concurrent_kv_isolation.py`).

## Test plan
- [x] New `tests/test_engine_concurrent_kv_isolation.py`: 3/3 passed (disjoint page-table rows, bit-identical KV under concurrency, slot reuse after completion)
- [x] `test_kvcache_mha_pool.py` updated (one test asserted the old buggy behavior on purpose -- flipped to assert the fix)
- [x] `.venv` (torch-free): 205 passed, 73 skipped
- [x] `.venv-xpu -m "not xpu"`: 462 passed, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)
- [x] Real XPU hardware: `test_engine_whole_model_capture_xpu.py`, `test_moe_fused_xpu.py` (9-token multi-expert prefill), `test_engine_graph_xpu.py`, `test_qwen35_offload_xpu.py` -- all pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5