### PR TITLE
feat(models): port LFM2-MoE short gated-conv layer primitive (issue #230)

### DIFF
--- a/python/freetoken/models/lfm2_moe/__init__.py
+++ b/python/freetoken/models/lfm2_moe/__init__.py
@@ -1,0 +1,203 @@
+"""LFM2(.5)-8B-A1B (``lfm2_moe``) -- Intel Arc Pro B70 port. Epic #229.
+
+Upstream reference: HF ``transformers.models.lfm2_moe`` (real, registered
+``Lfm2MoeConfig``/``Lfm2MoeForCausalLM``, not this session's cloned
+FLashML/FreeToken upstream tree -- that project has no LFM2 port at all;
+this is a different upstream entirely). Ground truth for the conv math
+below is ``transformers/models/lfm2_moe/modeling_lfm2_moe.py``'s own
+``Lfm2MoeShortConv``.
+
+Fill in: GitHub issues `models-lfm2moe-conv` (#230), `models-lfm2moe-attn-moe`
+(#231), `models-lfm2moe-e2e` (#232) -- one package, built up incrementally
+(this port's established one-``__init__.py``-per-model convention).
+
+This file currently ships #230 only: ``parse_config`` (real) and the short
+gated-conv layer primitive (``ShortConv`` / ``short_conv_forward``) below.
+``iter_weights``/``Lfm2MoeForCausalLM`` stay stubs (``unimplemented``) until
+#232 wires the full model -- the conv primitive is unit-tested standalone
+in the meantime (see ``tests/test_models_lfm2moe_conv.py``).
+
+## Hybrid backbone
+
+Unlike every other MoE model in this port, LFM2-MoE's decoder alternates
+TWO different layer kinds per ``layer_types`` (confirmed against the real
+``LiquidAI/LFM2.5-8B-A1B-Base`` checkpoint's own ``config.json``, NOT
+assumed from the class default): most layers are a short causal gated
+convolution (this issue), a periodic few (roughly every 4th, starting at
+index 2) are full attention (issue #231). The first ``num_dense_layers``
+layers use a plain dense MLP; the rest use the sparse MoE (also #231).
+
+## Short gated conv (``ShortConv``, #230)
+
+Ground truth: ``Lfm2MoeShortConv.forward`` in the real
+``modeling_lfm2_moe.py``::
+
+    BCx = in_proj(x).transpose(-1, -2)      # [.., 3*hidden, T]
+    B, C, x = BCx.chunk(3, dim=-2)          # each [.., hidden, T]
+    h = B * x                                # first gate
+    h = causal_depthwise_conv1d(h, conv_weight, conv_bias, K=conv_L_cache)
+    y = C * h                                # second gate
+    y = out_proj(y.transpose(-1, -2))
+
+The causal depthwise conv itself (the real upstream implementation calls
+an external fused kernel, ``causal_conv1d_fn``/``causal_conv1d_update``,
+whose semantics this port reproduces in pure torch): a standard
+left-padded-only depthwise ``Conv1d`` -- ``nn.Conv1d(groups=hidden,
+kernel_size=K, padding=K-1)(h)`` produces ``T+K-1`` outputs; the LAST
+``K-1`` of those read from the (irrelevant) right zero-padding, so taking
+only the first ``T`` outputs gives the causal result: position ``t``'s
+output depends only on ``h[t-K+1 .. t]`` (zero-padded on the left for
+``t < K-1``). This is exactly ``F.conv1d(..., padding=K-1)[..., :T]``,
+confirmed by direct derivation from ``nn.Conv1d``'s own cross-correlation
+definition -- ``output[t] = bias + sum_k weight[k] * input[t-(K-1)+k]``,
+which for ``t <= T-1`` and ``k <= K-1`` never indexes past the original
+input's last position, so the right-padding zeros are never read.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from freetoken._stub import unimplemented
+from freetoken.models.config import ModelConfig
+
+
+# --------------------------------------------------------------------------- #
+# Checkpoint side (config parsing)
+# --------------------------------------------------------------------------- #
+
+
+def parse_config(hf_config: Any, model_path: str | None = None, **_kwargs) -> ModelConfig:
+    """Build a :class:`ModelConfig` from a real HF ``Lfm2MoeConfig``.
+
+    ``layer_types`` is read verbatim from the checkpoint (a real list of
+    ``"conv"``/``"full_attention"`` strings, one per layer) -- do NOT
+    assume a fixed ratio; the real ``LiquidAI/LFM2.5-8B-A1B-Base``
+    checkpoint's own pattern is `[conv, conv, full_attention, conv, conv,
+    conv, full_attention, ...]` (attention roughly every 4th layer,
+    starting at index 2), confirmed directly from its ``config.json`` --
+    but the config class ships no default builder for this field at all
+    (unlike e.g. Mellum's ``["full_attention"] * num_hidden_layers``
+    default), so a checkpoint that omits it entirely has no sane fallback
+    and this raises rather than guessing.
+    """
+    src = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    layer_types = src.get("layer_types")
+    num_layers = src.get("num_hidden_layers")
+    if not layer_types:
+        raise ValueError(
+            "lfm2_moe checkpoint's config.json has no 'layer_types' -- this "
+            "architecture has no derivable default (unlike e.g. Mellum's "
+            "all-full_attention fallback), so the real conv/attention "
+            "pattern must be present, not guessed"
+        )
+    if num_layers is not None and len(layer_types) != num_layers:
+        raise ValueError(
+            f"layer_types has {len(layer_types)} entries but num_hidden_layers={num_layers}"
+        )
+
+    cfg = ModelConfig(
+        architectures=["Lfm2MoeForCausalLM"],
+        hidden_size=src.get("hidden_size"),
+        vocab_size=src.get("vocab_size"),
+        num_layers=num_layers,
+        num_experts=src.get("num_experts") or src.get("num_local_experts"),
+        num_attention_heads=src.get("num_attention_heads"),
+        num_key_value_heads=src.get("num_key_value_heads"),
+        intermediate_size=src.get("intermediate_size"),
+        moe_intermediate_size=src.get("moe_intermediate_size"),
+        num_experts_per_tok=src.get("num_experts_per_tok"),
+        first_k_dense_replace=src.get("num_dense_layers") or 0,
+        is_moe=True,
+        max_position_embeddings=src.get("max_position_embeddings"),
+        tie_word_embeddings=src.get("tie_word_embeddings", False),
+        rope_theta=(src.get("rope_parameters") or {}).get("rope_theta"),
+        hidden_act=src.get("hidden_act", "silu"),
+        dtype=src.get("dtype") or src.get("torch_dtype"),
+    )
+    cfg.attrs["layer_types"] = list(layer_types)
+    cfg.attrs["conv_bias"] = bool(src.get("conv_bias", False))
+    cfg.attrs["conv_L_cache"] = int(src.get("conv_L_cache", 3))
+    cfg.attrs["num_dense_layers"] = int(src.get("num_dense_layers") or 0)
+    cfg.attrs["norm_eps"] = src.get("norm_eps", 1e-5)
+    cfg.attrs["norm_topk_prob"] = bool(src.get("norm_topk_prob", True))
+    cfg.attrs["use_expert_bias"] = bool(src.get("use_expert_bias", False))
+    cfg.attrs["routed_scaling_factor"] = src.get("routed_scaling_factor", 1.0)
+    return cfg
+
+
+def iter_weights(*args, **kwargs):
+    unimplemented("iter_weights", "models-lfm2moe-e2e")
+
+
+# --------------------------------------------------------------------------- #
+# Forward side: the short gated-conv primitive (#230 only)
+# --------------------------------------------------------------------------- #
+
+
+def causal_depthwise_conv1d(
+    h: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None, kernel_size: int
+) -> torch.Tensor:
+    """Left-padded-only depthwise causal conv over the time axis.
+
+    ``h [.., C, T]`` (channels, time -- matches ``nn.Conv1d``'s own layout),
+    ``weight [C, kernel_size]`` (one filter per channel, depthwise),
+    ``bias [C]`` or ``None``. Returns ``[.., C, T]``: position ``t`` depends
+    only on ``h[.., t-kernel_size+1 .. t]`` (left-zero-padded).
+    """
+    padded = F.pad(h, (kernel_size - 1, 0))
+    out = F.conv1d(padded, weight.unsqueeze(1), bias=bias, groups=h.shape[-2])
+    return out
+
+
+class ShortConv(nn.Module):
+    """LFM2-MoE's short gated causal convolution (real math: see module docstring).
+
+    Standalone/testable: takes and returns plain ``[T, hidden]`` (no batch
+    dim, matching this port's own single-request-per-call convention used
+    by every other model package here). Not yet wired into a decoder layer
+    or the engine -- that is #232's job.
+    """
+
+    def __init__(self, hidden_size: int, kernel_size: int, has_bias: bool, dtype=None) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.kernel_size = kernel_size
+        self.in_proj = nn.Linear(hidden_size, 3 * hidden_size, bias=has_bias, dtype=dtype)
+        self.conv_weight = nn.Parameter(torch.empty(hidden_size, kernel_size, dtype=dtype))
+        self.conv_bias = nn.Parameter(torch.empty(hidden_size, dtype=dtype)) if has_bias else None
+        self.out_proj = nn.Linear(hidden_size, hidden_size, bias=has_bias, dtype=dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """``x [T, hidden] -> [T, hidden]``."""
+        bcx = self.in_proj(x).transpose(0, 1)  # [3*hidden, T]
+        b, c, gx = bcx.chunk(3, dim=0)  # each [hidden, T]
+        h = b * gx
+        h = causal_depthwise_conv1d(h.unsqueeze(0), self.conv_weight, self.conv_bias, self.kernel_size).squeeze(0)
+        y = c * h
+        return self.out_proj(y.transpose(0, 1))
+
+
+# --------------------------------------------------------------------------- #
+# Not yet implemented: attention + MoE router (#231), full model wiring (#232).
+# --------------------------------------------------------------------------- #
+
+
+class Lfm2MoeForCausalLM:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def forward(self, *args, **kwargs):
+        unimplemented("Lfm2MoeForCausalLM.forward", "models-lfm2moe-e2e")
+
+
+__all__ = [
+    "ShortConv",
+    "causal_depthwise_conv1d",
+    "iter_weights",
+    "Lfm2MoeForCausalLM",
+    "parse_config",
+]

--- a/tests/test_models_lfm2moe_conv.py
+++ b/tests/test_models_lfm2moe_conv.py
@@ -1,0 +1,164 @@
+"""Unit tests for LFM2-MoE's short gated-conv primitive (issue
+``models-lfm2moe-conv``, #230). Standalone -- not yet wired into a decoder
+layer or the engine (that's #232's job); these pin the conv/gate math
+itself against an independently hand-computed reference, and
+``parse_config`` against the real checkpoint's own field shapes.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.models.lfm2_moe import ShortConv, causal_depthwise_conv1d, parse_config
+
+
+def _hand_causal_conv(h, weight, bias, kernel_size):
+    """Independent re-derivation: for each channel c and position t,
+    y[c,t] = bias[c] + sum_{k=0}^{K-1} weight[c,k] * h[c, t-K+1+k] (h[<0]=0)."""
+    C, T = h.shape
+    out = torch.zeros_like(h)
+    for c in range(C):
+        for t in range(T):
+            acc = bias[c].item() if bias is not None else 0.0
+            for k in range(kernel_size):
+                src = t - kernel_size + 1 + k
+                if src >= 0:
+                    acc += (weight[c, k] * h[c, src]).item()
+            out[c, t] = acc
+    return out
+
+
+def test_causal_depthwise_conv1d_matches_hand_computed_reference():
+    torch.manual_seed(0)
+    C, T, K = 4, 6, 3
+    h = torch.randn(1, C, T)
+    weight = torch.randn(C, K)
+    bias = torch.randn(C)
+    got = causal_depthwise_conv1d(h, weight, bias, K).squeeze(0)
+    expected = _hand_causal_conv(h.squeeze(0), weight, bias, K)
+    torch.testing.assert_close(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_causal_depthwise_conv1d_no_bias():
+    torch.manual_seed(1)
+    C, T, K = 3, 5, 2
+    h = torch.randn(1, C, T)
+    weight = torch.randn(C, K)
+    got = causal_depthwise_conv1d(h, weight, None, K).squeeze(0)
+    expected = _hand_causal_conv(h.squeeze(0), weight, None, K)
+    torch.testing.assert_close(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_causal_conv1d_position_zero_only_sees_itself():
+    """Position 0 must not read any real (non-zero-padded) prior context --
+    the defining property of causal conv."""
+    K = 3
+    h = torch.zeros(1, 1, 5)
+    h[0, 0, 0] = 1.0
+    weight = torch.ones(1, K)
+    out = causal_depthwise_conv1d(h, weight, None, K).squeeze()
+    # y[0] only sums weight[K-1]*h[0] (the rest of the kernel reads left zero-pad)
+    assert out[0].item() == pytest.approx(1.0)
+    # y[1] sums weight[K-2]*h[0] + weight[K-1]*h[1](=0)
+    assert out[1].item() == pytest.approx(1.0)
+    # y[K-1] is the first position where the full kernel reads real (or already-seen) data
+    assert out[K - 1].item() == pytest.approx(1.0)
+    # positions beyond the kernel width no longer see the impulse at 0
+    assert out[K].item() == pytest.approx(0.0)
+
+
+def test_short_conv_module_matches_manual_gate_and_conv_composition():
+    torch.manual_seed(2)
+    hidden, K, T = 8, 3, 6
+    conv = ShortConv(hidden, K, has_bias=True)
+    x = torch.randn(T, hidden)
+
+    got = conv(x)
+    assert got.shape == (T, hidden)
+
+    # Independent re-derivation of the full forward: in_proj -> gate -> conv -> gate -> out_proj.
+    bcx = conv.in_proj(x).transpose(0, 1)
+    b, c, gx = bcx.chunk(3, dim=0)
+    h = b * gx
+    h = _hand_causal_conv(h, conv.conv_weight, conv.conv_bias, K)
+    y = c * h
+    expected = conv.out_proj(y.transpose(0, 1))
+    torch.testing.assert_close(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_short_conv_no_bias_variant():
+    torch.manual_seed(3)
+    hidden, K, T = 4, 2, 5
+    conv = ShortConv(hidden, K, has_bias=False)
+    assert conv.conv_bias is None
+    x = torch.randn(T, hidden)
+    out = conv(x)
+    assert out.shape == (T, hidden)
+    assert torch.isfinite(out).all()
+
+
+_REAL_LAYER_TYPES = [
+    "conv", "conv", "full_attention", "conv", "conv", "conv", "full_attention",
+    "conv", "conv", "conv", "full_attention", "conv", "conv", "conv", "full_attention",
+    "conv", "conv", "conv", "full_attention", "conv", "conv", "full_attention", "conv", "conv",
+]
+
+_REAL_CONFIG = {
+    "architectures": ["Lfm2MoeForCausalLM"],
+    "model_type": "lfm2_moe",
+    "hidden_size": 2048,
+    "vocab_size": 128000,
+    "num_hidden_layers": 24,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "intermediate_size": 7168,
+    "moe_intermediate_size": 1792,
+    "num_experts": 32,
+    "num_experts_per_tok": 4,
+    "num_dense_layers": 2,
+    "conv_bias": False,
+    "conv_L_cache": 3,
+    "layer_types": _REAL_LAYER_TYPES,
+    "norm_eps": 1e-5,
+    "norm_topk_prob": True,
+    "use_expert_bias": True,
+    "routed_scaling_factor": 1.0,
+    "rope_parameters": {"rope_theta": 1000000.0, "rope_type": "default"},
+    "max_position_embeddings": 128000,
+    "tie_word_embeddings": True,
+    "dtype": "bfloat16",
+}
+
+
+def _hf(d):
+    return type("Hf", (), {"to_dict": lambda self: d})()
+
+
+def test_parse_config_reads_real_checkpoint_fields_verbatim():
+    config = parse_config(_hf(_REAL_CONFIG))
+    assert config.hidden_size == 2048
+    assert config.num_layers == 24
+    assert config.first_k_dense_replace == 2
+    assert config.is_moe is True
+    assert config.attrs["layer_types"] == _REAL_LAYER_TYPES
+    assert config.attrs["conv_L_cache"] == 3
+    assert config.attrs["conv_bias"] is False
+    assert config.attrs["num_dense_layers"] == 2
+    assert config.rope_theta == 1000000.0
+
+
+def test_parse_config_rejects_missing_layer_types_rather_than_guessing():
+    cfg = dict(_REAL_CONFIG)
+    del cfg["layer_types"]
+    with pytest.raises(ValueError, match="layer_types"):
+        parse_config(_hf(cfg))
+
+
+def test_parse_config_rejects_layer_types_length_mismatch():
+    cfg = dict(_REAL_CONFIG)
+    cfg["layer_types"] = _REAL_LAYER_TYPES[:-1]  # 23 entries, num_hidden_layers=24
+    with pytest.raises(ValueError, match="layer_types"):
+        parse_config(_hf(cfg))


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Why
Foundational first piece of epic #229 (LFM2(.5)-8B-A1B) -- the conv layer is a genuinely new primitive for this port and other layers depend on the layer-type alternation pattern it establishes.

## What
- Real `parse_config` for `lfm2_moe`: `conv_bias`, `conv_L_cache`, `num_dense_layers`, `layer_types` -- read verbatim from the real checkpoint (`LiquidAI/LFM2.5-8B-A1B-Base`'s own `config.json`, confirmed directly, not guessed): mostly `"conv"` with `"full_attention"` roughly every 4th layer starting at index 2. Raises rather than guessing when a checkpoint omits `layer_types` (unlike Mellum's config class, LFM2-MoE's ships no default-builder fallback).
- `ShortConv`: the short gated causal convolution primitive, grounded directly from `transformers`' installed `modeling_lfm2_moe.py` (`Lfm2MoeShortConv`) -- the real, authoritative upstream reference for this architecture (not this session's cloned FLashML/FreeToken tree, which has no LFM2 port at all).
- `causal_depthwise_conv1d`: the causal conv itself, derived directly from `nn.Conv1d`'s own cross-correlation definition and pinned with an explicit "position 0 only sees itself" regression test.

Scope: config parsing + the conv primitive only. Attention/MoE router is #231, full model wiring is #232 -- both separate later children.

## Test plan
- [x] `.venv-xpu -m "not xpu"`: 604 passed (+8 new), 1 pre-existing unrelated flake, 1 skipped, 117 deselected
- [x] Real B70 hardware (`xpu:0`): finite output confirmed on a synthetic fixture

Parent epic: #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `lfm2_moe` config parsing from real checkpoint fields.

- Implement `ShortConv` causal gated convolution primitive.

- Add unit tests pinning conv math and config behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["parse_config reads real checkpoint fields"] --> B["ModelConfig with layer_types, conv_bias, conv_L_cache"]
    C["ShortConv module"] --> D["causal_depthwise_conv1d left-padded causal conv"]
    C --> E["gated composition: in_proj -> gate -> conv -> gate -> out_proj"]
    F["Unit tests"] --> C
    F --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add LFM2-MoE config parsing and ShortConv primitive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/lfm2_moe/__init__.py

<ul><li>Add <code>parse_config</code> reading <code>layer_types</code>, <code>conv_bias</code>, <code>conv_L_cache</code>, and <br>dense-layer fields verbatim.<br> <li> Implement <code>causal_depthwise_conv1d</code> as left-padded causal depthwise <br>convolution.<br> <li> Add <code>ShortConv</code> module with gated composition <code>in_proj -> gate -> conv -> </code><br><code>gate -> out_proj</code>.<br> <li> Stub <code>iter_weights</code> and <code>Lfm2MoeForCausalLM</code> for later issues.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/235/files#diff-609228d09d52e25cfd7d2d826f50f2cfcaab4079d5adbf06b2e17fe43af3093b">+203/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_lfm2moe_conv.py</strong><dd><code>Add unit tests for ShortConv and parse_config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_lfm2moe_conv.py

<ul><li>Add hand-computed causal conv reference tests for <br><code>causal_depthwise_conv1d</code>.<br> <li> Test <code>ShortConv</code> manual gate/conv composition and no-bias variant.<br> <li> Test <code>parse_config</code> against a real checkpoint-shaped config and error <br>cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/235/files#diff-d0fabcef4730afbb14938695a84d7f7d214e5da32ab754c010cc2dc0909f7dca">+164/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

