### PR TITLE
feat(scheduler): tool-call anchor detection + GDN snapshot method (issue #171)

### DIFF
--- a/python/freetoken/core.py
+++ b/python/freetoken/core.py
@@ -32,7 +32,23 @@ class Req:
     mm_embeds: object | None = None
     linear_slot_idx: int | None = None
     aborted: bool = False
+    # Set once, at the first sampled tool-call opener token (issue
+    # `semantic-cache-scheduler`, #171 -- engine.py's own decode-loop
+    # detection): the state length just after that token (its index + 1).
+    # A client-side rewrite of the echoed tool call diverges strictly after
+    # this point, so it is the deepest reuse boundary that survives such a
+    # rewrite. GDN: the state is frozen into a ping-pong slot when
+    # device_len reaches it, and donated (committed into the hybrid tree)
+    # at finish.
     toolcall_anchor_len: int | None = None
+    # Hybrid-radix (GDN linear-state) ping-pong snapshot bookkeeping, all
+    # None/0 until a hybrid-GDN model with prefix caching actually assigns
+    # them (issue #172's own scope) -- these are pure bookkeeping fields, no
+    # behavior depends on them yet:
+    mamba_ping_pong: tuple[int, int] | None = None  # 2 donatable track slots under overlap
+    mamba_next_track_idx: int = 0  # which ping-pong slot is the next snapshot dst (0/1)
+    mamba_last_track_seqlen: int | None = None  # chunk-aligned committed len of the last snapshot
+    mamba_restore_src: int | None = None  # on a prefix hit: tree snapshot slot to COW into the live slot
 
     def __post_init__(self) -> None:
         self.device_len = len(self.input_ids) if hasattr(self.input_ids, "__len__") else 0

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -200,6 +200,26 @@ class Engine:
         # at all" by the time step() needs it at completion.
         self._admitted_cached_len: dict[int, int] = {}
 
+        # Tool-call anchor id (issue `semantic-cache-scheduler`, #171): the
+        # single token id of this model's tool-call-opener grammar marker,
+        # or None (default -- feature off). Engine itself never touches
+        # tokenizers/tool-call parsers (that's the server layer's job, see
+        # server/args.py + server/function_call_parser.py); this is set
+        # post-construction by the server path (server/launch.py's
+        # _build_engine_holder), mirroring the existing
+        # ``engine.frontend_tokenizer = ...`` attach pattern there. When
+        # set, step()'s decode loop watches for it and records
+        # req.toolcall_anchor_len the first time it appears -- the deepest
+        # reuse boundary that survives a client-side rewrite of the echoed
+        # tool call. Actually FREEZING the GDN state at that boundary
+        # (CacheManager.snapshot_toolcall_anchor) needs the model wired to
+        # a real ping-pong-capable LinearStatePool, which qwen3_5_moe does
+        # not do yet (it still uses its own, older, non-ping-pong
+        # _LinearStatePool) -- that wiring is issue #172's own scope, so for
+        # now, only ever gets read by tests and by whatever future PR does
+        # that wiring, not by a live snapshot call yet.
+        self.toolcall_anchor_id: int | None = None
+
         # Attention backend (reference pure-torch GQA under "auto").
         self.attn_backend = create_attention_backend(config.attention_backend, config)
 
@@ -608,6 +628,22 @@ class Engine:
                     self._full_ids[req.table_idx].append(tok)
                 else:
                     self._full_ids[req.table_idx] = list(req.input_ids)
+            # Tool-call anchor detection (issue #171): the FIRST time this
+            # request samples the tool-call-opener token, record the state
+            # length just after it (req.device_len, already bumped above --
+            # matches Req.toolcall_anchor_len's own field docstring: "its
+            # index + 1"). Once only (the `is None` guard): a real tool
+            # call is opened once per turn, and re-arming on a later
+            # occurrence (e.g. inside the arguments JSON, or a second call
+            # in the same turn) would move the anchor to a shallower-reuse
+            # -- but still theoretically valid -- point that isn't what a
+            # client-side rewrite of the FIRST call actually needs.
+            if (
+                self.toolcall_anchor_id is not None
+                and tok == self.toolcall_anchor_id
+                and req.toolcall_anchor_len is None
+            ):
+                req.toolcall_anchor_len = req.device_len
             # The FINAL chunk of a chunked prefill -- the one that just
             # completed the prompt -- is a plain Req (promoted out of the
             # ChunkedReq chain) whose cached_len is > 0 (it resumed from a

--- a/python/freetoken/scheduler/cache.py
+++ b/python/freetoken/scheduler/cache.py
@@ -19,7 +19,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import torch
 
+    from freetoken.core import Req
     from freetoken.kvcache.base import BaseCacheHandle, InsertResult, MatchResult
+    from freetoken.kvcache.linear_state_pool import LinearStatePool
 
 
 class CacheManager:
@@ -75,3 +77,38 @@ class CacheManager:
     @property
     def evictable_size(self) -> int:
         return self.prefix_cache.size_info.evictable_size
+
+    def snapshot_toolcall_anchor(self, reqs: "list[Req]", pool: "LinearStatePool") -> None:
+        """Freeze the live GDN state of any request that has just reached
+        its tool-call anchor into an idle ping-pong track slot (issue
+        `semantic-cache-scheduler`, #171).
+
+        Ported from the real upstream ``CacheManager.snapshot_toolcall_anchor``
+        (read directly, not guessed), with one deliberate simplification:
+        upstream's own guard also required ``req.cached_len == anchor_len``
+        to land the copy at the right point in its overlapped/async CUDA
+        stream schedule. This engine is fully synchronous (no stream
+        overlap to order against) -- by the time this is called (after the
+        step's forward pass has already written this step's state), the
+        pool already holds the anchor-token state, so that guard is
+        replaced by the plain ``is None`` bookkeeping checks below, which
+        are the only ones still needed to make the snapshot idempotent
+        (once per request) and only for requests actually opted into
+        ping-pong tracking (``mamba_ping_pong`` set -- issue #172's own
+        scope, not yet done by anything in the live engine today).
+        """
+        from freetoken.utils import align_down
+
+        for req in reqs:
+            anchor = req.toolcall_anchor_len
+            if (
+                anchor is None
+                or req.mamba_ping_pong is None
+                or req.mamba_last_track_seqlen is not None
+                or align_down(anchor, self.prefix_cache.page_size) != anchor
+            ):
+                continue
+            dst = req.mamba_ping_pong[req.mamba_next_track_idx]
+            pool.copy_from(req.linear_slot_idx, dst)
+            req.mamba_last_track_seqlen = anchor
+            req.mamba_next_track_idx = 1 - req.mamba_next_track_idx

--- a/python/freetoken/server/function_call_parser.py
+++ b/python/freetoken/server/function_call_parser.py
@@ -71,6 +71,16 @@ class FunctionCallParser:
     def parse(self, text_chunks: Iterable[str]) -> Iterator[dict]:
         raise NotImplementedError(f"{type(self).__name__}.parse")
 
+    @property
+    def toolcall_opener(self) -> str | None:
+        """This grammar's own unique tool-call-opening marker string, or
+        ``None`` if it has none (issue `semantic-cache-scheduler`, #171):
+        ``freetoken.utils.hf.load_toolcall_anchor_id`` tokenizes this to
+        find the single-token id the engine watches for during decode to
+        set a request's ``toolcall_anchor_len``. The base (passthrough)
+        parser has no grammar at all, so no opener."""
+        return None
+
 
 def _parse_json_object(blob: str) -> dict:
     try:
@@ -102,6 +112,10 @@ class GenericTagParser(FunctionCallParser):
     name: str = "generic"
     open_marker: str = _TAG_OPEN
     close_marker: str = _TAG_CLOSE
+
+    @property
+    def toolcall_opener(self) -> str | None:
+        return self.open_marker
 
     def parse(self, text_chunks: Iterable[str]) -> Iterator[dict]:
         buffer = ""

--- a/python/freetoken/server/launch.py
+++ b/python/freetoken/server/launch.py
@@ -347,6 +347,22 @@ def _build_engine_holder(server_args):
         # encode / decode path resolves it directly. Loading the tokenizer is
         # torch-free (AutoTokenizer) and happens once, here, at first request.
         engine.frontend_tokenizer = _frontend_tokenizer(server_args)
+        # Tool-call anchor id (issue `semantic-cache-scheduler`, #171): the
+        # single token id of this model's resolved tool-call-opener grammar
+        # marker, so the engine's decode loop can watch for it and set
+        # req.toolcall_anchor_len the first time a request samples it.
+        # server_args.tool_call_parser is already resolved away from "auto"
+        # by parse_args (see _infer_tool_call_parser) by the time this
+        # closure runs. None (no opener, or an unspellable/multi-token one)
+        # is a legitimate, silent no-op -- the anchor feature simply never
+        # arms for that model/grammar.
+        from freetoken.server.function_call_parser import get_parser
+        from freetoken.utils.hf import load_toolcall_anchor_id
+
+        tool_parser = get_parser(server_args.tool_call_parser)
+        engine.toolcall_anchor_id = load_toolcall_anchor_id(
+            engine.frontend_tokenizer.tokenizer, tool_parser.toolcall_opener
+        )
         engine_ref["engine"] = engine
         return engine
 

--- a/tests/test_toolcall_anchor.py
+++ b/tests/test_toolcall_anchor.py
@@ -1,0 +1,261 @@
+"""Tool-call anchor detection + GDN ping-pong snapshot (issue
+`semantic-cache-scheduler`, #171, part of the `semantic-cache` epic, #32).
+
+Three independent pieces, each tested in isolation:
+  1. ``toolcall_opener`` on the tool-call parser classes.
+  2. Live anchor DETECTION in ``Engine.step()`` -- ``req.toolcall_anchor_len``
+     is set exactly once, at the right decode position, when the engine
+     watches for a configured ``toolcall_anchor_id``.
+  3. ``CacheManager.snapshot_toolcall_anchor`` -- freezing a request's live
+     GDN state into an idle ping-pong track slot, standalone (a synthetic
+     ``LinearStatePool`` + ``Req``s, no real model).
+
+Actually wiring a hybrid-GDN model's forward to read/write through
+``LinearStatePool`` (so ``mamba_ping_pong``/``linear_slot_idx`` are ever set
+by live serving) is issue #172's own scope -- (3) below exercises the method
+directly against hand-built ``Req`` state, matching how #169/#170 tested
+their own new structures before any model wiring existed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.kvcache.linear_state_pool import LinearStatePool
+from freetoken.scheduler.cache import CacheManager
+from freetoken.server.function_call_parser import (
+    FunctionCallParser,
+    GenericTagParser,
+    Llama3ToolParser,
+    MistralToolParser,
+    QwenToolParser,
+    TOOL_CALL_PARSERS,
+)
+
+from tests.test_engine_loop import DEVICE, _engine_config, _write_tiny_checkpoint
+
+
+# --- (1) toolcall_opener -----------------------------------------------------
+
+
+def test_base_parser_has_no_opener():
+    assert FunctionCallParser().toolcall_opener is None
+
+
+def test_generic_tag_parser_opener_is_its_own_open_marker():
+    parser = GenericTagParser(open_marker="<foo>", close_marker="</foo>")
+    assert parser.toolcall_opener == "<foo>"
+
+
+def test_qwen_and_llama3_and_mistral_openers_match_their_registered_markers():
+    assert QwenToolParser().toolcall_opener == QwenToolParser().open_marker
+    assert Llama3ToolParser().toolcall_opener == Llama3ToolParser().open_marker
+    assert MistralToolParser().toolcall_opener == MistralToolParser().open_marker
+
+
+def test_gpt_oss_parser_has_no_opener():
+    # Harmony tool channels aren't a simple tag -- the base's None stands.
+    assert TOOL_CALL_PARSERS["gpt_oss"].toolcall_opener is None
+
+
+# --- (2) live anchor detection -----------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _add_prompt(engine: Engine, output_len: int) -> Req:
+    req = Req(
+        input_ids=[1, 2, 3],
+        table_idx=0,
+        cached_len=0,
+        output_len=output_len,
+        uid=0,
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+        cache_handle=None,
+    )
+    engine.add_request(req)
+    return req
+
+
+def _drive(engine: Engine, uid: int):
+    """Run ``engine.step()`` to completion (mirrors ``Engine.generate``'s own
+    loop), returning ``(generated_tokens, last_seen_req)``.
+
+    ``Engine.add_request`` hands the raw ``Req`` to the scheduler, which
+    wraps it in its own ``PendingReq``/``Req`` bookkeeping -- the object
+    mutated step-by-step (``req.toolcall_anchor_len`` included) is NOT the
+    caller's original object, so tests that need to observe it must read it
+    back off ``ForwardOutput.reqs`` (exactly what ``generate()`` itself
+    does to accumulate tokens), not off the object passed to
+    ``add_request``.
+    """
+    from freetoken.engine.engine import ChunkedReq
+
+    generated: list[int] = []
+    last_req = None
+    for _ in range(64):
+        out = engine.step()
+        if out.next_token_ids is None or len(out.next_token_ids) == 0:
+            break
+        for i, req in enumerate(out.reqs):
+            if isinstance(req, ChunkedReq) or req.uid != uid:
+                continue
+            generated.append(int(out.next_token_ids[i]))
+            last_req = req
+    return generated, last_req
+
+
+def test_anchor_id_none_by_default_is_a_silent_no_op(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+    assert engine.toolcall_anchor_id is None
+    _add_prompt(engine, output_len=3)
+    _, last_req = _drive(engine, uid=0)
+    assert last_req.toolcall_anchor_len is None
+
+
+def test_anchor_len_is_set_once_at_the_first_occurrence(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+
+    # First pass: learn the (deterministic, greedy) generated sequence for
+    # this dummy checkpoint -- see test_engine_greedy_is_deterministic for
+    # why two builds of the same checkpoint are bit-identical.
+    probe = Engine(_engine_config(model_path, device=DEVICE))
+    _add_prompt(probe, output_len=4)
+    generated, _ = _drive(probe, uid=0)
+    reset_global_ctx()
+
+    anchor_id = generated[0]
+    prompt_len = 3  # see _add_prompt's fixed prompt
+    first_occurrence = generated.index(anchor_id)
+    expected_anchor_len = prompt_len + first_occurrence + 1
+
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+    engine.toolcall_anchor_id = anchor_id
+    _add_prompt(engine, output_len=4)
+    out, last_req = _drive(engine, uid=0)
+
+    assert out == generated  # same deterministic weights + prompt -> same tokens
+    assert last_req.toolcall_anchor_len == expected_anchor_len
+
+    # Once-only: a later occurrence of the same id (if any) must not move it.
+    if generated.count(anchor_id) > 1:
+        second_occurrence = generated.index(anchor_id, first_occurrence + 1)
+        assert expected_anchor_len != prompt_len + second_occurrence + 1
+
+
+# --- (3) CacheManager.snapshot_toolcall_anchor -------------------------------
+
+
+def _pool(num_slots: int = 8) -> LinearStatePool:
+    return LinearStatePool(
+        num_layers=2,
+        num_key_heads=4,
+        num_value_heads=4,
+        key_head_dim=8,
+        value_head_dim=8,
+        conv_kernel_dim=4,
+        num_slots=num_slots,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+
+
+def _cache_manager(page_size: int = 1) -> CacheManager:
+    return CacheManager(torch.device("cpu"), page_size)
+
+
+def _req_with_state(uid: int, *, anchor_len, ping_pong, last_track_seqlen=None) -> Req:
+    return Req(
+        input_ids=[0],
+        table_idx=0,
+        cached_len=0,
+        output_len=1,
+        uid=uid,
+        sampling_params=SamplingParams(),
+        cache_handle=None,
+        linear_slot_idx=None,
+        toolcall_anchor_len=anchor_len,
+        mamba_ping_pong=ping_pong,
+        mamba_last_track_seqlen=last_track_seqlen,
+    )
+
+
+def test_snapshot_copies_live_slot_into_the_next_ping_pong_track_slot():
+    pool = _pool()
+    live, track0, track1 = pool.alloc(3)
+    pool.conv_state(0, live)[:] = 5.0
+    pool.recurrent_state(0, live)[:] = 7.0
+
+    req = _req_with_state(0, anchor_len=4, ping_pong=(track0, track1))
+    req.linear_slot_idx = live
+
+    mgr = _cache_manager(page_size=1)
+    mgr.snapshot_toolcall_anchor([req], pool)
+
+    torch.testing.assert_close(pool.conv_state(0, track0), pool.conv_state(0, live))
+    torch.testing.assert_close(pool.recurrent_state(0, track0), pool.recurrent_state(0, live))
+    assert req.mamba_last_track_seqlen == 4
+    assert req.mamba_next_track_idx == 1  # flipped, ready for the next snapshot
+
+
+def test_snapshot_is_a_real_copy_surviving_later_overwrites_of_the_live_slot():
+    pool = _pool()
+    live, track0, track1 = pool.alloc(3)
+    pool.conv_state(0, live)[:] = 1.0
+
+    req = _req_with_state(0, anchor_len=2, ping_pong=(track0, track1))
+    req.linear_slot_idx = live
+    _cache_manager(page_size=1).snapshot_toolcall_anchor([req], pool)
+
+    pool.conv_state(0, live)[:] = 99.0
+    assert pool.conv_state(0, track0).max().item() == 1.0
+
+
+def test_snapshot_skips_a_request_with_no_anchor_yet():
+    pool = _pool()
+    live, track0, track1 = pool.alloc(3)
+    req = _req_with_state(0, anchor_len=None, ping_pong=(track0, track1))
+    req.linear_slot_idx = live
+    _cache_manager(page_size=1).snapshot_toolcall_anchor([req], pool)
+    assert req.mamba_last_track_seqlen is None
+
+
+def test_snapshot_skips_a_request_not_opted_into_ping_pong_tracking():
+    pool = _pool()
+    live = pool.alloc(1)[0]
+    req = _req_with_state(0, anchor_len=4, ping_pong=None)
+    req.linear_slot_idx = live
+    _cache_manager(page_size=1).snapshot_toolcall_anchor([req], pool)
+    assert req.mamba_last_track_seqlen is None
+
+
+def test_snapshot_is_idempotent_once_already_tracked():
+    pool = _pool()
+    live, track0, track1 = pool.alloc(3)
+    req = _req_with_state(0, anchor_len=4, ping_pong=(track0, track1), last_track_seqlen=4)
+    req.linear_slot_idx = live
+    mgr = _cache_manager(page_size=1)
+    mgr.snapshot_toolcall_anchor([req], pool)
+    # No flip happened -- the guard skipped this request outright.
+    assert req.mamba_next_track_idx == 0
+
+
+def test_snapshot_skips_an_anchor_not_page_aligned():
+    pool = _pool()
+    live, track0, track1 = pool.alloc(3)
+    req = _req_with_state(0, anchor_len=5, ping_pong=(track0, track1))
+    req.linear_slot_idx = live
+    _cache_manager(page_size=4).snapshot_toolcall_anchor([req], pool)  # 5 % 4 != 0
+    assert req.mamba_last_track_seqlen is None


### PR DESCRIPTION
## Summary
Part of the `semantic-cache` epic (#32), following #169 (`HybridRadixCache`) and #170 (`LinearStatePool`). Delivers the scheduler/engine-side pieces of the tool-call anchor mechanism as real, tested code:

- `FunctionCallParser.toolcall_opener` / `GenericTagParser` override — exposes each grammar's own tool-call-opening marker string (Qwen/Llama3/Mistral inherit it via `GenericTagParser`; the base and gpt-oss stay `None`).
- `Req` gains the four `mamba_*` ping-pong/track bookkeeping fields upstream's real design uses, plus a fuller docstring on the existing `toolcall_anchor_len` field.
- `Engine.toolcall_anchor_id` — set post-construction by the server layer (`server/launch.py`'s `_build_engine_holder`, mirroring the existing `engine.frontend_tokenizer` attach pattern), resolved via `load_toolcall_anchor_id(tokenizer, parser.toolcall_opener)` (an already-existing, previously-unused utility).
- `Engine.step()` now detects, once per request, the first time it samples the anchor token, and records `req.toolcall_anchor_len` at that point.
- `CacheManager.snapshot_toolcall_anchor(reqs, pool)` — freezes a request's live GDN state into an idle ping-pong track slot via `LinearStatePool.copy_from`, ported from the real upstream method with one documented simplification: this engine is fully synchronous, so upstream's stream-ordering `cached_len` guard (needed to land the copy at the right point in an overlapped CUDA stream schedule) isn't needed here.

**Deliberately deferred to #172** (the e2e-proof issue): wiring a real hybrid-GDN model's forward (`qwen3_5_moe`'s `_GatedDeltaNet`) to actually read/write through `LinearStatePool` and set `mamba_ping_pong`/`linear_slot_idx` on live requests. Nothing in live serving calls `snapshot_toolcall_anchor` yet — it's a real, standalone-tested method waiting for that wiring, exactly the pattern #169/#170 used for their own new structures.

## Test plan
- [x] `tests/test_toolcall_anchor.py` (12 new tests): `toolcall_opener` across parser classes; live anchor-detection timing against a fresh tiny dummy-weight checkpoint (greedy/deterministic — verifies the anchor lands at the exact expected `device_len` and only once); `snapshot_toolcall_anchor`'s guards (no anchor yet, not opted into ping-pong, already tracked, page-misaligned) plus its real copy-on-write semantics.
- [x] `.venv` (torch-free) full suite: 205 passed, 77 skipped, 0 failed.
- [x] `.venv-xpu -m "not xpu"` full suite: 504 passed, 1 skipped, 1 pre-existing unrelated failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`, reproduces identically on a clean `main` checkout — an environment leak, not caused by this PR).

Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5