### PR TITLE
feat(moe): wire compressed-tensors INT8 packed banks into the in-VRAM fused expert path (issue #182)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -441,22 +441,56 @@ def _place_fp8_expert_weights(model, gate_up_banks, down_banks, device) -> None:
         )
 
 
+def _place_int8_expert_weights(model, gate_up_banks, down_banks, device) -> None:
+    """Build fully XPU-resident compressed-tensors INT8 expert modules from
+    packed banks (issue `moe-fused-int8`, #182, part of the `quant-xpu`
+    epic, #10). The INT8 sibling of :func:`_place_mxfp4_expert_weights` /
+    :func:`_place_fp8_expert_weights` -- see their docstrings for the shared
+    rationale."""
+    import torch.nn as nn
+
+    from freetoken.models.qwen3_5_moe import _Qwen35Int8Expert
+
+    intermediate = int(getattr(model.config, "moe_intermediate_size", 0))
+    for layer_id in _moe_layers(model.config):
+        moe = getattr(getattr(model, "layers", [None] * (layer_id + 1))[layer_id], "mlp", None)
+        if getattr(moe, "experts", None) is None:
+            continue
+        gu_bank = gate_up_banks[layer_id]
+        dn_bank = down_banks[layer_id]
+        num_experts = gu_bank.weight_packed.shape[0]
+        moe.experts = nn.ModuleList(
+            _Qwen35Int8Expert(
+                gu_bank.weight_packed[e].to(device),
+                gu_bank.weight_scale[e].to(device),
+                dn_bank.weight_packed[e].to(device),
+                dn_bank.weight_scale[e].to(device),
+                intermediate=intermediate,
+                k_gate_up=gu_bank.k,
+                k_down=dn_bank.k,
+            )
+            for e in range(num_experts)
+        )
+
+
 def _place_expert_weights_any(model, gate_up_banks, down_banks, device) -> None:
     """Dispatch the in-VRAM (``moe_backend="fused"``) expert placement by
     bank type: a plain bf16 stacked tensor goes through
     :func:`_place_expert_weights` unchanged (every existing bf16 test);
-    a packed :class:`~freetoken.models.weight.MxfpExpertBank` (issue #180)
-    or :class:`~freetoken.models.weight.Fp8BlockExpertBank` (issue #181)
-    goes through its own placement function instead. INT8 (#182) is the
-    remaining sibling issue that adds its own branch here.
+    a packed :class:`~freetoken.models.weight.MxfpExpertBank` (issue #180),
+    :class:`~freetoken.models.weight.Fp8BlockExpertBank` (issue #181), or
+    :class:`~freetoken.models.weight.Int8ExpertBank` (issue #182) goes
+    through its own placement function instead.
     """
-    from freetoken.models.weight import Fp8BlockExpertBank, MxfpExpertBank
+    from freetoken.models.weight import Fp8BlockExpertBank, Int8ExpertBank, MxfpExpertBank
 
     first = next((b for b in gate_up_banks if b is not None), None)
     if isinstance(first, MxfpExpertBank):
         _place_mxfp4_expert_weights(model, gate_up_banks, down_banks, device)
     elif isinstance(first, Fp8BlockExpertBank):
         _place_fp8_expert_weights(model, gate_up_banks, down_banks, device)
+    elif isinstance(first, Int8ExpertBank):
+        _place_int8_expert_weights(model, gate_up_banks, down_banks, device)
     else:
         _place_expert_weights(model, gate_up_banks, down_banks)
 

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -559,6 +559,7 @@ def _ensure_torch() -> None:
         "_Qwen35Expert",
         "_Qwen35MxfpExpert",
         "_Qwen35Fp8Expert",
+        "_Qwen35Int8Expert",
         "_Qwen35DecoderLayer",
         "Qwen3_5MoEForCausalLM",
     )
@@ -1773,6 +1774,59 @@ class _Qwen35Fp8Expert:
             self.weight_down,
             self.scale_down,
             intermediate=self.intermediate,
+            out_dtype=x.dtype,
+        )
+
+
+class _Qwen35Int8Expert:
+    """A single compressed-tensors pack-quantized INT8 MoE expert, fully
+    XPU-resident (issue `moe-fused-int8`, #182, part of the `quant-xpu`
+    epic, #10).
+
+    The INT8 sibling of :class:`_Qwen35MxfpExpert` / :class:`_Qwen35Fp8Expert`:
+    holds the checkpoint's packed ``weight_packed``/``weight_scale`` (the
+    same per-expert tensors :class:`freetoken.models.weight.Int8ExpertBank`
+    streams for the offload backend, moved onto the device instead of
+    staying on host) and never materializes a dequantized weight --
+    :func:`freetoken.kernel.triton.fused_int8_linear.fused_int8_expert_forward`
+    runs the native packed GEMM directly, the same kernel the offload
+    backend's dequant-at-compute path (#163) uses. ``k_gate_up``/``k_down``
+    (the real logical in-features per projection, an architecture constant
+    shared by every expert -- see :class:`Int8ExpertBank`'s own docstring)
+    are plain ints, not tensors, so no buffer is needed for them.
+    """
+
+    def __init__(
+        self,
+        weight_packed_gate_up: torch.Tensor,
+        weight_scale_gate_up: torch.Tensor,
+        weight_packed_down: torch.Tensor,
+        weight_scale_down: torch.Tensor,
+        intermediate: int,
+        k_gate_up: int,
+        k_down: int,
+    ) -> None:
+        super().__init__()
+        self.register_buffer("weight_packed_gate_up", weight_packed_gate_up, persistent=False)
+        self.register_buffer("weight_scale_gate_up", weight_scale_gate_up, persistent=False)
+        self.register_buffer("weight_packed_down", weight_packed_down, persistent=False)
+        self.register_buffer("weight_scale_down", weight_scale_down, persistent=False)
+        self.intermediate = intermediate
+        self.k_gate_up = k_gate_up
+        self.k_down = k_down
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        from freetoken.kernel.triton.fused_int8_linear import fused_int8_expert_forward
+
+        return fused_int8_expert_forward(
+            x,
+            self.weight_packed_gate_up,
+            self.weight_scale_gate_up,
+            self.weight_packed_down,
+            self.weight_scale_down,
+            intermediate=self.intermediate,
+            k_gate_up=self.k_gate_up,
+            k_down=self.k_down,
             out_dtype=x.dtype,
         )
 

--- a/tests/test_qwen35_int8_fused_e2e_xpu.py
+++ b/tests/test_qwen35_int8_fused_e2e_xpu.py
@@ -1,0 +1,158 @@
+"""End-to-end: load_model() wires a compressed-tensors pack-quantized
+INT8 checkpoint's routed experts into the fully XPU-resident (fused) path
+and runs a real forward step (issue `moe-fused-int8`, #182, part of the
+`quant-xpu` epic, #10).
+
+This is the "fused" sibling of ``test_qwen35_int8_e2e_loader.py`` (the
+already-merged OFFLOAD e2e test, #154/#163): same checkpoint fixture (reused
+directly, not duplicated), different backend (``moe_backend="fused"``
+instead of ``"offload"``), proving the previously-missing gap -- loader.py's
+in-VRAM placement path did not know how to place a quantized bank at all.
+
+``xpu``-marked: :func:`freetoken.kernel.triton.fused_int8_linear.
+fused_int8_expert_forward` needs a real Triton-XPU compile, the same
+reasoning ``test_fused_int8_linear_xpu.py`` documents -- no meaningful
+CPU-only synthetic-fixture version exists.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+XPU = pytest.mark.skipif(not torch.xpu.is_available(), reason="no XPU available")
+
+from freetoken.models.loader import load_model
+
+from tests.test_qwen35_int8_e2e_loader import E, GROUP_SIZE, H, I, V, _int8_expert_weights
+
+
+@pytest.fixture(scope="module")
+def qwen35_int8_ckpt_fused(tmp_path_factory):
+    """Same fixture shape as test_qwen35_int8_e2e_loader.qwen35_int8_ckpt,
+    built directly here (a module-scoped fixture from another test module
+    can't be reused as a fixture across files) via the same weight/config
+    builders that module already exports."""
+    import json
+
+    from safetensors.torch import save_file
+
+    path = tmp_path_factory.mktemp("qwen35_int8_fused")
+    text_config = {
+        "hidden_size": H,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": I,
+        "shared_expert_intermediate_size": I,
+        "vocab_size": V,
+        "max_position_embeddings": 128,
+        "head_dim": 16,
+        "attn_output_gate": False,
+        "partial_rotary_factor": 0.5,
+        "full_attention_interval": 1,
+        "layer_types": ["full_attention"],
+        "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.5},
+    }
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "tie_word_embeddings": True,
+        "text_config": text_config,
+        "quantization_config": {
+            "quant_method": "compressed-tensors",
+            "config_groups": {
+                "group_0": {
+                    "format": "pack-quantized",
+                    "weights": {
+                        "num_bits": 8,
+                        "type": "int",
+                        "strategy": "group",
+                        "group_size": GROUP_SIZE,
+                        "symmetric": True,
+                        "actorder": "static",
+                    },
+                }
+            },
+        },
+    }
+    weights = _int8_expert_weights()
+    (path / "config.json").write_text(json.dumps(config))
+    save_file({k: v.contiguous() for k, v in weights.items()}, str(path / "model.safetensors"))
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {k: "model.safetensors" for k in weights}})
+    )
+    return str(path)
+
+
+@XPU
+@pytest.mark.xpu
+def test_load_model_places_int8_experts_fully_resident(qwen35_int8_ckpt_fused):
+    """The real point of #182: moe_backend="fused" no longer crashes on a
+    quantized bank -- each expert becomes a real _Qwen35Int8Expert holding
+    packed weight_packed/weight_scale on the device, not a bf16 nn.Linear."""
+    from freetoken.models.qwen3_5_moe import _Qwen35Int8Expert
+
+    model, _ = load_model(
+        qwen35_int8_ckpt_fused, torch.device("xpu"), dtype=torch.bfloat16, moe_backend="fused"
+    )
+    experts = model.layers[0].mlp.experts
+    assert len(experts) == E
+    for expert in experts:
+        assert isinstance(expert, _Qwen35Int8Expert)
+        assert expert.weight_packed_gate_up.device.type == "xpu"
+        assert expert.weight_packed_gate_up.dtype == torch.int32
+        assert expert.k_gate_up == H
+        assert expert.k_down == I
+
+
+@XPU
+@pytest.mark.xpu
+def test_int8_fused_forward_step_produces_finite_logits(qwen35_int8_ckpt_fused):
+    """A real forward pass through the fully-resident INT8 experts -- the
+    native fused_int8_expert_forward kernel, no host round-trip at all."""
+    from freetoken.attention.triton import TritonAttentionBackend
+    from freetoken.core import Batch, Context, Req, SamplingParams, reset_global_ctx, set_global_ctx
+    from freetoken.kvcache.base import BaseKVCachePool
+
+    model, _ = load_model(
+        qwen35_int8_ckpt_fused, torch.device("xpu"), dtype=torch.bfloat16, moe_backend="fused"
+    )
+    seq = torch.randint(0, V, (5,), device="xpu")
+    T = seq.shape[0]
+
+    req = Req(
+        input_ids=seq,
+        table_idx=0,
+        cached_len=0,
+        output_len=1,
+        uid=0,
+        sampling_params=SamplingParams(),
+        cache_handle=None,
+    )
+    batch = Batch(reqs=[req], phase="prefill")
+    batch.input_ids = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.positions = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.out_loc = torch.arange(T, dtype=torch.long, device="xpu")
+    batch.extend_lens = torch.tensor([T])
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(model.config, 1, 1024, torch.device("xpu"), torch.bfloat16)
+    pt = torch.zeros((1, 1024), dtype=torch.int32, device="xpu")
+    pt[0, :T] = torch.arange(T, device="xpu")
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    backend = TritonAttentionBackend(model.config)
+    backend.prepare_metadata(batch)
+    ctx.attn_backend = backend
+    ctx.model = model
+    set_global_ctx(ctx)
+    ctx._batch = batch
+    try:
+        logits = model.forward(batch.input_ids, batch.positions, batch.out_loc)
+    finally:
+        reset_global_ctx()
+
+    assert logits.shape == (1, V)
+    assert torch.isfinite(logits.float()).all()


### PR DESCRIPTION
## Summary
Part of the `quant-xpu` epic (#10), the INT8 sibling of #180 (MXFP4) and #181 (FP8, both merged) — the last of the three quant formats. Completes `loader.py`'s in-VRAM (`moe_backend="fused"`) expert placement dispatch across every packed bank type this port supports.

- New `_Qwen35Int8Expert` (`qwen3_5_moe/__init__.py`): holds a single expert's packed `weight_packed`/`weight_scale` as device buffers (plus `k_gate_up`/`k_down`, the real logical in-features per projection — plain ints, no buffer needed) and runs `fused_int8_expert_forward` (the native packed-GEMM kernel, #163) directly. Same `(x) -> tensor` interface as the other three expert classes, so `_forward_inram` needs no changes. Added to `_ensure_torch()`'s `nn.Module` rebind order.
- `loader.py`: `_place_int8_expert_weights` (mirrors the MXFP4/FP8 placement functions exactly) replaces a MoE layer's `experts` `ModuleList` with device-resident `_Qwen35Int8Expert` instances built from the streamed `Int8ExpertBank` rows; `_place_expert_weights_any` now dispatches across all four bank shapes (plain bf16, `MxfpExpertBank`, `Fp8BlockExpertBank`, `Int8ExpertBank`).

With this, the `quant-xpu` epic's (#10) remaining fused-path gap is closed for MXFP4/FP8/INT8 — GPTQ's own fused-native path was already offload-only by design (#139), not part of this epic's split.

## Test plan
- [x] `tests/test_qwen35_int8_fused_e2e_xpu.py` (`xpu`-marked, same reasoning as #180/#181's tests): reuses `test_qwen35_int8_e2e_loader.py`'s existing weight/fixture builders (not duplicated) with `moe_backend="fused"` instead of `"offload"`. Confirms every expert is a real `_Qwen35Int8Expert` with device-resident packed buffers (and the right `k_gate_up`/`k_down`), and a real forward pass produces finite logits. **Both tests run and pass on real B70 hardware.**
- [x] Existing INT8/FP8/MXFP4/offload regression tests: `test_qwen35_offload_xpu.py`, `test_qwen35_int8_e2e_loader.py`, `test_qwen35_fp8_e2e_loader.py`, `test_qwen35_mxfp4_e2e_loader.py` — all pass, no regression.
- [x] `.venv` (torch-free) full suite: 205 passed, 81 skipped, 0 failed.
- [x] `.venv-xpu -m "not xpu"` full suite: 505 passed, 1 skipped, 1 pre-existing unrelated failure (`test_moe_hybrid_profile.py::test_fetch_fraction_none_when_no_profile`, reproduces identically on a clean `main` checkout).

Closes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5