### PR TITLE
feat(moe): wire MXFP4 packed banks into the in-VRAM fused expert path (issue #180)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -235,7 +235,7 @@ def load_model(
                     model_path=model_path,
                 )
             else:
-                _place_expert_weights(model, gate_up_banks, down_banks)
+                _place_expert_weights_any(model, gate_up_banks, down_banks, device)
             expert_sources = (gate_up_banks, down_banks)
         else:
             expert_sources = ([], [])
@@ -272,7 +272,7 @@ def load_model(
                     model_path=model_path,
                 )
             else:
-                _place_expert_weights(model, gate_up_banks, down_banks)
+                _place_expert_weights_any(model, gate_up_banks, down_banks, device)
             expert_sources = (gate_up_banks, down_banks)
         else:
             expert_sources = ([], [])
@@ -367,6 +367,65 @@ def _place_expert_weights(model, gate_up_banks, down_banks) -> None:
                 experts[e].gate_proj.weight.copy_(gu[e, 0:intermediate])
                 experts[e].up_proj.weight.copy_(gu[e, intermediate : 2 * intermediate])
                 experts[e].down_proj.weight.copy_(dn[e])
+
+
+def _place_mxfp4_expert_weights(model, gate_up_banks, down_banks, device) -> None:
+    """Build fully XPU-resident MXFP4 expert modules from packed banks
+    (issue `moe-fused-mxfp4`, #180, part of the `quant-xpu` epic, #10).
+
+    The in-VRAM (``moe_backend="fused"``) sibling of :func:`_attach_offload_
+    cache`'s MXFP4 detection: instead of handing the packed
+    :class:`~freetoken.models.weight.MxfpExpertBank` rows to a host-side LRU
+    slot pool, this REPLACES each MoE layer's ``experts`` ``ModuleList``
+    (already built by the model's constructor as plain bf16
+    ``_Qwen35Expert``s -- thrown away here, a known minor inefficiency, not
+    a correctness issue) with :class:`~freetoken.models.qwen3_5_moe.
+    _Qwen35MxfpExpert` instances holding this expert's own packed
+    ``blocks``/``scales`` moved onto ``device``. Every other expert-type
+    dispatch (``_forward_inram``'s ``self.experts[e](...)`` call) is
+    unchanged -- ``_Qwen35MxfpExpert.forward`` has the identical ``(x) ->
+    tensor`` signature.
+    """
+    import torch.nn as nn
+
+    from freetoken.models.qwen3_5_moe import _Qwen35MxfpExpert
+
+    intermediate = int(getattr(model.config, "moe_intermediate_size", 0))
+    for layer_id in _moe_layers(model.config):
+        moe = getattr(getattr(model, "layers", [None] * (layer_id + 1))[layer_id], "mlp", None)
+        if getattr(moe, "experts", None) is None:
+            continue
+        gu_bank = gate_up_banks[layer_id]
+        dn_bank = down_banks[layer_id]
+        num_experts = gu_bank.blocks.shape[0]
+        moe.experts = nn.ModuleList(
+            _Qwen35MxfpExpert(
+                gu_bank.blocks[e].to(device),
+                gu_bank.scales[e].to(device),
+                dn_bank.blocks[e].to(device),
+                dn_bank.scales[e].to(device),
+                intermediate=intermediate,
+            )
+            for e in range(num_experts)
+        )
+
+
+def _place_expert_weights_any(model, gate_up_banks, down_banks, device) -> None:
+    """Dispatch the in-VRAM (``moe_backend="fused"``) expert placement by
+    bank type (issue #180): a plain bf16 stacked tensor goes through
+    :func:`_place_expert_weights` unchanged (every existing bf16 test);
+    a packed :class:`~freetoken.models.weight.MxfpExpertBank` (the only
+    quant format wired to the fused path so far -- FP8/#181 and INT8/#182
+    are the sibling issues that add their own branch here) goes through
+    :func:`_place_mxfp4_expert_weights` instead.
+    """
+    from freetoken.models.weight import MxfpExpertBank
+
+    first = next((b for b in gate_up_banks if b is not None), None)
+    if isinstance(first, MxfpExpertBank):
+        _place_mxfp4_expert_weights(model, gate_up_banks, down_banks, device)
+    else:
+        _place_expert_weights(model, gate_up_banks, down_banks)
 
 
 def _attach_offload_cache(

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -557,6 +557,7 @@ def _ensure_torch() -> None:
         "_Qwen35Attention",
         "_Qwen35MoE",
         "_Qwen35Expert",
+        "_Qwen35MxfpExpert",
         "_Qwen35DecoderLayer",
         "Qwen3_5MoEForCausalLM",
     )
@@ -1681,6 +1682,55 @@ class _Qwen35Expert:
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _Qwen35MxfpExpert:
+    """A single MXFP4-quantized MoE expert, fully XPU-resident (issue
+    `moe-fused-mxfp4`, #180, part of the `quant-xpu` epic, #10).
+
+    Unlike :class:`_Qwen35Expert` (plain bf16 ``gate_proj``/``up_proj``/
+    ``down_proj`` ``nn.Linear``s), this holds the checkpoint's packed MXFP4
+    ``blocks``/``scales`` (the same per-expert tensors
+    :class:`freetoken.models.weight.MxfpExpertBank` streams for the offload
+    backend, moved onto the device instead of staying on host) and never
+    materializes a dequantized weight: :func:`freetoken.kernel.triton.
+    fused_mxfp4_linear.fused_mxfp4_expert_forward` runs the native packed
+    GEMM directly, the same kernel the offload backend's dequant-at-compute
+    path (#163) uses -- this is its fully-resident sibling, with no host
+    round-trip / LRU slot pool at all.
+    """
+
+    def __init__(
+        self,
+        blocks_gate_up: torch.Tensor,
+        scales_gate_up: torch.Tensor,
+        blocks_down: torch.Tensor,
+        scales_down: torch.Tensor,
+        intermediate: int,
+    ) -> None:
+        super().__init__()
+        # persistent=False: these are checkpoint-derived, streamed by the
+        # loader every load, never part of a state_dict this port saves/
+        # restores (matching every other quant bank's own storage -- the
+        # offload cache's host banks aren't state_dict members either).
+        self.register_buffer("blocks_gate_up", blocks_gate_up, persistent=False)
+        self.register_buffer("scales_gate_up", scales_gate_up, persistent=False)
+        self.register_buffer("blocks_down", blocks_down, persistent=False)
+        self.register_buffer("scales_down", scales_down, persistent=False)
+        self.intermediate = intermediate
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        from freetoken.kernel.triton.fused_mxfp4_linear import fused_mxfp4_expert_forward
+
+        return fused_mxfp4_expert_forward(
+            x,
+            self.blocks_gate_up,
+            self.scales_gate_up,
+            self.blocks_down,
+            self.scales_down,
+            intermediate=self.intermediate,
+            out_dtype=x.dtype,
+        )
 
 
 def _make_shared_config(config: ModelConfig, shared_inter: int) -> ModelConfig:

--- a/tests/test_qwen35_mxfp4_fused_e2e_xpu.py
+++ b/tests/test_qwen35_mxfp4_fused_e2e_xpu.py
@@ -1,0 +1,186 @@
+"""End-to-end: load_model() wires an MXFP4-quantized checkpoint's routed
+experts into the fully XPU-resident (fused) path and runs a real forward
+step (issue `moe-fused-mxfp4`, #180, part of the `quant-xpu` epic, #10).
+
+This is the "fused" sibling of ``test_qwen35_mxfp4_e2e_loader.py`` (the
+already-merged OFFLOAD e2e test, #153): same packed-bank checkpoint shape,
+different backend (``moe_backend="fused"`` instead of ``"offload"``),
+proving the previously-missing gap -- `loader.py`'s in-VRAM placement path
+did not know how to place a quantized bank at all (it assumed a plain
+stacked bf16 tensor and would crash on a real `MxfpExpertBank`).
+
+``xpu``-marked: :func:`freetoken.kernel.triton.fused_mxfp4_linear.
+fused_mxfp4_expert_forward` needs a real Triton-XPU compile, the same
+reasoning ``test_fused_mxfp4_linear_xpu.py`` documents -- no meaningful
+CPU-only synthetic-fixture version exists.
+
+A small (few-KB) fabricated MXFP4 checkpoint, not a real multi-GB one --
+mirrors ``test_qwen35_gptq_e2e_loader.py``'s own established style.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.kernel.triton.mxfp4_linear import quantize_mxfp4_blocks
+from freetoken.models.loader import load_model
+
+H, I, E, V, L = 32, 32, 4, 64, 1  # H, I both multiples of 32 (MXFP4's own block size)
+NH, NKV, HD = 4, 2, 16
+Q_PROJ_DIM = NH * HD * 2  # q_proj always fuses query + output gate (_Qwen35Attention)
+O_PROJ_DIM = NH * HD
+KV_PROJ_DIM = NKV * HD
+
+
+def _pack_experts(dense: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """``[E, N, K] -> (blocks [E, N, K//32, 16], scales [E, N, K//32])``,
+    matching MxfpExpertBank's own per-expert layout exactly."""
+    blocks, scales = quantize_mxfp4_blocks(dense)
+    return blocks, scales
+
+
+def _qwen35_mxfp4_weights() -> dict:
+    """One full-attention layer's dense weights (unquantized) plus MXFP4-
+    packed routed experts (the real gpt-oss/Qwen3.6 checkpoint's own
+    already-packed-per-projection layout, verified against
+    openai/gpt-oss-20b's index.json -- see MxfpExpertBank's own docstring)
+    and a plain (unquantized) shared expert."""
+    w = {
+        "model.language_model.embed_tokens.weight": torch.randn(V, H),
+        "model.language_model.norm.weight": torch.randn(H),
+        "lm_head.weight": torch.randn(V, H),
+        "model.language_model.layers.0.self_attn.q_proj.weight": torch.randn(Q_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.k_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.v_proj.weight": torch.randn(KV_PROJ_DIM, H),
+        "model.language_model.layers.0.self_attn.o_proj.weight": torch.randn(H, O_PROJ_DIM),
+        "model.language_model.layers.0.self_attn.q_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.self_attn.k_norm.weight": torch.randn(HD),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(E, H),
+        "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.up_proj.weight": torch.randn(I, H),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(H, I),
+        "model.language_model.layers.0.mlp.shared_expert_gate.weight": torch.randn(1, H),
+    }
+    gate_up_dense = torch.randn(E, 2 * I, H)  # K = H (must be a multiple of 32)
+    down_dense = torch.randn(E, H, I)  # K = I (must be a multiple of 32)
+    gu_blocks, gu_scales = _pack_experts(gate_up_dense)
+    dn_blocks, dn_scales = _pack_experts(down_dense)
+    base = "model.language_model.layers.0.mlp.experts"
+    w[f"{base}.gate_up_proj_blocks"] = gu_blocks
+    w[f"{base}.gate_up_proj_scales"] = gu_scales
+    w[f"{base}.down_proj_blocks"] = dn_blocks
+    w[f"{base}.down_proj_scales"] = dn_scales
+    return w
+
+
+@pytest.fixture(scope="module")
+def qwen35_mxfp4_ckpt(tmp_path_factory):
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_mxfp4_fused")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NKV,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": HD,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {"quant_method": "mxfp4"},
+    }
+    weights = _qwen35_mxfp4_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+@XPU
+@pytest.mark.xpu
+def test_load_model_places_mxfp4_experts_fully_resident(qwen35_mxfp4_ckpt):
+    """The real point of #180: moe_backend="fused" no longer crashes on a
+    quantized bank -- each expert becomes a real _Qwen35MxfpExpert holding
+    packed blocks/scales on the device, not a bf16 nn.Linear."""
+    from freetoken.models.qwen3_5_moe import _Qwen35MxfpExpert
+
+    model, _ = load_model(
+        qwen35_mxfp4_ckpt, torch.device("xpu"), dtype=torch.bfloat16, moe_backend="fused"
+    )
+    experts = model.layers[0].mlp.experts
+    assert len(experts) == E
+    for expert in experts:
+        assert isinstance(expert, _Qwen35MxfpExpert)
+        assert expert.blocks_gate_up.device.type == "xpu"
+        assert expert.blocks_gate_up.dtype == torch.uint8
+
+
+@XPU
+@pytest.mark.xpu
+def test_mxfp4_fused_forward_step_produces_finite_logits(qwen35_mxfp4_ckpt):
+    """A real forward pass through the fully-resident MXFP4 experts -- the
+    native fused_mxfp4_expert_forward kernel, no host round-trip at all."""
+    from freetoken.attention.triton import TritonAttentionBackend
+    from freetoken.core import Batch, Context, Req, SamplingParams, reset_global_ctx, set_global_ctx
+    from freetoken.kvcache.base import BaseKVCachePool
+
+    model, _ = load_model(
+        qwen35_mxfp4_ckpt, torch.device("xpu"), dtype=torch.bfloat16, moe_backend="fused"
+    )
+    seq = torch.randint(0, V, (5,), device="xpu")
+    T = seq.shape[0]
+
+    req = Req(
+        input_ids=seq,
+        table_idx=0,
+        cached_len=0,
+        output_len=1,
+        uid=0,
+        sampling_params=SamplingParams(),
+        cache_handle=None,
+    )
+    batch = Batch(reqs=[req], phase="prefill")
+    batch.input_ids = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.positions = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.out_loc = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.extend_lens = torch.tensor([T])
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(model.config, 1, 1024, torch.device("xpu"), torch.bfloat16)
+    pt = torch.zeros((1, 1024), dtype=torch.int32, device="xpu")
+    pt[0, :T] = torch.arange(T, device="xpu")
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    backend = TritonAttentionBackend(model.config)
+    backend.prepare_metadata(batch)
+    ctx.attn_backend = backend
+    ctx.model = model
+    set_global_ctx(ctx)
+    ctx._batch = batch
+    try:
+        logits = model.forward(batch.input_ids, batch.positions, batch.out_loc)
+    finally:
+        reset_global_ctx()
+
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits.float()).all()


### PR DESCRIPTION
## Summary
Part of the `quant-xpu` epic (#10): the offload backend's MXFP4 support (#153) was complete, but `loader.py`'s in-VRAM (`moe_backend="fused"`) path never learned about quantized banks at all — `_place_expert_weights` only handled a plain stacked bf16 tensor (`hasattr(bank, "tensor")`); handed a real `MxfpExpertBank` it would crash trying to read it as a raw tensor.

- New `_Qwen35MxfpExpert` (`qwen3_5_moe/__init__.py`): holds a single expert's packed `blocks`/`scales` as device buffers and runs `fused_mxfp4_expert_forward` (the native packed-GEMM kernel, #163) directly — never materializes a dequantized weight. Same `(x) -> tensor` interface as the existing bf16 `_Qwen35Expert`, so `_forward_inram`'s generic `self.experts[e](...)` dispatch needs no changes at all. Added to `_ensure_torch()`'s `nn.Module` rebind order.
- `loader.py`: `_place_mxfp4_expert_weights` replaces a MoE layer's `experts` `ModuleList` with device-resident `_Qwen35MxfpExpert` instances built straight from the streamed `MxfpExpertBank` rows (moved onto device); `_place_expert_weights_any` dispatches by bank type (plain bf16 vs `MxfpExpertBank`) at both in-VRAM call sites, leaving every existing bf16 test's code path completely unchanged.

Known minor inefficiency, not a correctness issue: the model's constructor still builds the throwaway bf16 experts before this function replaces them (quant format isn't known until after `load_moe_expert_sources` streams the checkpoint, which runs after model construction) — documented in the function's own docstring.

Sibling issues #181 (FP8) and #182 (INT8) will add their own branch to `_place_expert_weights_any` for their formats — not done here.

## Test plan
- [x] `tests/test_qwen35_mxfp4_fused_e2e_xpu.py` (`xpu`-marked — the native Triton-XPU kernel needs a real compile, no CPU-only fixture is meaningful, same reasoning as `test_fused_mxfp4_linear_xpu.py`): a small fabricated MXFP4-packed checkpoint (mirrors `test_qwen35_gptq_e2e_loader.py`'s style), loaded with `moe_backend="fused"`, confirms every expert is a real `_Qwen35MxfpExpert` with device-resident packed buffers, and a real forward pass produces finite logits. **Both tests run and pass on real B70 hardware.**
- [x] Existing XPU regression tests touching `loader.py`/`qwen3_5_moe`: `test_qwen35_offload_xpu.py`, `test_qwen35_gptq_native_fused_xpu.py`, `test_moe_fused_xpu.py` — all pass, no regression.
- [x] `.venv` (torch-free) full suite: 205 passed, 79 skipped, 0 failed.
- [x] `.venv-xpu -m "not xpu"` full suite: 505 passed, 1 skipped, 1 pre-existing unrelated failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`, reproduces identically on a clean `main` checkout).

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5