### PR TITLE
feat(moe): wire block-FP8 packed banks into the in-VRAM fused expert path (issue #181)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -410,20 +410,53 @@ def _place_mxfp4_expert_weights(model, gate_up_banks, down_banks, device) -> Non
         )
 
 
+def _place_fp8_expert_weights(model, gate_up_banks, down_banks, device) -> None:
+    """Build fully XPU-resident block-FP8 expert modules from packed banks
+    (issue `moe-fused-fp8`, #181, part of the `quant-xpu` epic, #10). The
+    block-FP8 sibling of :func:`_place_mxfp4_expert_weights` -- see its own
+    docstring for the shared rationale (in-VRAM sibling of the offload
+    backend's dequant-at-compute path, and the same "constructor already
+    built throwaway bf16 experts" known minor inefficiency)."""
+    import torch.nn as nn
+
+    from freetoken.models.qwen3_5_moe import _Qwen35Fp8Expert
+
+    intermediate = int(getattr(model.config, "moe_intermediate_size", 0))
+    for layer_id in _moe_layers(model.config):
+        moe = getattr(getattr(model, "layers", [None] * (layer_id + 1))[layer_id], "mlp", None)
+        if getattr(moe, "experts", None) is None:
+            continue
+        gu_bank = gate_up_banks[layer_id]
+        dn_bank = down_banks[layer_id]
+        num_experts = gu_bank.weight.shape[0]
+        moe.experts = nn.ModuleList(
+            _Qwen35Fp8Expert(
+                gu_bank.weight[e].to(device),
+                gu_bank.weight_scale_inv[e].to(device),
+                dn_bank.weight[e].to(device),
+                dn_bank.weight_scale_inv[e].to(device),
+                intermediate=intermediate,
+            )
+            for e in range(num_experts)
+        )
+
+
 def _place_expert_weights_any(model, gate_up_banks, down_banks, device) -> None:
     """Dispatch the in-VRAM (``moe_backend="fused"``) expert placement by
-    bank type (issue #180): a plain bf16 stacked tensor goes through
+    bank type: a plain bf16 stacked tensor goes through
     :func:`_place_expert_weights` unchanged (every existing bf16 test);
-    a packed :class:`~freetoken.models.weight.MxfpExpertBank` (the only
-    quant format wired to the fused path so far -- FP8/#181 and INT8/#182
-    are the sibling issues that add their own branch here) goes through
-    :func:`_place_mxfp4_expert_weights` instead.
+    a packed :class:`~freetoken.models.weight.MxfpExpertBank` (issue #180)
+    or :class:`~freetoken.models.weight.Fp8BlockExpertBank` (issue #181)
+    goes through its own placement function instead. INT8 (#182) is the
+    remaining sibling issue that adds its own branch here.
     """
-    from freetoken.models.weight import MxfpExpertBank
+    from freetoken.models.weight import Fp8BlockExpertBank, MxfpExpertBank
 
     first = next((b for b in gate_up_banks if b is not None), None)
     if isinstance(first, MxfpExpertBank):
         _place_mxfp4_expert_weights(model, gate_up_banks, down_banks, device)
+    elif isinstance(first, Fp8BlockExpertBank):
+        _place_fp8_expert_weights(model, gate_up_banks, down_banks, device)
     else:
         _place_expert_weights(model, gate_up_banks, down_banks)
 

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -558,6 +558,7 @@ def _ensure_torch() -> None:
         "_Qwen35MoE",
         "_Qwen35Expert",
         "_Qwen35MxfpExpert",
+        "_Qwen35Fp8Expert",
         "_Qwen35DecoderLayer",
         "Qwen3_5MoEForCausalLM",
     )
@@ -1728,6 +1729,49 @@ class _Qwen35MxfpExpert:
             self.scales_gate_up,
             self.blocks_down,
             self.scales_down,
+            intermediate=self.intermediate,
+            out_dtype=x.dtype,
+        )
+
+
+class _Qwen35Fp8Expert:
+    """A single block-FP8-quantized MoE expert, fully XPU-resident (issue
+    `moe-fused-fp8`, #181, part of the `quant-xpu` epic, #10).
+
+    The block-FP8 sibling of :class:`_Qwen35MxfpExpert`: holds the
+    checkpoint's packed ``weight``/``weight_scale_inv`` (the same per-expert
+    tensors :class:`freetoken.models.weight.Fp8BlockExpertBank` streams for
+    the offload backend, moved onto the device instead of staying on host)
+    and never materializes a dequantized weight --
+    :func:`freetoken.kernel.triton.fused_fp8_linear.fused_fp8_expert_forward`
+    runs the native packed GEMM directly, the same kernel the offload
+    backend's dequant-at-compute path (#163) uses.
+    """
+
+    def __init__(
+        self,
+        weight_gate_up: torch.Tensor,
+        scale_gate_up: torch.Tensor,
+        weight_down: torch.Tensor,
+        scale_down: torch.Tensor,
+        intermediate: int,
+    ) -> None:
+        super().__init__()
+        self.register_buffer("weight_gate_up", weight_gate_up, persistent=False)
+        self.register_buffer("scale_gate_up", scale_gate_up, persistent=False)
+        self.register_buffer("weight_down", weight_down, persistent=False)
+        self.register_buffer("scale_down", scale_down, persistent=False)
+        self.intermediate = intermediate
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        from freetoken.kernel.triton.fused_fp8_linear import fused_fp8_expert_forward
+
+        return fused_fp8_expert_forward(
+            x,
+            self.weight_gate_up,
+            self.scale_gate_up,
+            self.weight_down,
+            self.scale_down,
             intermediate=self.intermediate,
             out_dtype=x.dtype,
         )

--- a/tests/test_qwen35_fp8_fused_e2e_xpu.py
+++ b/tests/test_qwen35_fp8_fused_e2e_xpu.py
@@ -1,0 +1,147 @@
+"""End-to-end: load_model() wires a block-FP8-quantized checkpoint's routed
+experts into the fully XPU-resident (fused) path and runs a real forward
+step (issue `moe-fused-fp8`, #181, part of the `quant-xpu` epic, #10).
+
+This is the "fused" sibling of ``test_qwen35_fp8_e2e_loader.py`` (the
+already-merged OFFLOAD e2e test, #152/#163): same checkpoint fixture (reused
+directly, not duplicated), different backend (``moe_backend="fused"``
+instead of ``"offload"``), proving the previously-missing gap -- loader.py's
+in-VRAM placement path did not know how to place a quantized bank at all.
+
+``xpu``-marked: :func:`freetoken.kernel.triton.fused_fp8_linear.
+fused_fp8_expert_forward` needs a real Triton-XPU compile, the same
+reasoning ``test_fused_fp8_linear_xpu.py`` documents -- no meaningful
+CPU-only synthetic-fixture version exists.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.models.loader import load_model
+
+from tests.test_qwen35_fp8_e2e_loader import E, H, HD, I, NH, NKV, V, _fp8_expert_weights  # noqa: F401
+
+
+@pytest.fixture(scope="module")
+def qwen35_fp8_ckpt_fused(tmp_path_factory):
+    """Same fixture shape as test_qwen35_fp8_e2e_loader.qwen35_fp8_ckpt,
+    built directly here (a module-scoped fixture from another test module
+    can't be reused as a fixture across files) via the same weight/config
+    builders that module already exports."""
+    import json
+
+    from safetensors.torch import save_file
+
+    from tests.test_qwen35_fp8_e2e_loader import BLOCK, L, _fp8_expert_weights
+
+    path = tmp_path_factory.mktemp("qwen35_fp8_fused")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": L,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NKV,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": HD,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "activation_scheme": "dynamic",
+            "weight_block_size": [BLOCK, BLOCK],
+        },
+    }
+    weights = _fp8_expert_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+@XPU
+@pytest.mark.xpu
+def test_load_model_places_fp8_experts_fully_resident(qwen35_fp8_ckpt_fused):
+    """The real point of #181: moe_backend="fused" no longer crashes on a
+    quantized bank -- each expert becomes a real _Qwen35Fp8Expert holding
+    packed weight/weight_scale_inv on the device, not a bf16 nn.Linear."""
+    from freetoken.models.qwen3_5_moe import _Qwen35Fp8Expert
+
+    model, _ = load_model(
+        qwen35_fp8_ckpt_fused, torch.device("xpu"), dtype=torch.bfloat16, moe_backend="fused"
+    )
+    experts = model.layers[0].mlp.experts
+    assert len(experts) == E
+    for expert in experts:
+        assert isinstance(expert, _Qwen35Fp8Expert)
+        assert expert.weight_gate_up.device.type == "xpu"
+        assert expert.weight_gate_up.dtype == torch.float8_e4m3fn
+
+
+@XPU
+@pytest.mark.xpu
+def test_fp8_fused_forward_step_produces_finite_logits(qwen35_fp8_ckpt_fused):
+    """A real forward pass through the fully-resident block-FP8 experts --
+    the native fused_fp8_expert_forward kernel, no host round-trip at all."""
+    from freetoken.attention.triton import TritonAttentionBackend
+    from freetoken.core import Batch, Context, Req, SamplingParams, reset_global_ctx, set_global_ctx
+    from freetoken.kvcache.base import BaseKVCachePool
+
+    model, _ = load_model(
+        qwen35_fp8_ckpt_fused, torch.device("xpu"), dtype=torch.bfloat16, moe_backend="fused"
+    )
+    seq = torch.randint(0, V, (5,), device="xpu")
+    T = seq.shape[0]
+
+    req = Req(
+        input_ids=seq,
+        table_idx=0,
+        cached_len=0,
+        output_len=1,
+        uid=0,
+        sampling_params=SamplingParams(),
+        cache_handle=None,
+    )
+    batch = Batch(reqs=[req], phase="prefill")
+    batch.input_ids = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.positions = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.out_loc = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.extend_lens = torch.tensor([T])
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(model.config, 1, 1024, torch.device("xpu"), torch.bfloat16)
+    pt = torch.zeros((1, 1024), dtype=torch.int32, device="xpu")
+    pt[0, :T] = torch.arange(T, device="xpu")
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    backend = TritonAttentionBackend(model.config)
+    backend.prepare_metadata(batch)
+    ctx.attn_backend = backend
+    ctx.model = model
+    set_global_ctx(ctx)
+    ctx._batch = batch
+    try:
+        logits = model.forward(batch.input_ids, batch.positions, batch.out_loc)
+    finally:
+        reset_global_ctx()
+
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits.float()).all()


### PR DESCRIPTION
## Summary
Part of the `quant-xpu` epic (#10), the block-FP8 sibling of #180 (MXFP4, merged). Same gap: `loader.py`'s in-VRAM (`moe_backend="fused"`) path had no branch for a real `Fp8BlockExpertBank` and would crash on one.

- New `_Qwen35Fp8Expert` (`qwen3_5_moe/__init__.py`): holds a single expert's packed `weight`/`weight_scale_inv` as device buffers and runs `fused_fp8_expert_forward` (the native packed-GEMM kernel, #163) directly. Same `(x) -> tensor` interface as `_Qwen35Expert`/`_Qwen35MxfpExpert`, so `_forward_inram` needs no changes. Added to `_ensure_torch()`'s `nn.Module` rebind order.
- `loader.py`: `_place_fp8_expert_weights` (mirrors `_place_mxfp4_expert_weights` exactly) replaces a MoE layer's `experts` `ModuleList` with device-resident `_Qwen35Fp8Expert` instances built from the streamed `Fp8BlockExpertBank` rows; `_place_expert_weights_any` now dispatches by bank type across all three shapes (plain bf16, `MxfpExpertBank`, `Fp8BlockExpertBank`).

Sibling issue #182 (INT8) adds its own branch to `_place_expert_weights_any` — not done here.

## Test plan
- [x] `tests/test_qwen35_fp8_fused_e2e_xpu.py` (`xpu`-marked, same reasoning as #180's test): reuses `test_qwen35_fp8_e2e_loader.py`'s existing weight/fixture builders (not duplicated) with `moe_backend="fused"` instead of `"offload"`. Confirms every expert is a real `_Qwen35Fp8Expert` with device-resident packed buffers, and a real forward pass produces finite logits. **Both tests run and pass on real B70 hardware.**
- [x] Existing FP8/MXFP4/offload regression tests: `test_qwen35_offload_xpu.py`, `test_qwen35_fp8_e2e_loader.py`, `test_qwen35_mxfp4_e2e_loader.py` — all pass, no regression.
- [x] `.venv` (torch-free) full suite: 205 passed, 80 skipped, 0 failed.
- [x] `.venv-xpu -m "not xpu"` full suite: 505 passed, 1 skipped, 1 pre-existing unrelated failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`, reproduces identically on a clean `main` checkout).

Closes #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5