### PR TITLE
feat(engine): wire GDN ping-pong restore end-to-end (issue #172)

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -211,14 +211,37 @@ class Engine:
         # set, step()'s decode loop watches for it and records
         # req.toolcall_anchor_len the first time it appears -- the deepest
         # reuse boundary that survives a client-side rewrite of the echoed
-        # tool call. Actually FREEZING the GDN state at that boundary
-        # (CacheManager.snapshot_toolcall_anchor) needs the model wired to
-        # a real ping-pong-capable LinearStatePool, which qwen3_5_moe does
-        # not do yet (it still uses its own, older, non-ping-pong
-        # _LinearStatePool) -- that wiring is issue #172's own scope, so for
-        # now, only ever gets read by tests and by whatever future PR does
-        # that wiring, not by a live snapshot call yet.
+        # tool call.
         self.toolcall_anchor_id: int | None = None
+
+        # GDN (Gated-Delta-Net) ping-pong state pool (issue
+        # `semantic-cache-e2e`, #172): only built for a HYBRID model
+        # (qwen3_5_moe-style, mixed linear/full-attention layers) running
+        # with prefix caching on -- a plain (non-hybrid) model never has
+        # anything to build here, and prefix caching off means no request's
+        # KV ever gets reused, so the parallel GDN-state reuse this pool
+        # exists for has nothing to attach to either. When built, this
+        # REPLACES the model's own default per-request-1:1 pool
+        # (self.model.linear_state_pool) as ctx.linear_state_pool -- see
+        # qwen3_5_moe.Qwen3_5MoEForCausalLM.forward's own comment on why it
+        # leaves an already-set ctx.linear_state_pool alone.
+        self.linear_state_pool = None
+        if self.cache_manager is not None:
+            self.linear_state_pool = self._build_hybrid_linear_pool(self.model, config, device, dtype)
+        # tuple(prompt token ids up to a committed anchor) -> the ping-pong
+        # track slot holding that anchor's frozen GDN state. A later
+        # request whose prompt shares that exact prefix (add_request looks
+        # this up after its own KV-prefix match) restores from it instead
+        # of recomputing (Req.mamba_restore_src). Deliberate scope cut vs
+        # a full HybridRadixCache-donation integration (the tree-based
+        # ownership/eviction #169 already built for the KV+mamba-node
+        # case): this dict is a flat, never-evicted lookaside -- proving
+        # the restore MECHANISM end-to-end (this issue's own accept bar)
+        # doesn't need the tree's eviction/ownership machinery, and wiring
+        # HybridRadixCache into CacheManager in place of the plain
+        # RadixPrefixCache it wraps today is real, separable follow-up
+        # work of its own.
+        self._mamba_anchor_snapshots: dict[tuple[int, ...], int] = {}
 
         # Attention backend (reference pure-torch GQA under "auto").
         self.attn_backend = create_attention_backend(config.attention_backend, config)
@@ -234,6 +257,8 @@ class Engine:
         self.ctx.kv_cache = self.kv_cache
         self.ctx.attn_backend = self.attn_backend
         self.ctx.page_table = self.page_table
+        if self.linear_state_pool is not None:
+            self.ctx.linear_state_pool = self.linear_state_pool
         # ADR 0002: when the MoE experts are host-offloaded, the model's forward
         # serves them through the LRU slot pool the loader attached.
         if getattr(self.model, "moe_offload", False) and getattr(self.model, "moe_cache", None) is not None:
@@ -369,6 +394,45 @@ class Engine:
             eos_token_id = eos_token_id[0] if eos_token_id else None
         return Sampler(eos_token_id=eos_token_id if eos_token_id is not None else -1, device=device)
 
+    @staticmethod
+    def _build_hybrid_linear_pool(model, config, device, dtype):
+        """A real ping-pong-capable ``LinearStatePool`` sized off the model's
+        own GDN layers (issue `semantic-cache-e2e`, #172), or ``None`` for a
+        non-hybrid model (no ``linear_attn`` layers at all).
+
+        Dims are read directly off the model's own ``_GatedDeltaNet``
+        instances (mirrors ``qwen3_5_moe``'s own ``_register_linear_pool``)
+        rather than duplicated from config parsing -- every linear layer in
+        this model family shares one head/dim configuration, so the first
+        one found is representative. ``num_slots`` reserves slot 0
+        (padding, see ``LinearStatePool``'s own convention) plus 3 slots per
+        possible concurrent request: 1 live working slot + 2 ping-pong
+        track slots (this issue's own tool-call-anchor snapshot needs both,
+        see ``Req.mamba_ping_pong``).
+        """
+        linear_layers = [
+            layer.linear_attn for layer in getattr(model, "layers", []) if getattr(layer, "linear_attn", None) is not None
+        ]
+        if not linear_layers:
+            return None
+
+        from freetoken.kvcache.linear_state_pool import LinearStatePool
+
+        ref = linear_layers[0]
+        num_slots = 3 * config.max_running_req + 1
+        return LinearStatePool(
+            num_layers=len(linear_layers),
+            num_key_heads=ref.num_k_heads,
+            num_value_heads=ref.num_v_heads,
+            key_head_dim=ref.head_k_dim,
+            value_head_dim=ref.head_v_dim,
+            conv_kernel_dim=ref.conv_kernel,
+            num_slots=num_slots,
+            dtype=dtype or torch.bfloat16,
+            device=device,
+            layer_ids=[layer.linear_attn.layer_id for layer in model.layers if getattr(layer, "linear_attn", None) is not None],
+        )
+
     # -- request admission ---------------------------------------------------
 
     def add_request(self, req: Req) -> Req:
@@ -421,7 +485,35 @@ class Engine:
             matched_indices = cache_handle.get_matched_indices()
             req.cache_handle = cache_handle
             req.cached_len = cached_len
-        pending = make_pending_req(req.uid, req.input_ids, req.sampling_params, cache_handle, cached_len)
+        if self.linear_state_pool is not None:
+            # A real free-list slot, distinct from table_idx: 1 live working
+            # slot + 2 ping-pong track slots this request's own tool-call
+            # anchor (if any) may later freeze into (issue #172).
+            live, track0, track1 = self.linear_state_pool.alloc(3)
+            req.linear_slot_idx = live
+            req.mamba_ping_pong = (track0, track1)
+            # A client-side rewrite of an earlier finished request's tool
+            # call: if this prompt's KV-matched prefix (cached_len, from
+            # the plain radix match above) reaches at least as far as a
+            # recorded anchor snapshot for the SAME token prefix, restore
+            # that GDN state into this request's live slot instead of
+            # starting from zero -- the actual copy happens once, in
+            # step()'s prefill bookkeeping (mirrors upstream's own
+            # restore-before-forward timing).
+            if cached_len:
+                snap = self._mamba_anchor_snapshots.get(tuple(int(t) for t in req.input_ids[:cached_len]))
+                if snap is not None:
+                    req.mamba_restore_src = snap
+        pending = make_pending_req(
+            req.uid,
+            req.input_ids,
+            req.sampling_params,
+            cache_handle,
+            cached_len,
+            linear_slot_idx=req.linear_slot_idx,
+            mamba_ping_pong=req.mamba_ping_pong,
+            mamba_restore_src=req.mamba_restore_src,
+        )
         uid = self.scheduler.add(pending)
         req.uid = uid
         req.table_idx = pending._table_idx  # noqa: SLF001
@@ -479,6 +571,30 @@ class Engine:
             handle = self._find_cache_handle(uid)
             if handle is not None:
                 self.cache_manager.unlock(handle)
+        if self.linear_state_pool is not None:
+            # An aborted request never reaches step()'s finish-handling
+            # (issue #172's own donation/free path), so its live +
+            # ping-pong slots would otherwise leak forever. Nothing to
+            # preserve here (an abort never donates a snapshot). Read the
+            # slot ids off the PendingReq itself (stable for the request's
+            # whole lifetime, see its own docstring) rather than the
+            # per-step Req -- correct whether the request has started
+            # prefilling yet or not.
+            linear_slot_idx = mamba_ping_pong = None
+            for pending in self.scheduler.prefill_manager.pending_list:
+                if pending.uid == uid:
+                    linear_slot_idx, mamba_ping_pong = pending.linear_slot_idx, pending.mamba_ping_pong
+                    break
+            else:
+                for req in self.scheduler.decode_manager.running_reqs:
+                    if req.uid == uid:
+                        linear_slot_idx, mamba_ping_pong = req.linear_slot_idx, req.mamba_ping_pong
+                        break
+            if linear_slot_idx is not None:
+                to_free = [linear_slot_idx]
+                if mamba_ping_pong is not None:
+                    to_free.extend(mamba_ping_pong)
+                self.linear_state_pool.free(to_free)
         before = set(self.scheduler._free_slots)  # noqa: SLF001
         ok = self.scheduler.abort(uid)
         if ok:
@@ -593,6 +709,21 @@ class Engine:
         # prefill and decode requests slices each request's tokens by its own count.
         batch.extend_lens = torch.tensor(extend_lens, dtype=torch.int64, device=device)
 
+        if self.linear_state_pool is not None:
+            # Restore a frozen tool-call-anchor GDN snapshot into this
+            # request's live slot, once, right before the forward that will
+            # read it (issue #172 -- mirrors upstream's own restore-before-
+            # forward timing, see CacheManager.snapshot_toolcall_anchor's
+            # docstring for why this port's synchronous engine needs no
+            # stream-ordering guard). A request never gets a second
+            # mamba_restore_src (add_request sets it at most once, from a
+            # fresh admission), so clearing it here is enough to make the
+            # copy exactly-once for the request's lifetime.
+            for req in batch.reqs:
+                if req.mamba_restore_src is not None:
+                    self.linear_state_pool.copy_from(req.mamba_restore_src, req.linear_slot_idx)
+                    req.mamba_restore_src = None
+
         with self.ctx.forward_batch(batch):
             self.attn_backend.prepare_metadata(batch)
             logits = self.model(batch.input_ids, batch.positions, batch.out_loc)
@@ -644,6 +775,38 @@ class Engine:
                 and req.toolcall_anchor_len is None
             ):
                 req.toolcall_anchor_len = req.device_len
+            # Freeze the GDN state at the anchor into an idle ping-pong
+            # track slot (issue #172), and remember it by the exact prompt
+            # PREFIX it was taken at (self._full_ids -- the full history,
+            # not req.input_ids, which decode has already trimmed to just
+            # the latest token) so a later request whose prompt shares that
+            # prefix can restore it (add_request's own lookup).
+            #
+            # NOT on the detection step itself: the anchor token has only
+            # just been SAMPLED there (from the logits this step already
+            # computed) -- the recurrent core has not yet forward-processed
+            # it, so the GDN state at that instant is only "as of the
+            # prompt", one token short of what toolcall_anchor_len claims.
+            # That forward happens at the START of the NEXT step (whichever
+            # batch's positions include position toolcall_anchor_len - 1),
+            # after which device_len has been bumped a second time -- so
+            # device_len == toolcall_anchor_len + 1 is exactly "the anchor
+            # token has now actually been consumed", confirmed directly (an
+            # unguarded, immediate snapshot produced a state one token
+            # stale, diverging a restored run from a cold recompute of the
+            # same prompt).
+            if (
+                self.linear_state_pool is not None
+                and req.mamba_ping_pong is not None
+                and req.toolcall_anchor_len is not None
+                and req.mamba_last_track_seqlen is None
+                and req.device_len == req.toolcall_anchor_len + 1
+            ):
+                dst = req.mamba_ping_pong[req.mamba_next_track_idx]
+                self.cache_manager.snapshot_toolcall_anchor([req], self.linear_state_pool)
+                if req.mamba_last_track_seqlen == req.toolcall_anchor_len:
+                    prefix = tuple(self._full_ids[req.table_idx][: req.toolcall_anchor_len])
+                    self._mamba_anchor_snapshots[prefix] = dst
             # The FINAL chunk of a chunked prefill -- the one that just
             # completed the prompt -- is a plain Req (promoted out of the
             # ChunkedReq chain) whose cached_len is > 0 (it resumed from a
@@ -720,6 +883,19 @@ class Engine:
                     redundant = self.page_table[req.table_idx, admitted_cached_len : insert_result.cached_len]
                     never_written = self.page_table[req.table_idx, len(full_ids) : self.max_seq_len]
                     self.kv_cache.free_slots(torch.cat([redundant, never_written]))
+                if self.linear_state_pool is not None and req.linear_slot_idx is not None:
+                    # Return this request's live slot, plus whichever
+                    # ping-pong track slot was NOT donated as an anchor
+                    # snapshot (issue #172) -- a donated slot stays
+                    # allocated, owned by self._mamba_anchor_snapshots,
+                    # until a later request restores from it (there is no
+                    # eviction of these yet, see this dict's own docstring
+                    # in __init__ -- a known, documented scope cut).
+                    donated = set(self._mamba_anchor_snapshots.values())
+                    to_free = [req.linear_slot_idx]
+                    if req.mamba_ping_pong is not None:
+                        to_free.extend(s for s in req.mamba_ping_pong if s not in donated)
+                    self.linear_state_pool.free(to_free)
 
         # Record the step in the scheduler: promote finished prefills into the
         # decode set, refresh the decode set, and free the rows of requests that

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -766,6 +766,31 @@ class _LinearStatePool:
         return len(self._layers[layer_id])
 
 
+def _pool_slot(pool, layer_id: int, slot_idx: int) -> "_LinearStateSlot | None":
+    """Duck-type a per-request state slot out of either pool shape.
+
+    ``pool`` is either this model's own :class:`_LinearStatePool` (a plain
+    dict of pre-allocated ``_LinearStateSlot``s, the default -- unchanged
+    behavior for every non-hybrid-cache-managed run) or a real
+    :class:`freetoken.kvcache.linear_state_pool.LinearStatePool` (the
+    ping-pong/COW-capable stacked-tensor pool, issue `semantic-cache-e2e`
+    #172 -- the engine assigns this to ``ctx.linear_state_pool`` only when
+    prefix caching + a hybrid model are both on). Wrapping the new pool's
+    per-slot tensor VIEWS (not copies) in a ``_LinearStateSlot`` lets
+    ``_conv``/``_delta_rule`` read/write either pool identically -- their
+    ``.copy_()`` calls land directly on the new pool's own backing storage.
+    """
+    if pool is None:
+        return None
+    if hasattr(pool, "get"):  # this model's own _LinearStatePool
+        if layer_id not in pool:
+            return None
+        return pool.get(layer_id, slot_idx)
+    if pool.is_linear_layer(layer_id):  # freetoken.kvcache.linear_state_pool.LinearStatePool
+        return _LinearStateSlot(pool.recurrent_state(layer_id, slot_idx), pool.conv_state(layer_id, slot_idx))
+    return None
+
+
 class _GatedDeltaNet:
     """A Qwen3.5/3.6 linear-attention (Gated-Delta-Net) layer.
 
@@ -920,15 +945,19 @@ class _GatedDeltaNet:
             slot.state.copy_(s[0])
         return out.transpose(1, 2).contiguous().to(out_dtype)
 
-    def forward(self, hidden_states, positions, table_idx, ctx, batch) -> torch.Tensor:
+    def forward(self, hidden_states, positions, table_idx, ctx, batch, linear_slot_idx=None) -> torch.Tensor:
         # ``hidden_states`` is this request's token slice [T, H] (the decoder
         # layer hands it a 2-D per-request slice, mirroring qwen3_moe); positions
         # is that slice's [T]. T is this request's new-token count.
+        # ``linear_slot_idx`` (issue `semantic-cache-e2e`, #172) is this
+        # request's OWN GDN-state pool slot -- distinct from ``table_idx``
+        # (the KV page-table row) once a hybrid engine with prefix caching
+        # assigns one (Req.linear_slot_idx). Falls back to table_idx (the
+        # pre-#172 1:1 behavior) when not set, so a non-hybrid-managed run
+        # is unaffected.
         T = hidden_states.shape[0]
-        slot = None
-        pool = ctx.linear_state_pool
-        if pool is not None and self.layer_id in pool:
-            slot = pool.get(self.layer_id, table_idx)
+        slot_idx = linear_slot_idx if linear_slot_idx is not None else table_idx
+        slot = _pool_slot(ctx.linear_state_pool, self.layer_id, slot_idx)
         # Mixed qkv projection + causal conv (the conv ring is per-request).
         mixed_qkv = self.in_proj_qkv(hidden_states).unsqueeze(0).transpose(1, 2)  # [1, conv_dim, T]
         z = self.in_proj_z(hidden_states)  # [T, value_dim]
@@ -1711,11 +1740,12 @@ class _Qwen35DecoderLayer:
             )
         self.mlp = _Qwen35MoE(config, device, dtype, layer_id)
 
-    def forward(self, hidden_states, positions, table_idx, ctx, batch) -> torch.Tensor:
+    def forward(self, hidden_states, positions, table_idx, ctx, batch, linear_slot_idx=None) -> torch.Tensor:
         residual = hidden_states
         if self.linear_attn is not None:
             hidden_states = self.linear_attn(
-                self.input_layernorm(hidden_states), positions, table_idx, ctx, batch
+                self.input_layernorm(hidden_states), positions, table_idx, ctx, batch,
+                linear_slot_idx=linear_slot_idx,
             )
         else:
             hidden_states = self.self_attn(
@@ -1844,12 +1874,21 @@ class Qwen3_5MoEForCausalLM:
         reqs = batch.reqs
         num_tokens = input_ids.shape[0]
 
-        # The linear layers read per-request recurrent state from the pool; the
-        # engine assigns each request a linear_slot_idx (== table_idx here) and
-        # points ctx.linear_state_pool at this model's pool.
-        ctx.linear_state_pool = self.linear_state_pool
+        # The linear layers read per-request recurrent state from the pool.
+        # Default: the model's own pool, one slot per table_idx (1:1, no
+        # ping-pong). A hybrid engine running with prefix caching on
+        # (issue `semantic-cache-e2e`, #172) instead assigns a real
+        # ping-pong-capable LinearStatePool (freetoken.kvcache.
+        # linear_state_pool) to ctx.linear_state_pool, and a real
+        # free-list-allocated req.linear_slot_idx, BEFORE the first
+        # forward -- both are left alone here when already set, so that
+        # path's own slot lifetime (allocated at admission, freed at
+        # completion) is authoritative rather than being reset every step.
+        if ctx.linear_state_pool is None:
+            ctx.linear_state_pool = self.linear_state_pool
         for req in reqs:
-            req.linear_slot_idx = req.table_idx
+            if req.linear_slot_idx is None:
+                req.linear_slot_idx = req.table_idx
 
         hidden = self.embed_tokens(input_ids)  # [num_tokens, hidden]
         out = torch.empty((batch.size, self.config.hidden_size), device=hidden.device, dtype=hidden.dtype)
@@ -1871,7 +1910,7 @@ class Qwen3_5MoEForCausalLM:
             h = hidden[token_slice]
             pos = positions[token_slice]
             for layer in self.layers:
-                h = layer(h, pos, req.table_idx, ctx, batch)
+                h = layer(h, pos, req.table_idx, ctx, batch, linear_slot_idx=req.linear_slot_idx)
             # Keep only the last position of this request (next-token logits).
             out[i] = self.norm(h)[-1]
             offset += ext

--- a/python/freetoken/scheduler/prefill.py
+++ b/python/freetoken/scheduler/prefill.py
@@ -77,6 +77,18 @@ class PendingReq:
     _table_idx: int = 0
     _next_table_idx: int = 0
     _cache_handle: object = None
+    # GDN ping-pong state (issue `semantic-cache-e2e`, #172): the engine
+    # allocates these from its LinearStatePool at admission (add_request),
+    # BEFORE this PendingReq's prompt is ever prefilled -- _add_one_req
+    # below threads them into every Req/ChunkedReq it constructs for this
+    # request (a chunked prompt is reconstructed fresh per continuation
+    # chunk, see ``is_chunked`` below, so these must live on the STABLE
+    # PendingReq, not on any one chunk's transient Req). None for a
+    # non-hybrid model / prefix caching off (the engine never allocates
+    # them in that case).
+    linear_slot_idx: int | None = None
+    mamba_ping_pong: "tuple[int, int] | None" = None
+    mamba_restore_src: int | None = None
 
     @property
     def input_len(self) -> int:
@@ -93,6 +105,9 @@ def make_pending_req(
     sampling_params: "SamplingParams",
     cache_handle=None,
     cached_len: int = 0,
+    linear_slot_idx: int | None = None,
+    mamba_ping_pong: "tuple[int, int] | None" = None,
+    mamba_restore_src: int | None = None,
 ) -> PendingReq:
     """Build a :class:`PendingReq` from raw request fields.
 
@@ -102,7 +117,10 @@ def make_pending_req(
     (not in the engine) so the wrap stays in the torch-free scheduler package --
     the engine imports it on the XPU path but the CPU-venv policy tests never do.
     ``cached_len`` (issue #12) is the page-aligned prefix length the engine's
-    own ``CacheManager.match`` already found before calling this.
+    own ``CacheManager.match`` already found before calling this. The
+    ``linear_slot_idx``/``mamba_*`` params (issue #172) are the engine's
+    LinearStatePool allocation for this request, or None when this isn't a
+    hybrid-model + prefix-caching run.
     """
     return PendingReq(
         uid=uid,
@@ -110,6 +128,9 @@ def make_pending_req(
         sampling_params=sampling_params,
         _cache_handle=cache_handle,
         cached_len=cached_len,
+        linear_slot_idx=linear_slot_idx,
+        mamba_ping_pong=mamba_ping_pong,
+        mamba_restore_src=mamba_restore_src,
     )
 
 
@@ -264,6 +285,9 @@ class PrefillAdder:
             uid=pending_req.uid,
             cache_handle=cache_handle,
             sampling_params=pending_req.sampling_params,
+            linear_slot_idx=pending_req.linear_slot_idx,
+            mamba_ping_pong=pending_req.mamba_ping_pong,
+            mamba_restore_src=pending_req.mamba_restore_src,
         )
         req._next_table_idx = next_table_idx  # noqa: SLF001 - engine fills after forward
         return req

--- a/tests/test_toolcall_anchor_gdn_e2e.py
+++ b/tests/test_toolcall_anchor_gdn_e2e.py
@@ -1,0 +1,267 @@
+"""End-to-end: a rewritten tool-call resumes GDN state from the anchor
+instead of recomputing it (issue `semantic-cache-e2e`, #172 -- the final
+child of the `semantic-cache` epic, #32).
+
+The actual point of the whole epic, proven with a real forward pass (not
+just the isolated-piece unit tests #169/#170/#171 already wrote): a small
+fabricated Qwen3.5-shaped hybrid (linear-attention + full-attention)
+checkpoint, run through the real ``Engine``, mirroring this project's own
+established e2e style (``test_qwen35_gptq_e2e_loader.py`` et al: a few-KB
+synthetic checkpoint, not a real multi-GB one).
+
+Scenario:
+  1. Request 1 prefills a prompt and decodes to completion (greedy,
+     deterministic -- same weights + prompt always sample the same
+     tokens). ``engine.toolcall_anchor_id`` is armed to the token this
+     model actually samples FIRST (learned via a throwaway probe run,
+     matching this port's own established technique for "inject a real
+     anchor without depending on a model choosing to call a tool" --
+     see tests/test_toolcall_anchor.py), so the anchor lands right after
+     the prompt: a real, working (not synthetic-forced) GDN snapshot.
+  2. Request 2's prompt is request 1's prompt + its first generated
+     token (the shared "echoed tool call") + ONE new, different token
+     (the "client-side rewrite") -- exactly reproducing request 1 up to
+     the anchor, then diverging.
+  3. Confirms: engine.add_request restores request 2's GDN state from the
+     frozen snapshot (not from zero) -- proven the strong way, by matching
+     request 2's ENTIRE generated continuation against a COLD run of the
+     same (rewritten) prompt on a fresh engine, bit-identical. GDN
+     recurrence is a pure function of token history, so a wrong (zero or
+     partial) restore would diverge these two runs; only a byte-correct
+     restore reproduces the cold run exactly.
+  4. A coarse, real "does less work" signal (this issue's own Accept
+     bar): a spy on ``_GatedDeltaNet._delta_rule`` counts the total
+     tokens the recurrent core actually processes for request 2's
+     prefill step -- the cache/restore path must process strictly fewer
+     than request 2's full prompt length (it only extends the tail past
+     ``cached_len``), unlike a cold run which processes the whole thing.
+
+Deliberate scope cut (documented in engine.py's own comments): restore
+routing goes through a flat, never-evicted ``Engine._mamba_anchor_snapshots``
+lookaside keyed by the exact token prefix, not the full HybridRadixCache
+tree-donation/eviction machinery #169 already built for the KV+mamba-node
+case -- proving the restore MECHANISM end-to-end doesn't need that tree's
+ownership/eviction machinery; wiring HybridRadixCache into CacheManager in
+place of the plain RadixPrefixCache it wraps today is real, separable
+follow-up work.
+
+CPU-only (DEVICE = "cpu", like test_engine_loop.py) -- runs in the
+CPU-only CI runner; an XPU run is the same engine/model path on a
+different device, not a new code path to test separately here.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+
+DEVICE = "cpu"
+
+H, I, E, V, L = 32, 16, 4, 64, 2
+NH, NKV, HD = 4, 2, 16
+NK, NV = 2, 2
+KD, VD = 16, 16
+KEY_DIM, VALUE_DIM = NK * KD, NV * VD
+QKV_DIM = KEY_DIM * 2 + VALUE_DIM
+CONV_DIM = KEY_DIM * 2 + VALUE_DIM
+CONV_K = 4
+Q_PROJ_DIM = NH * HD * 2  # q_proj always fuses query + output gate (_Qwen35Attention)
+O_PROJ_DIM = NH * HD
+KV_PROJ_DIM = NKV * HD
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _text_config() -> dict:
+    return {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NKV,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": HD,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 2,
+        "layer_types": ["linear_attention", "full_attention"],
+        "linear_num_key_heads": NK,
+        "linear_num_value_heads": NV,
+        "linear_key_head_dim": KD,
+        "linear_value_head_dim": VD,
+        "linear_conv_kernel_dim": CONV_K,
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+
+
+def _weights() -> dict:
+    g = torch.Generator().manual_seed(0)
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H, generator=g),
+        "model.language_model.norm.weight": torch.randn(H, generator=g),
+        "lm_head.weight": torch.randn(V, H, generator=g),
+    }
+    for layer in range(L):
+        if layer % 2 == 0:  # linear-attention (Gated-Delta-Net)
+            p = f"model.language_model.layers.{layer}.linear_attn"
+            w[f"{p}.in_proj_qkv.weight"] = torch.randn(QKV_DIM, H, generator=g)
+            w[f"{p}.in_proj_z.weight"] = torch.randn(VALUE_DIM, H, generator=g)
+            w[f"{p}.in_proj_b.weight"] = torch.randn(NV, H, generator=g)
+            w[f"{p}.in_proj_a.weight"] = torch.randn(NV, H, generator=g)
+            w[f"{p}.conv1d.weight"] = torch.randn(CONV_DIM, 1, CONV_K, generator=g)
+            w[f"{p}.out_proj.weight"] = torch.randn(H, VALUE_DIM, generator=g)
+            w[f"{p}.A_log"] = torch.randn(NV, generator=g)
+            w[f"{p}.dt_bias"] = torch.randn(NV, generator=g)
+        else:  # full-attention (gated GQA)
+            p = f"model.language_model.layers.{layer}.self_attn"
+            w[f"{p}.q_proj.weight"] = torch.randn(Q_PROJ_DIM, H, generator=g)
+            w[f"{p}.k_proj.weight"] = torch.randn(KV_PROJ_DIM, H, generator=g)
+            w[f"{p}.v_proj.weight"] = torch.randn(KV_PROJ_DIM, H, generator=g)
+            w[f"{p}.o_proj.weight"] = torch.randn(H, O_PROJ_DIM, generator=g)
+            w[f"{p}.q_norm.weight"] = torch.randn(HD, generator=g)
+            w[f"{p}.k_norm.weight"] = torch.randn(HD, generator=g)
+        m = f"model.language_model.layers.{layer}.mlp"
+        w[f"{m}.gate.weight"] = torch.randn(E, H, generator=g)
+        w[f"{m}.experts.gate_up_proj"] = torch.randn(E, 2 * I, H, generator=g)
+        w[f"{m}.experts.down_proj"] = torch.randn(E, H, I, generator=g)
+        w[f"{m}.shared_expert.gate_proj.weight"] = torch.randn(I, H, generator=g)
+        w[f"{m}.shared_expert.up_proj.weight"] = torch.randn(I, H, generator=g)
+        w[f"{m}.shared_expert.down_proj.weight"] = torch.randn(H, I, generator=g)
+        w[f"{m}.shared_expert_gate.weight"] = torch.randn(1, H, generator=g)
+    return w
+
+
+@pytest.fixture(scope="module")
+def hybrid_ckpt(tmp_path_factory):
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_hybrid_e2e")
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": _text_config(),
+    }
+    weights = _weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+def _cfg(model_path: str, **overrides) -> EngineConfig:
+    kwargs = dict(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=DEVICE,
+        attention_backend="auto",
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+        num_page_override=256,
+    )
+    kwargs.update(overrides)
+    return EngineConfig(**kwargs)
+
+
+def _req(uid: int, ids: list[int], output_len: int) -> Req:
+    return Req(
+        input_ids=list(ids),
+        table_idx=0,
+        cached_len=0,
+        output_len=output_len,
+        uid=uid,
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+        cache_handle=None,
+    )
+
+
+PROMPT = [5, 9, 13, 17]
+REWRITE_TAIL = 42  # a token that never appears anywhere in PROMPT/the probe run
+
+
+def _delta_rule_token_count_spy():
+    """Patches _GatedDeltaNet._delta_rule to also record the total T
+    (sequence length) it is called with, across every call -- a coarse,
+    real measure of how many tokens the recurrent core actually
+    processed, this issue's own Accept-bar signal for "less recompute"."""
+    from freetoken.models.qwen3_5_moe import _GatedDeltaNet
+
+    counts: list[int] = []
+    original = _GatedDeltaNet._delta_rule
+
+    def spy(self, q, k, v, g, beta, slot, out_dtype=None):
+        counts.append(q.shape[1])  # q is [B, T, num_v, D] on entry
+        return original(self, q, k, v, g, beta, slot, out_dtype=out_dtype)
+
+    return patch.object(_GatedDeltaNet, "_delta_rule", spy), counts
+
+
+def test_rewritten_toolcall_restores_gdn_state_from_the_anchor(hybrid_ckpt):
+    # --- Learn the real (deterministic) first-sampled token, to arm a
+    # real anchor without depending on this random-weight model actually
+    # choosing to call a tool (mirrors test_toolcall_anchor.py's own
+    # technique).
+    probe = Engine(_cfg(hybrid_ckpt))
+    probe.add_request(_req(0, PROMPT, output_len=1))
+    first_token = probe.generate()[0][0]
+    reset_global_ctx()
+    assert first_token != REWRITE_TAIL
+
+    # --- Request 1: prefill + decode to completion, with the anchor armed
+    # at the model's own real first-sampled token. Finishing commits its
+    # full sequence into the prefix cache AND (issue #172) freezes its GDN
+    # state at the anchor into a ping-pong track slot.
+    engine = Engine(_cfg(hybrid_ckpt, enable_prefix_cache=True))
+    engine.toolcall_anchor_id = first_token
+    engine.add_request(_req(0, PROMPT, output_len=3))
+    engine.generate()
+    assert len(engine._mamba_anchor_snapshots) == 1  # noqa: SLF001
+    anchor_prefix = next(iter(engine._mamba_anchor_snapshots))  # noqa: SLF001
+    assert anchor_prefix == tuple(PROMPT + [first_token])
+
+    # --- Request 2: request 1's prompt, plus its first generated token
+    # (the shared echoed tool call), plus ONE new diverging token (the
+    # client-side rewrite) -- reproduces request 1 exactly up to the
+    # anchor, then diverges.
+    rewritten_prompt = PROMPT + [first_token, REWRITE_TAIL]
+    spy_ctx, counts = _delta_rule_token_count_spy()
+    with spy_ctx:
+        engine.add_request(_req(1, rewritten_prompt, output_len=3))
+        restored_out = engine.generate()[0]
+    # The cache/restore path only extends the un-cached tail (the one
+    # diverging token) during prefill, not the whole 6-token prompt --
+    # the coarse "less recompute" signal this issue's Accept bar asks for.
+    assert counts[0] < len(rewritten_prompt)
+    assert counts[0] == 1
+
+    # --- Cold baseline: a FRESH engine (no prior history, prefix caching
+    # off -- nothing to restore from), fed the exact same rewritten
+    # prompt from scratch. A wrong (zero-state, or stale) restore would
+    # make request 2's continuation diverge from this; only a byte-
+    # correct restore reproduces it exactly, since GDN recurrence is a
+    # pure function of token history.
+    cold = Engine(_cfg(hybrid_ckpt, enable_prefix_cache=False))
+    cold.add_request(_req(0, rewritten_prompt, output_len=3))
+    cold_out = cold.generate()[0]
+
+    assert restored_out == cold_out


### PR DESCRIPTION
## Summary
The final child of the `semantic-cache` epic (#32), following #169 (`HybridRadixCache`), #170 (`LinearStatePool`) and #171 (anchor detection + `snapshot_toolcall_anchor`). Proves with a real forward pass that a client-side rewrite of an echoed tool-call reuses the GDN state computed up to the anchor instead of recomputing it.

**Model wiring (`qwen3_5_moe`)**
- `_GatedDeltaNet.forward` accepts a real `linear_slot_idx` (falls back to `table_idx` when unset — no change for a non-hybrid-managed run).
- A new `_pool_slot()` helper duck-types a `_LinearStateSlot`-shaped view out of either this model's own per-request-1:1 `_LinearStatePool` or a real ping-pong-capable `LinearStatePool` (#170) — the new pool's per-slot tensor views back the slot directly, so `_conv`/`_delta_rule`'s existing `.copy_()` calls land on its own storage with zero changes to their own code.
- `Qwen3_5MoEForCausalLM.forward` no longer clobbers an already-set `ctx.linear_state_pool`/`req.linear_slot_idx` every step — a hybrid engine's own slot lifetime (allocated at admission, freed at completion) is now authoritative when present.

**Engine wiring**
- `Engine._build_hybrid_linear_pool` builds a real `LinearStatePool` sized off the model's own GDN layers, only for a hybrid model running with prefix caching on.
- `add_request` allocates 1 live + 2 ping-pong slots per hybrid request, and looks up `Engine._mamba_anchor_snapshots` (a prefix-keyed lookaside — see its own docstring for the deliberate scope cut vs. a full `HybridRadixCache`-donation integration) to set `mamba_restore_src` when this request's KV-matched prefix reaches a recorded anchor.
- `step()` restores `mamba_restore_src` into the live slot once, right before the forward that reads it; snapshots the anchor into a ping-pong track slot exactly **one step after** the anchor token has actually been forward-processed (not on the detection step itself — confirmed directly: an immediate snapshot is one token stale, since the token is only sampled, not yet consumed by the recurrent core, at that instant); frees a finished request's live + (non-donated) ping-pong slots.
- `abort_request` now also frees a hybrid request's linear-pool slots.
- `PendingReq` gained `linear_slot_idx`/`mamba_ping_pong`/`mamba_restore_src` fields (stable across chunked-prefill continuations, which reconstruct a fresh `Req` per chunk) so a hybrid request's pool allocation survives from admission through every prefill chunk.

**Deliberately deferred** as separable follow-up: replacing the flat `_mamba_anchor_snapshots` lookaside with a full `HybridRadixCache`-donation integration in `CacheManager` (in place of the plain `RadixPrefixCache` it wraps today) — this issue's own accept bar is proving the restore MECHANISM end-to-end, which doesn't need that tree's eviction/ownership machinery.

## Test plan
- [x] `tests/test_toolcall_anchor_gdn_e2e.py`: a small fabricated Qwen3.5-shaped hybrid checkpoint (mirrors `test_qwen35_gptq_e2e_loader.py`'s own style), run through the real `Engine`. Proves the restore is byte-correct (request 2's full generated continuation matches a cold, from-scratch run of the same rewritten prompt bit-identically — GDN recurrence is a pure function of token history, so a wrong restore would diverge) and a call-count spy on `_GatedDeltaNet._delta_rule` confirms the cached/restore path processes strictly fewer tokens during prefill than a cold run.
- [x] `.venv` (torch-free) full suite: 205 passed, 78 skipped, 0 failed.
- [x] `.venv-xpu -m "not xpu"` full suite: 505 passed, 1 skipped, 1 pre-existing unrelated failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`, reproduces identically on a clean `main` checkout).

Closes #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5