### PR TITLE
fix(models): qwen3/qwen3_moe wrote KV cache entries to the wrong physical slot on real hardware

### DIFF
--- a/python/freetoken/models/qwen3/__init__.py
+++ b/python/freetoken/models/qwen3/__init__.py
@@ -188,12 +188,20 @@ class _Qwen3Attention(nn.Module):
         self.register_buffer("inv_freq", inv_freq)
 
     def _rope(self, x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
+        # Half-split (rotate_half) RoPE -- matches ``cos``/``sin``'s own
+        # ``cat(freqs, freqs)`` construction below and the real HF Qwen3
+        # convention (confirmed against a real downloaded checkpoint's
+        # generated text; the previous ``x[..., ::2]``/``x[..., 1::2]``
+        # interleaved split did not match this cos/sin layout and produced
+        # degenerate output -- see qwen3_5_moe's own ``_rotate_half``,
+        # which already documents this is NOT the interleaved variant).
         freqs = torch.outer(pos.to(torch.float32), self.inv_freq)  # [N, D/2]
         emb = torch.cat((freqs, freqs), dim=-1)  # [N, D]
         cos = emb.cos()[None, :, :]
         sin = emb.sin()[None, :, :]
         x_f = x.to(torch.float32)
-        x1, x2 = x_f[..., ::2], x_f[..., 1::2]
+        half = x_f.shape[-1] // 2
+        x1, x2 = x_f[..., :half], x_f[..., half:]
         rotated = torch.cat((-x2, x1), dim=-1)
         return (x_f * cos + rotated * sin).to(x.dtype)
 
@@ -204,7 +212,19 @@ class _Qwen3Attention(nn.Module):
         v = self.v_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
         q = self._rope(self.q_norm(q), positions)
         k = self._rope(self.k_norm(k), positions)
-        ctx.kv_cache.write_kv(k, v, positions, self.layer_id)
+        # write_kv's third argument is out_loc -- PHYSICAL pool slots, not
+        # logical token positions. These only coincide under an identity
+        # page table; MHAKVCache's real per-request free-list allocator is
+        # NOT identity (slot 0 is a reserved dummy/padding slot, so the
+        # first real token of any request lands on slot >= 1, never slot 0
+        # -- see kvcache/mha_pool.py). Passing raw `positions` here silently
+        # wrote every token to the wrong slot on real hardware: a real
+        # checkpoint's generation was degenerate garbage even after the
+        # rope fix, traced to this exact line via a `read_kv` == pre-write
+        # `v` round-trip check that failed only under MHAKVCache, not the
+        # identity-mapped BaseKVCachePool used in isolated tests.
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k, v, out_loc, self.layer_id)
         out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, table_idx=table_idx)
         return self.o_proj(out.transpose(0, 1).contiguous().reshape(bsz, -1))
 

--- a/python/freetoken/models/qwen3_moe/__init__.py
+++ b/python/freetoken/models/qwen3_moe/__init__.py
@@ -261,14 +261,22 @@ class _Qwen3Attention(nn.Module):
     def _rope(self, x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
         # x: [H, N, D] (head-major); pos: [N] absolute positions (rotate_half RoPE).
         # The token dim is the *middle* one here, so the per-token cos/sin must index dim 1.
+        #
+        # Half-split (rotate_half), NOT interleaved -- matches the ``cos``/``sin``
+        # ``cat(freqs, freqs)`` layout below and the real HF Qwen3 convention
+        # (confirmed against a real downloaded checkpoint's generated text on
+        # this port's own qwen3 dense sibling, which had this exact bug: the
+        # previous ``x[..., ::2]``/``x[..., 1::2]`` interleaved split did not
+        # match this cos/sin layout and produced degenerate/wrong output. See
+        # qwen3_5_moe's own ``_rotate_half``, which already documents this is
+        # NOT the interleaved variant.
         freqs = torch.outer(pos.to(torch.float32), self.inv_freq)  # [N, D/2]
-        # Expand to the full head dim [N, D] (interleaved (x, y) pairs) and
-        # place it on the token (middle) dim so it broadcasts over [H, N, D].
         emb = torch.cat((freqs, freqs), dim=-1)  # [N, D]
         cos = emb.cos()[None, :, :]  # [1, N, D]
         sin = emb.sin()[None, :, :]  # [1, N, D]
         x_f = x.to(torch.float32)
-        x1, x2 = x_f[..., ::2], x_f[..., 1::2]
+        half = x_f.shape[-1] // 2
+        x1, x2 = x_f[..., :half], x_f[..., half:]
         rotated = torch.cat((-x2, x1), dim=-1)
         return (x_f * cos + rotated * sin).to(x.dtype)
 
@@ -302,12 +310,23 @@ class _Qwen3Attention(nn.Module):
         v = self.v_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
         q = self._rope(self.q_norm(q), positions)
         k = self._rope(self.k_norm(k), positions)
-        # Append this request's K/V to the pool. ``positions`` here is this
-        # request's token positions (the decoder layer passed
-        # positions[token_slice]); the new token's out_loc slot equals its
-        # absolute position under the identity page table, so index out_loc by
-        # this request's positions rather than the whole-batch out_loc.
-        ctx.kv_cache.write_kv(k, v, positions, self.layer_id)
+        # Append this request's K/V to the pool. write_kv's third argument is
+        # out_loc -- PHYSICAL pool slots, not logical token positions. These
+        # only coincide under an identity page table; MHAKVCache's real
+        # per-request free-list allocator is NOT identity (slot 0 is a
+        # reserved dummy/padding slot, so the first real token of any
+        # request lands on slot >= 1, never slot 0 -- see
+        # kvcache/mha_pool.py). The previous "identity page table" comment
+        # here documented a real, incorrect assumption: passing raw
+        # `positions` silently wrote every token to the wrong slot on real
+        # hardware (confirmed via a `read_kv` == pre-write `v` round-trip
+        # check on qwen3's identical pattern, which failed only under
+        # MHAKVCache, not the identity-mapped BaseKVCachePool used in
+        # isolated/synthetic tests -- which is why this was never caught
+        # against a synthetic fixture). Translate positions -> slots via the
+        # page table, exactly as read_kv already does internally.
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k, v, out_loc, self.layer_id)
         # ``table_idx`` identifies *this* request (the decoder layer runs each
         # request's layers on its own hidden slice, so q/k/v hold only this
         # request's new tokens, not the whole batch's). The backend uses it to

--- a/tests/test_models_qwen3_dense_e2e.py
+++ b/tests/test_models_qwen3_dense_e2e.py
@@ -177,3 +177,68 @@ def test_engine_greedy_is_deterministic(tmp_path):
     b = build()
     assert a == b
     assert len(a[0]) == 3
+
+
+def test_write_kv_uses_physical_pool_slots_not_logical_positions(tmp_path):
+    """Real bug found running a real trained checkpoint's generation through
+    the actual Engine (not a synthetic fixture): ``write_kv``'s third
+    argument is ``out_loc`` -- PHYSICAL pool slots -- not logical token
+    positions. These only coincide under an identity page table.
+    ``MHAKVCache`` (the real per-request free-list allocator every live
+    Engine uses, not ``BaseKVCachePool``) reserves slot 0 as a dummy/padding
+    slot, so the first real token of any request lands on slot >= 1, never
+    slot 0 -- the two spaces are NOT identity for any real request. Passing
+    raw ``positions`` here silently wrote every token to the wrong physical
+    slot: real (non-synthetic) generation was degenerate garbage even after
+    an unrelated RoPE-orientation bug was independently fixed, traced to
+    this exact call via a ``read_kv`` == pre-write value round-trip check
+    that failed only under the real ``MHAKVCache`` allocator, never under a
+    synthetic fixture's identity-mapped pool -- which is why no existing
+    synthetic-checkpoint test (including this file's own
+    ``test_engine_generate_prefill_and_decode``/``test_engine_greedy_is_deterministic``,
+    both of which only assert "produces some deterministic in-range token",
+    not correctness against a reference) ever caught it.
+
+    This pins the fix directly: after a real Engine's real per-request slot
+    allocation (never slot 0 for a real request's first token), the value
+    written into the pool and the value read back for that same position
+    must be byte-identical -- proof ``write_kv`` received real physical
+    slots, not raw positions.
+    """
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+
+    # Spy on the KV pool's own write_kv -- the ONLY reliable way to see what
+    # out_loc argument the model code actually passed (not what a test
+    # independently recomputes, which would pass vacuously regardless of
+    # the model code's real behavior).
+    captured = {}
+    pool = engine.ctx.kv_cache
+    orig_pool_write_kv = pool.write_kv
+
+    def spy_write_kv(k, v, out_loc, layer_id=0):
+        if layer_id == 0 and "out_loc" not in captured:
+            captured["out_loc"] = out_loc.clone()
+        return orig_pool_write_kv(k, v, out_loc, layer_id)
+
+    pool.write_kv = spy_write_kv
+    try:
+        _add_prompt(engine, output_len=1)
+        engine.generate()
+    finally:
+        pool.write_kv = orig_pool_write_kv
+
+    table_idx = 0
+    positions = torch.arange(3)  # the prompt is 3 tokens, see _add_prompt
+    expected_slots = engine.ctx.page_table[table_idx, positions.long()]
+
+    # A real request's first token never lands on the reserved slot 0 --
+    # confirms the allocator genuinely isn't identity for this run.
+    assert 0 not in expected_slots.tolist()
+    # The actual out_loc write_kv received must be the PHYSICAL pool slots
+    # from the page table, not the raw logical positions [0, 1, 2] -- this
+    # is what the real bug got wrong (verified this assertion fails without
+    # the fix: reverting the out_loc translation makes captured["out_loc"]
+    # equal positions instead of the real allocated slots).
+    assert captured["out_loc"].equal(expected_slots)
+    assert not captured["out_loc"].equal(positions)


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 90** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit efcac78](https://github.com/Performant-Labs/FreeToken-Intel/commit/efcac78bb7e00d182cd7bbce311dbbf108283fe5) · run [#33911839977](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33911839977) · 2026-09-04 13:38 MDT / 2026-09-04 19:38 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Why

This port's `qwen3` (dense) architecture was marked "working" per the compat matrix, but had never been run against a real trained checkpoint with real generation — only synthetic random-weight fixtures. Running it for real (`Qwen/Qwen3-0.6B`, via `transformers.AutoModelForCausalLM` as the reference oracle) surfaced two real, independent bugs, both invisible until now.

## Bug 1: RoPE orientation

`_rope` built `cos`/`sin` half-split style (`cat(freqs, freqs)`) but split `x` interleaved (`x[..., ::2]`, `x[..., 1::2]`) instead of half-split (`x[..., :half]`, `x[..., half:]`). Confirmed against `transformers`' real `rotate_half`/`apply_rotary_pos_emb`. Fixing this alone was necessary but not sufficient — output changed but was still garbage.

## Bug 2: KV cache addressing (the actual root cause of the remaining garbage)

`write_kv`'s third argument is `out_loc` — **physical pool slots**, not logical token positions. These only coincide under an identity page table. `MHAKVCache` (the real per-request free-list allocator every live `Engine` uses, not `BaseKVCachePool`) reserves slot 0 as dummy/padding, so the first real token of any request lands on slot ≥ 1, never slot 0 — the two spaces are never identity for a real request.

Passing raw `positions` here silently wrote every token to the wrong physical slot; `read_kv` correctly translates positions → slots via the page table, so it read back garbage. Root-caused via a `read_kv(write_kv(v)) == v` round-trip invariant check that held under an isolated `BaseKVCachePool` (identity page table) but failed by exactly the magnitude of the real model's corrupted output under the real engine's `MHAKVCache`.

Fixed both call sites (`qwen3`, `qwen3_moe`) to translate positions → physical slots via `ctx.page_table` before calling `write_kv`, exactly as `read_kv` already does internally.

## Result

Real checkpoint generation for "What is the capital of France? Answer in one word." now correctly produces "...France's capital is Paris...", confirmed on CPU and on the real B70 (`xpu:0`).

## Scope note

The identical `positions`-as-`out_loc` bug also appears in `qwen3_5_moe` and `deepseek_v4` (same documented "under the identity page table" assumption in both files) — **NOT fixed in this PR**, flagged for separate follow-up since every one of those architectures has the same real-hardware corruption risk.

## Test plan
- [x] New regression test (`test_write_kv_uses_physical_pool_slots_not_logical_positions`) pins the actual bug class: verified to fail with the bug reintroduced (`out_loc` becomes `[0,1,2]` instead of the real allocated `[1,2,3]`) and pass with the fix.
- [x] `.venv` (torch-free): 208 passed
- [x] `.venv-xpu -m "not xpu"`: 588 passed, 1 pre-existing unrelated flake (`test_fetch_fraction_none_when_no_profile`), 1 skipped, 117 deselected
- [x] Real generation on a real downloaded checkpoint (`Qwen/Qwen3-0.6B`), CPU and real B70 hardware, coherent output confirmed on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix half-split RoPE orientation in `qwen3` and `qwen3_moe`.

- Translate logical positions to physical KV slots via page table.

- Add regression test capturing actual `write_kv` slot usage.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["qwen3/qwen3_moe _rope"] -- "half-split fix" --> B["RoPE orientation"]
  C["qwen3/qwen3_moe forward"] -- "out_loc page_table" --> D["KV cache physical slots"]
  E["test_models_qwen3_dense_e2e.py"] -- "spy write_kv" --> F["Regression test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Fix RoPE and KV slot translation in qwen3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3/__init__.py

<ul><li>Change <code>_rope</code> x split from interleaved <code>[::2]/[1::2]</code> to half-split <br><code>[:half]/[half:]</code>.<br> <li> In <code>forward</code>, compute <code>out_loc</code> via <code>ctx.page_table[table_idx, </code><br><code>positions.long()]</code> and pass it to <code>write_kv</code>.<br> <li> Update comments explaining physical pool slots vs logical positions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/234/files#diff-ff0e066d9bc29766aee298941dcdf422d391ce9243d0eeb8ee2abf648dde401e">+22/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Fix RoPE and KV slot translation in qwen3_moe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen3_moe/__init__.py

<ul><li>Change <code>_rope</code> split to half-split to match <code>cos</code>/<code>sin</code> layout.<br> <li> Replace <code>positions</code> argument to <code>write_kv</code> with page-table-translated <br>physical slots.<br> <li> Remove outdated identity-page-table comment and document MHAKVCache <br>behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/234/files#diff-7df44a0f5eb5c411dc8b6f5d672093944a031ba3e91e79a23781674f3ceb1a3e">+28/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_qwen3_dense_e2e.py</strong><dd><code>Add regression test for KV cache slot translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_qwen3_dense_e2e.py

<ul><li>Add <code>test_write_kv_uses_physical_pool_slots_not_logical_positions</code>.<br> <li> Spy on <code>pool.write_kv</code> to capture <code>out_loc</code> layer-0 argument.<br> <li> Assert first real token slot is not 0 and captured <code>out_loc</code> matches <br><code>engine.ctx.page_table</code> slots, not raw positions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/234/files#diff-1b278939216b95396d19e59ee455393f50bd585d65e3370d1c69e7f6ea6f20f6">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___