### PR TITLE
feat(kvcache): port HybridRadixCache, the KV+GDN-slot paired radix tree (issue #169)

### DIFF
--- a/python/freetoken/kvcache/hybrid_radix_cache.py
+++ b/python/freetoken/kvcache/hybrid_radix_cache.py
@@ -1,0 +1,327 @@
+"""Hybrid (full-attn KV + GDN linear-state) radix cache.
+
+Upstream NVIDIA path: python/freetoken/kvcache/hybrid_radix_cache.py
+Issue: `semantic-cache-hybrid-tree` (#169, part of the `semantic-cache`
+epic, #32).
+
+A SEPARATE class from ``RadixPrefixCache`` (Option C, matching upstream's
+own comment) that REUSES the shared ``RadixTreeNode`` and walk/split logic,
+so the production KV radix is untouched (zero risk to non-hybrid models).
+It adds a second "currency": an optional GDN state snapshot
+(``node.mamba_value`` = a linear-state-pool slot id) attached at
+page-aligned boundary nodes, with its own LRU eviction. Mirrors sglang
+``MambaRadixCache`` (donate-not-copy, dual eviction, internal-node
+tombstone, ``full_ref >= mamba_ref``) on FreeToken's tree.
+
+Deliberately narrower than upstream here: upstream's own constructor
+asserts its chunked GDN kernel's ``CHUNK_SIZE`` divides ``page_size``
+(snapshots land on chunk boundaries there). This port's own GDN layer
+(``models/qwen3_5_moe/__init__.py``'s ``_GatedDeltaNet``) runs the exact
+token-by-token recurrent update, not a chunked kernel (its own module
+docstring: "the chunked variant is a perf follow-up") -- there is no
+chunk-size concept to align against here, so a snapshot only needs to land
+on the SAME page boundary the KV radix already requires, no extra
+constraint. If/when a chunked GDN kernel lands, re-add the analogous
+assert against ITS real chunk size at that point, not a guessed one now.
+
+Currency seam: the secondary value + its eviction is the slot a future SWA
+component could plug into (explicitly out of scope for #32 right now --
+see that epic's own body for why). This class is pool-agnostic -- it
+stores/returns slot ids and KV page indices; the caller (the engine's
+CacheManager) does the actual LinearStatePool / KV-pool free.
+"""
+from __future__ import annotations
+
+import heapq
+import time
+from dataclasses import dataclass
+from typing import List, NamedTuple, Optional, Tuple
+
+import torch
+
+from freetoken.utils import align_down
+
+from .base import BaseCacheHandle
+from .radix_cache import RadixTreeNode, _get_key_fn
+
+
+@dataclass(frozen=True)
+class HybridCacheHandle(BaseCacheHandle):
+    """Lock handle for a matched hybrid prefix: the matched node (lock
+    target) + the reusable KV page indices. ``cached_len`` is already
+    truncated to the deepest live-snapshot boundary. Plugs into the same
+    admission surface as the plain ``RadixCacheHandle`` (reads
+    ``.cached_len`` / ``.get_matched_indices()``); the restore slot rides
+    on ``HybridMatch.mamba_value``."""
+
+    node: RadixTreeNode
+    kv_indices: torch.Tensor
+
+    def get_matched_indices(self) -> torch.Tensor:
+        return self.kv_indices
+
+
+class HybridMatch(NamedTuple):
+    kv_indices: torch.Tensor  # reused KV page indices for [0:cached_len)
+    cached_len: int  # truncated to the deepest LIVE-snapshot boundary
+    mamba_value: Optional[int]  # GDN snapshot slot to restore from (None = cold start)
+    node: RadixTreeNode  # the matched node (lock target)
+
+
+class EvictResult(NamedTuple):
+    kv_indices: torch.Tensor  # KV page indices to free
+    mamba_slots: List[int]  # GDN state slots to free
+
+
+class HybridRadixCache:
+    def __init__(self, device: torch.device, page_size: int) -> None:
+        self.device = device
+        self.page_size = page_size
+        self.key_fn = _get_key_fn(page_size)
+        self.empty = torch.empty(0, dtype=torch.int32, device=device)
+        self.root = RadixTreeNode(self.key_fn)
+        self.root.set_key_value(self.empty, self.empty)
+        self.root.ref_count = 1  # root is always protected
+        self.full_evictable = 0
+        self.full_protected = 0
+        self.mamba_evictable = 0  # number of live, unlocked snapshots
+        self.mamba_protected = 0
+
+    # ---------------------------------------------------------------- match / insert
+    def match_prefix(self, input_ids: torch.Tensor) -> HybridMatch:
+        """Match the token prefix, then truncate the reusable length to the
+        deepest node on the path that still owns a LIVE snapshot (a
+        continuation can only resume the GDN recurrence from a checkpointed
+        boundary)."""
+        node, _ = self._walk(input_ids)
+        # walk up to the deepest node whose END boundary has a live snapshot
+        cur, end_len = node, self._path_len(node)
+        while not cur.is_root():
+            if cur.mamba_value is not None:
+                return HybridMatch(self._collect_kv(cur), end_len, cur.mamba_value, cur)
+            end_len -= cur.length
+            cur = cur.parent
+        return HybridMatch(self.empty, 0, None, self.root)
+
+    def insert(
+        self, input_ids: torch.Tensor, kv_indices: torch.Tensor, mamba_value: int
+    ) -> Tuple[int, bool]:
+        """Insert the committed KV prefix and DONATE ``mamba_value`` at the
+        (page-aligned) end boundary node. Returns ``(matched_prefix_len,
+        mamba_exist)``. If the boundary node already owns a live snapshot,
+        returns ``mamba_exist=True`` and does not attach (caller frees the
+        donated slot -- dedup)."""
+        insert_len = align_down(len(input_ids), self.page_size)
+        input_ids, kv_indices = input_ids[:insert_len], kv_indices[:insert_len]
+        node, prefix_len = self._walk(input_ids)
+        if prefix_len != insert_len:
+            new_node = RadixTreeNode(self.key_fn)
+            new_node.set_key_value(input_ids[prefix_len:], kv_indices[prefix_len:].clone())
+            new_node.set_parent(node)
+            self.full_evictable += new_node.length
+            node = new_node
+        if node.is_root():
+            return prefix_len, True  # root can't hold a snapshot; report exist so caller frees it
+        if node.mamba_value is not None:
+            return prefix_len, True  # dedup: caller frees its donated slot
+        node.mamba_value = mamba_value  # fills a fresh node or a tombstone
+        if node.mamba_ref_count == 0:
+            self.mamba_evictable += 1
+        return prefix_len, False
+
+    # ---------------------------------------------------------------- locking (dual)
+    def inc_lock(self, node: RadixTreeNode) -> None:
+        """Protect a matched node's snapshot (mamba ref on the node) and its
+        KV path (full ref node..root). Enforces ``full_ref >= mamba_ref``:
+        using a snapshot at N pins the whole root..N KV chain."""
+        if node.mamba_value is not None:
+            if node.mamba_ref_count == 0:
+                self.mamba_evictable -= 1
+                self.mamba_protected += 1
+            node.mamba_ref_count += 1
+        cur = node
+        while not cur.is_root():
+            if cur.ref_count == 0:
+                self.full_evictable -= cur.length
+                self.full_protected += cur.length
+            cur.ref_count += 1
+            cur = cur.parent
+
+    def dec_lock(self, node: RadixTreeNode) -> None:
+        if node.mamba_value is not None and node.mamba_ref_count > 0:
+            node.mamba_ref_count -= 1
+            if node.mamba_ref_count == 0:
+                self.mamba_evictable += 1
+                self.mamba_protected -= 1
+        cur = node
+        while not cur.is_root():
+            cur.ref_count -= 1
+            assert cur.ref_count >= 0
+            if cur.ref_count == 0:
+                self.full_evictable += cur.length
+                self.full_protected -= cur.length
+            cur = cur.parent
+
+    # ---------------------------------------------------------------- eviction (dual)
+    def evict_full(self, num_tokens: int) -> EvictResult:
+        """Evict KV tokens by LRU over UNLOCKED LEAF nodes (an internal
+        node's KV is a prefix dependency for all descendants). Frees each
+        evicted node's snapshot too."""
+        leaves = [n for n in self._leaves() if n.ref_count == 0]
+        heapq.heapify(leaves)
+        kv, mamba, freed = [], [], 0
+        while freed < num_tokens and leaves:
+            node = heapq.heappop(leaves)
+            if node.ref_count != 0 or not node.is_leaf() or node.is_root():
+                continue
+            freed += node.length
+            kv.append(node.value)
+            self.full_evictable -= node.length
+            self._free_node_mamba(node, mamba)
+            parent, casc = self._cascade_tombstone_leaves(self._unlink(node), kv)
+            freed += casc
+            if parent.is_leaf() and parent.ref_count == 0 and not parent.is_root():
+                heapq.heappush(leaves, parent)
+        return EvictResult(_cat(kv, self.empty), mamba)
+
+    def evict_mamba(self, num: int) -> EvictResult:
+        """Evict GDN snapshots by LRU over UNLOCKED snapshot-bearing nodes
+        -- internal nodes too. Internal node -> TOMBSTONE (free the slot,
+        keep KV + children). Leaf node -> free both KV and slot and unlink,
+        then cascade-delete any KV-only tombstone leaves it exposes upward
+        (so a leaf always carries a live snapshot -- mirrors sglang)."""
+        cands = [n for n in self._snapshot_nodes() if n.mamba_ref_count == 0]
+        heapq.heapify(cands)
+        kv, mamba, freed = [], [], 0
+        while freed < num and cands:
+            node = heapq.heappop(cands)
+            if node.mamba_value is None or node.mamba_ref_count != 0 or node.is_root():
+                continue
+            if node.is_leaf() and node.ref_count == 0:
+                kv.append(node.value)
+                self.full_evictable -= node.length
+                self._free_node_mamba(node, mamba)
+                freed += 1
+                self._cascade_tombstone_leaves(self._unlink(node), kv)
+            else:
+                self._free_node_mamba(node, mamba)  # tombstone internal (or locked-KV) node
+                freed += 1
+        return EvictResult(_cat(kv, self.empty), mamba)
+
+    @property
+    def full_evictable_size(self) -> int:
+        return self.full_evictable
+
+    @property
+    def mamba_evictable_size(self) -> int:
+        return self.mamba_evictable
+
+    @property
+    def size_info(self):
+        """KV-page currency, for code that reads a ``BasePrefixCache``
+        ``size_info`` (metrics/usage). The GDN-snapshot currency is
+        reported via :attr:`mamba_evictable_size`."""
+        from .base import SizeInfo
+
+        return SizeInfo(evictable_size=self.full_evictable, protected_size=self.full_protected)
+
+    def check_integrity(self) -> None:
+        # Structural: every snapshot-bearing node holds a real slot id; ref
+        # counts non-negative. (KV/page conservation is checked by the
+        # caller's own pool-level integrity check, not here.)
+        for n in self._snapshot_nodes():
+            assert n.mamba_value is not None and n.mamba_ref_count >= 0 and n.ref_count >= 0
+
+    # ---------------------------------------------------------------- helpers
+    def _free_node_mamba(self, node: RadixTreeNode, out: List[int]) -> None:
+        if node.mamba_value is not None:
+            out.append(node.mamba_value)
+            node.mamba_value = None
+            if node.mamba_ref_count == 0:
+                self.mamba_evictable -= 1
+
+    def _unlink(self, node: RadixTreeNode) -> RadixTreeNode:
+        parent = node.parent
+        del parent.children[self.key_fn(node._key)]
+        return parent
+
+    def _cascade_tombstone_leaves(self, parent: RadixTreeNode, kv_out: List[torch.Tensor]):
+        """After a leaf is unlinked, eagerly reclaim the KV-only tombstone
+        leaves it exposes upward (``mamba_value`` None, no children,
+        unlocked): free their KV and unlink, walking up. Keeps the "a leaf
+        always carries a live snapshot" invariant (sglang
+        ``_iteratively_delete_tombstone_leaf``). Returns ``(highest
+        surviving ancestor, freed_tokens)``."""
+        freed = 0
+        while (
+            parent.mamba_value is None
+            and parent.is_leaf()
+            and parent.ref_count == 0
+            and not parent.is_root()
+        ):
+            kv_out.append(parent.value)
+            self.full_evictable -= parent.length
+            freed += parent.length
+            parent = self._unlink(parent)
+        return parent, freed
+
+    def _path_len(self, node: RadixTreeNode) -> int:
+        n, total = node, 0
+        while not n.is_root():
+            total += n.length
+            n = n.parent
+        return total
+
+    def _collect_kv(self, node: RadixTreeNode) -> torch.Tensor:
+        vals: List[torch.Tensor] = []
+        n = node
+        while not n.is_root():
+            vals.append(n.value)
+            n = n.parent
+        vals.reverse()
+        return _cat(vals, self.empty)
+
+    def _leaves(self) -> List[RadixTreeNode]:
+        out, stack = [], [self.root]
+        while stack:
+            n = stack.pop()
+            if n.is_leaf():
+                if not n.is_root():
+                    out.append(n)
+            else:
+                stack.extend(n.children.values())
+        return out
+
+    def _snapshot_nodes(self) -> List[RadixTreeNode]:
+        out, stack = [], [self.root]
+        while stack:
+            n = stack.pop()
+            if n.mamba_value is not None and not n.is_root():
+                out.append(n)
+            stack.extend(n.children.values())
+        return out
+
+    def _walk(self, input_ids: torch.Tensor) -> Tuple[RadixTreeNode, int]:
+        prefix_len, total = 0, len(input_ids)
+        node = self.root
+        tic = time.monotonic_ns()
+        while prefix_len < total:
+            child = node.children.get(self.key_fn(input_ids[prefix_len:]))
+            if child is None:
+                return node, prefix_len
+            node = child
+            match_len = align_down(node.get_match_len(input_ids[prefix_len:]), self.page_size)
+            prefix_len += match_len
+            if match_len != node.length:
+                node = node.split_at(match_len)
+                node.timestamp = tic
+                return node, prefix_len
+            node.timestamp = tic
+        return node, prefix_len
+
+
+def _cat(tensors: List[torch.Tensor], empty: torch.Tensor) -> torch.Tensor:
+    return torch.cat(tensors) if tensors else empty
+
+
+__all__ = ["HybridRadixCache", "HybridMatch", "EvictResult", "HybridCacheHandle"]

--- a/python/freetoken/kvcache/radix_cache.py
+++ b/python/freetoken/kvcache/radix_cache.py
@@ -49,6 +49,19 @@ class RadixTreeNode:
         RadixTreeNode.counter += 1
         self.timestamp = tic or time.monotonic_ns()
 
+        # Secondary "currency" for hybrid models (HybridRadixCache, issue
+        # `semantic-cache-hybrid-tree`, #169): an optional GDN (Gated Delta
+        # Net) recurrent-state snapshot slot attached at this node's END
+        # boundary, with its own ref count. None for the plain KV radix
+        # (this class is shared by both -- HybridRadixCache is a separate
+        # class built on top of the same node/walk/split logic, so the
+        # production KV-only radix stays completely unaffected). split_at
+        # leaves the new prefix node's mamba_value None ("a snapshot cannot
+        # be split") -- the snapshot stays on the original (suffix) node,
+        # whose end boundary is unchanged.
+        self.mamba_value: int | None = None
+        self.mamba_ref_count: int = 0
+
         # these fields should be updated later
         self._key: torch.Tensor
         self._value: torch.Tensor

--- a/tests/test_kvcache_hybrid_radix.py
+++ b/tests/test_kvcache_hybrid_radix.py
@@ -1,0 +1,180 @@
+"""HybridRadixCache: paired KV + GDN-snapshot radix tree (issue
+`semantic-cache-hybrid-tree`, #169, part of the `semantic-cache` epic,
+#32).
+
+CPU-safe (dual-venv contract), mirrors test_kvcache_radix.py's own style
+-- a SEPARATE tree class from RadixPrefixCache, sharing only RadixTreeNode/
+the walk/split logic, so these tests never touch the plain KV radix at all.
+``page_size`` is fixed (not read from global ctx) since HybridRadixCache
+takes it directly in its constructor.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.kvcache.hybrid_radix_cache import HybridRadixCache
+
+
+def _cache(page_size: int = 2) -> HybridRadixCache:
+    return HybridRadixCache(torch.device("cpu"), page_size=page_size)
+
+
+def _ids(*vals: int) -> torch.Tensor:
+    return torch.tensor(vals, dtype=torch.int32)
+
+
+def _slots(n: int, start: int = 1) -> torch.Tensor:
+    return torch.arange(start, start + n, dtype=torch.int32)
+
+
+# --- insert + re-match --------------------------------------------------
+
+
+def test_insert_donates_a_mamba_snapshot_at_the_end_boundary():
+    cache = _cache()
+    prefix_len, mamba_exist = cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    assert prefix_len == 0  # brand new -- nothing was already cached
+    assert mamba_exist is False  # donated slot 7 was actually attached
+
+    m = cache.match_prefix(_ids(10, 11, 12, 13))
+    assert m.cached_len == 4
+    assert m.mamba_value == 7
+    assert m.kv_indices.tolist() == [1, 2, 3, 4]
+
+
+def test_match_truncates_to_the_deepest_live_snapshot_boundary():
+    """A continuation can only resume the GDN recurrence from a
+    checkpointed boundary -- if the DEEPEST matched node has no live
+    snapshot (tombstoned by a prior eviction, or simply never got one),
+    match_prefix must walk back UP to the shallower node that still has
+    one, not report the full (unrestorable) depth as cached."""
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    # A longer prompt sharing the first 4 tokens as a prefix: node1 (len 4)
+    # becomes an INTERNAL node once this child (node2, len 2 more) is
+    # attached, with its OWN snapshot (9) at the full 6-token depth.
+    cache.insert(_ids(10, 11, 12, 13, 14, 15), _slots(6), mamba_value=9)
+
+    # Directly tombstone node2's snapshot (simulating it having been
+    # independently evicted, or never having been snapshotted at all --
+    # evict_mamba's own dedicated tests below cover the real eviction path
+    # itself; this test is isolating match_prefix's own truncation logic).
+    node2 = cache.match_prefix(_ids(10, 11, 12, 13, 14, 15)).node
+    assert node2.mamba_value == 9
+    node2.mamba_value = None
+    cache.mamba_evictable -= 1
+
+    m = cache.match_prefix(_ids(10, 11, 12, 13, 14, 15))
+    # The full 6-token KV span still matches, but node2 no longer has a
+    # live snapshot -- truncate to node1's boundary (cached_len=4,
+    # mamba_value=7), the deepest point actually resumable.
+    assert m.cached_len == 4
+    assert m.mamba_value == 7
+
+
+def test_insert_dedups_when_the_boundary_node_already_has_a_live_snapshot():
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    prefix_len, mamba_exist = cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=9)
+    assert mamba_exist is True  # caller must free its own donated slot 9
+
+    m = cache.match_prefix(_ids(10, 11, 12, 13))
+    assert m.mamba_value == 7  # the ORIGINAL snapshot wins, not the dup
+
+
+def test_insert_into_root_reports_exist_since_root_cannot_hold_a_snapshot():
+    cache = _cache()
+    prefix_len, mamba_exist = cache.insert(_ids(), _slots(0), mamba_value=1)
+    assert mamba_exist is True
+
+
+# --- dual locking ---------------------------------------------------------
+
+
+def test_inc_lock_protects_both_currencies():
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    m = cache.match_prefix(_ids(10, 11, 12, 13))
+    assert cache.full_evictable_size == 4
+    assert cache.mamba_evictable_size == 1
+
+    cache.inc_lock(m.node)
+    assert cache.full_evictable_size == 0
+    assert cache.mamba_evictable_size == 0
+
+    cache.dec_lock(m.node)
+    assert cache.full_evictable_size == 4
+    assert cache.mamba_evictable_size == 1
+
+
+def test_locked_snapshot_survives_eviction_pressure():
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    m = cache.match_prefix(_ids(10, 11, 12, 13))
+    cache.inc_lock(m.node)
+
+    # Nothing evictable while locked.
+    result = cache.evict_mamba(1)
+    assert result.mamba_slots == []
+    assert cache.mamba_evictable_size == 0
+
+
+# --- dual eviction ----------------------------------------------------------
+
+
+def test_evict_full_frees_kv_and_the_leaf_snapshot_together():
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    assert cache.full_evictable_size == 4
+    assert cache.mamba_evictable_size == 1
+
+    result = cache.evict_full(4)
+    assert set(result.kv_indices.tolist()) == {1, 2, 3, 4}
+    assert result.mamba_slots == [7]
+    assert cache.full_evictable_size == 0
+    assert cache.mamba_evictable_size == 0
+
+
+def test_evict_mamba_on_an_internal_node_tombstones_without_freeing_kv():
+    """Internal node -> TOMBSTONE (free the slot, keep KV + children):
+    evict_mamba alone must never delete a node that still has live
+    descendants relying on its KV as a prefix."""
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    # A second, longer prompt shares the first 4 tokens as a prefix and
+    # extends it -- the shared node becomes an INTERNAL node (has a child).
+    cache.insert(_ids(10, 11, 12, 13, 14, 15), _slots(6), mamba_value=9)
+
+    assert cache.mamba_evictable_size == 2  # both boundary nodes hold a snapshot
+    result = cache.evict_mamba(1)
+    assert result.mamba_slots == [7]  # the older (internal) node's snapshot
+    assert result.kv_indices.numel() == 0  # its KV was NOT freed (still a prefix dependency)
+    assert cache.mamba_evictable_size == 1
+
+    # The KV is still there: the longer prompt still matches in full.
+    m = cache.match_prefix(_ids(10, 11, 12, 13, 14, 15))
+    assert m.kv_indices.numel() == 6
+
+
+def test_evict_mamba_on_a_leaf_frees_kv_too_and_cascades():
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+
+    result = cache.evict_mamba(1)
+    assert result.mamba_slots == [7]
+    assert set(result.kv_indices.tolist()) == {1, 2, 3, 4}
+    assert cache.full_evictable_size == 0
+    assert cache.mamba_evictable_size == 0
+
+
+def test_check_integrity_passes_after_a_sequence_of_operations():
+    cache = _cache()
+    cache.insert(_ids(10, 11, 12, 13), _slots(4), mamba_value=7)
+    cache.insert(_ids(10, 11, 12, 13, 14, 15), _slots(6), mamba_value=9)
+    m = cache.match_prefix(_ids(10, 11, 12, 13, 14, 15))
+    cache.inc_lock(m.node)
+    cache.dec_lock(m.node)
+    cache.evict_mamba(1)
+    cache.check_integrity()  # must not raise


### PR DESCRIPTION
## Summary

First of #32's (semantic-cache epic) four child issues: the foundational data structure the GDN tool-call-anchor snapshot/restore mechanism sits on top of.

Ported from the real upstream source (`python/freetoken/kvcache/hybrid_radix_cache.py`, read directly, not guessed): a SEPARATE class from `RadixPrefixCache` (Option C, matching upstream's own design comment) that reuses the shared `RadixTreeNode`/walk/split logic, so the production KV-only radix (#12) is completely untouched by this. Adds a second "currency": an optional GDN recurrent-state snapshot slot attached at page-aligned boundary nodes, with its own LRU eviction independent of KV eviction, mirroring sglang's `MambaRadixCache` (donate-not-copy, dual eviction, internal-node tombstone vs leaf-node full-delete, `full_ref >= mamba_ref` invariant).

## One deliberate, documented deviation from upstream

Upstream's own constructor asserts its chunked GDN kernel's `CHUNK_SIZE` divides `page_size` (snapshots land on chunk boundaries there). This port's own GDN layer (`qwen3_5_moe`'s `_GatedDeltaNet`) runs the exact token-by-token recurrent update, not a chunked kernel (its own docstring: "the chunked variant is a perf follow-up") -- there is no chunk-size concept to align against yet, so this port's snapshots only need the same page alignment the KV radix already requires. Left a note to re-add the real assert once a chunked GDN kernel actually lands, rather than guess at a constraint that doesn't apply yet.

## Change to the shared node class

`RadixTreeNode` (`kvcache/radix_cache.py`) gains `mamba_value`/`mamba_ref_count` fields -- both default off (`None`/`0`), so the plain KV-only `RadixPrefixCache` is unaffected.

## Test plan
- [x] New `tests/test_kvcache_hybrid_radix.py`: 10/10 passed (insert/match, snapshot dedup, dual locking, dual eviction -- internal-node tombstone vs leaf full-delete, integrity check)
- [x] `test_kvcache_radix.py` (the plain KV-only radix, exercising the shared `RadixTreeNode` this PR extends): passes unchanged
- [x] `.venv` (torch-free): 205 passed, 75 skipped
- [x] `.venv-xpu -m "not xpu"`: 477 passed, only the known pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5