### PR TITLE
fix(models): qsa_attend_mask's open-group tail must be per-query, not global (#208 follow-up)

### DIFF
--- a/python/freetoken/models/qwen4_exp/__init__.py
+++ b/python/freetoken/models/qwen4_exp/__init__.py
@@ -313,17 +313,23 @@ def qsa_sparse_attend(
 
 
 def qsa_attend_mask(
-    topk_idx: torch.Tensor, index_ratio: int, query_positions: torch.Tensor, num_complete_blocks: int, seq_len: int
+    topk_idx: torch.Tensor, index_ratio: int, query_positions: torch.Tensor, seq_len: int
 ) -> torch.Tensor:
-    """The full attend mask for one QSA layer: selected-block tokens UNION the trailing
-    incomplete-block tokens (always attended raw, see module note above), AND'd with causality."""
+    """The full attend mask for one QSA layer: selected-block tokens UNION each query's own
+    OPEN GROUP (upstream ``qsa_sparse.py`` module docstring, step 5: "expand them to token
+    indices plus the causal tail of the open group") -- the raw tokens of the still-forming
+    block a query's own position falls in are always attended, since that block has no
+    compressed representative yet to be top-k-selected. This is PER-QUERY (each row's open
+    group is ``[(pos // index_ratio) * index_ratio, pos]``), not a single global trailing
+    region for the whole sequence -- a query early in a long, block-aligned sequence has an
+    open group near its own position, not near the sequence's end."""
     device = topk_idx.device
     block_mask = qsa_expand_block_mask(topk_idx, index_ratio, seq_len)
-    tail_start = num_complete_blocks * index_ratio
     positions = torch.arange(seq_len, device=device)
-    tail_mask = positions >= tail_start
+    group_start = (query_positions // index_ratio) * index_ratio
+    open_mask = (positions[None, :] >= group_start[:, None]) & (positions[None, :] <= query_positions[:, None])
     causal = positions[None, :] <= query_positions[:, None]
-    return (block_mask | tail_mask[None, :]) & causal
+    return (block_mask | open_mask) & causal
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_models_qwen4_qsa.py
+++ b/tests/test_models_qwen4_qsa.py
@@ -151,12 +151,32 @@ def test_qsa_attend_mask_includes_trailing_incomplete_block_unconditionally():
     T, ratio = 10, 4  # 2 complete blocks (0-3, 4-7), trailing tokens 8-9 incomplete
     topk_idx = torch.tensor([[-1, -1]])  # no block selected at all for this query
     query_positions = torch.tensor([9])
-    mask = qsa_attend_mask(topk_idx, ratio, query_positions, num_complete_blocks=2, seq_len=T)
+    mask = qsa_attend_mask(topk_idx, ratio, query_positions, seq_len=T)
     assert mask.shape == (1, T)
     # tokens 8, 9 (trailing incomplete block) must be visible even with no block selected
     assert bool(mask[0, 8]) and bool(mask[0, 9])
     # no earlier (compressed-block) token is visible since nothing was selected
     assert not bool(mask[0, :8].any())
+
+
+def test_qsa_attend_mask_open_group_is_per_query_not_a_global_tail():
+    """Real bug this pins (found running the port on real B70 hardware): for a long,
+    EXACTLY block-aligned sequence, an early query (whose own block hasn't closed yet, so
+    it has no causally-visible compressed blocks at all) must still see its own open
+    group's raw prefix -- not zero tokens. A global "trailing incomplete block" concept
+    (the old, wrong implementation) only covers rows near the END of the sequence; upstream
+    ``qsa_sparse.py``'s own module docstring (step 5) says the always-visible region is
+    "the causal tail of the open group", which is PER QUERY."""
+    T, ratio = 40, 4  # exactly 10 complete blocks, no global trailing incomplete region at all
+    topk_idx = torch.full((T, 1), -1, dtype=torch.long)  # nothing selected for any query
+    query_positions = torch.arange(T)
+    mask = qsa_attend_mask(topk_idx, ratio, query_positions, seq_len=T)
+    # every query must see at least itself -- an all-false row means softmax(-inf) -> NaN
+    assert mask.any(dim=-1).all()
+    # query 0's open group is just position 0 (block 0 spans 0..3, not yet closed)
+    assert mask[0].tolist() == [i == 0 for i in range(T)]
+    # query 2's open group is positions 0..2 (still inside block 0, not yet closed)
+    assert mask[2, :3].all() and not mask[2, 3:].any()
 
 
 def test_qsa_sparse_attend_matches_dense_reference_when_nothing_is_pruned():


### PR DESCRIPTION
## Why
Real bug found while running #206/#208's primitives on the actual B70 (mid-#198 hardware verification, not caught by the existing CPU test suite): `qsa_attend_mask` computed a single GLOBAL "trailing incomplete block" region (`num_complete_blocks * index_ratio`) from the whole sequence's length, applied uniformly to every query row.

For a long, exactly block-aligned sequence (e.g. 40 tokens, `index_ratio=4` → 10 complete blocks, no global trailing region at all), any query whose own block hadn't closed yet — the first few tokens — got **zero** visible positions: an all `-inf` softmax row, confirmed as real NaN output on the B70 (`xpu:0`).

Upstream's own `qsa_sparse.py` module docstring (step 5) is explicit: the always-visible region is "the causal tail of the **open group**" — per query, not a single tail for the whole batch.

## Fix
`qsa_attend_mask` now computes each row's own open-group span (`[(pos // index_ratio) * index_ratio, pos]`) from its own query position, instead of a shared `num_complete_blocks` scalar (parameter removed). The existing "trailing incomplete block" test is unchanged in behavior (a query at the sequence's actual end still gets the identical result — that's the case the old formula happened to get right). Added a regression test pinning the exact 40-token/ratio-4 scenario that produced NaN on real hardware.

## Test plan
- [x] `.venv-xpu -m "not xpu"`: 563 passed, 1 pre-existing unrelated failure (`test_fetch_fraction_none_when_no_profile`, present on `main` before this branch), 1 skipped, 117 deselected
- [x] Real B70/XPU forward pass (`xpu:0`): before the fix, `torch.isfinite(out).all()` was `False` (NaN); after, `True`, and every query row has `mask.any(dim=-1)` true

Parent epic: #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDGZPcGhtd1J6MnZvRfD5