### PR TITLE
fix(models): qwen3_5_moe/deepseek_v4 wrote KV cache entries to the wrong physical slot on real hardware

### DIFF
--- a/python/freetoken/models/deepseek_v4/__init__.py
+++ b/python/freetoken/models/deepseek_v4/__init__.py
@@ -402,7 +402,14 @@ class _DeepseekV4MLA(nn.Module):
             v_for_pool = F.pad(k_idx, (0, pool_row_width - self.index_head_dim)).unsqueeze(0)
         else:
             v_for_pool = torch.zeros_like(k_for_pool)  # V half is unused for plain MLA -- see docstring
-        ctx.kv_cache.write_kv(k_for_pool, v_for_pool, positions, self.layer_id)
+        # write_kv's third argument is out_loc -- PHYSICAL pool slots, not
+        # logical token positions. These only coincide under an identity page
+        # table; MHAKVCache's real per-request free-list allocator is NOT
+        # identity (slot 0 is reserved as dummy/padding, so a real request's
+        # first token never lands on slot 0). See qwen3/qwen3_moe's identical
+        # fix (#234) -- this call had the same wrong "identity table" assumption.
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k_for_pool, v_for_pool, out_loc, self.layer_id)
 
         written = req_written_len(ctx, batch, table_idx)
         read_pos = torch.arange(written, device=hidden_states.device)

--- a/python/freetoken/models/qwen3_5_moe/__init__.py
+++ b/python/freetoken/models/qwen3_5_moe/__init__.py
@@ -1087,9 +1087,14 @@ class _Qwen35Attention:
         q = q.transpose(1, 2)[0]
         k = k.transpose(1, 2)[0]
         v = v.transpose(1, 2)[0]
-        # Append this request's K/V to the pool at its positions (identity table:
-        # out_loc == position under the identity page table, as in qwen3_moe).
-        ctx.kv_cache.write_kv(k, v, positions, self.layer_id)
+        # write_kv's third argument is out_loc -- PHYSICAL pool slots, not
+        # logical token positions. These only coincide under an identity page
+        # table; MHAKVCache's real per-request free-list allocator is NOT
+        # identity (slot 0 is reserved as dummy/padding, so a real request's
+        # first token never lands on slot 0). See qwen3/qwen3_moe's identical
+        # fix (#234) -- this call had the same wrong "identity table" assumption.
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k, v, out_loc, self.layer_id)
         out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, table_idx=table_idx)
         # Gated output: sigmoid(gate) elementwise over the attention output.
         # out is head-major [heads, T, head_dim]; make the gate head-major to match.

--- a/tests/test_models_deepseek_v4_moe_e2e.py
+++ b/tests/test_models_deepseek_v4_moe_e2e.py
@@ -214,3 +214,53 @@ def test_engine_greedy_is_deterministic(tmp_path):
     b = build()
     assert a == b
     assert len(a[0]) == 3
+
+
+def test_write_kv_uses_physical_pool_slots_not_logical_positions(tmp_path):
+    """Real bug (#234) found running qwen3/qwen3_moe against a real trained
+    checkpoint's generation through the actual Engine: ``write_kv``'s third
+    argument is ``out_loc`` -- PHYSICAL pool slots -- not logical token
+    positions. These only coincide under an identity page table. The real
+    ``MHAKVCache`` per-request free-list allocator (every live ``Engine``
+    uses this) reserves slot 0 as dummy/padding, so a real request's first
+    token never lands on slot 0. MLA's attention here had the identical
+    wrong pattern (passed raw ``positions`` straight through) -- fixed to
+    translate positions -> physical slots via ``ctx.page_table`` first,
+    exactly as ``qwen3``/``qwen3_moe``'s fix did.
+
+    Every existing deepseek_v4 e2e test only asserts "produces some
+    deterministic in-range token", not correctness against a physical-slot
+    oracle, so none of them caught this. This pins the fix directly.
+    """
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+
+    captured = {}
+    pool = engine.ctx.kv_cache
+    orig_write_kv = pool.write_kv
+
+    def spy_write_kv(k, v, out_loc, layer_id=0):
+        if layer_id not in captured:
+            captured[layer_id] = out_loc.clone()
+        return orig_write_kv(k, v, out_loc, layer_id)
+
+    pool.write_kv = spy_write_kv
+    try:
+        _add_prompt(engine, output_len=1)
+        engine.generate()
+    finally:
+        pool.write_kv = orig_write_kv
+
+    assert 0 in captured, "layer 0's write_kv must have been called"
+
+    table_idx = 0
+    positions = torch.arange(5)  # len(input_ids) in _add_prompt: [1, 2, 3, 4, 5]
+    expected_slots = engine.ctx.page_table[table_idx, positions.long()]
+
+    # A real request's first token never lands on the reserved slot 0 --
+    # confirms the allocator genuinely isn't identity for this run.
+    assert 0 not in expected_slots.tolist()
+    # The actual out_loc write_kv received must be the PHYSICAL pool slots
+    # from the page table, not the raw logical positions [0, 1, 2, 3, 4].
+    assert captured[0].equal(expected_slots)
+    assert not captured[0].equal(positions)

--- a/tests/test_qwen35_offload_xpu.py
+++ b/tests/test_qwen35_offload_xpu.py
@@ -288,3 +288,64 @@ def test_qwen35_auto_resolves_to_offload_on_xpu(qwen35_xpu_ckpt):
     _add_prompt(engine, output_len=6)
     tokens = engine.generate()
     assert len(tokens[0]) == 6 and all(0 <= t < _V for t in tokens[0])
+
+
+def test_write_kv_uses_physical_pool_slots_not_logical_positions(qwen35_xpu_ckpt):
+    """Real bug (#234) found running qwen3/qwen3_moe against a real trained
+    checkpoint's generation through the actual Engine: ``write_kv``'s third
+    argument is ``out_loc`` -- PHYSICAL pool slots -- not logical token
+    positions. These only coincide under an identity page table. The real
+    ``MHAKVCache`` per-request free-list allocator (every live ``Engine``
+    uses this, not the identity-mapped ``BaseKVCachePool`` this file's own
+    sibling module ``test_models_qwen35_loader.py`` uses via
+    ``_drive_prefill``) reserves slot 0 as dummy/padding, so a real request's
+    first token never lands on slot 0. The full-attention layer here had the
+    identical wrong pattern (passed raw ``positions`` straight through,
+    documented with a now-known-false "identity table" comment) -- fixed to
+    translate positions -> physical slots via ``ctx.page_table`` first,
+    exactly as ``qwen3``/``qwen3_moe``'s fix did.
+
+    This closes a real coverage gap: every existing qwen3_5_moe test either
+    used the identity-mapped ``BaseKVCachePool`` directly (masks the bug by
+    construction) or compared the offload path against the fused path
+    (both share this exact buggy call, so they'd corrupt identically and
+    still agree -- a self-referential check that can't catch this class of
+    bug). This is the first qwen3_5_moe test to run a real ``Engine`` +
+    real ``MHAKVCache`` and check the actual physical slot ``write_kv``
+    received against an independent oracle (the page table itself).
+    """
+    dev = torch.device("cpu")
+    engine = Engine(_engine_config(qwen35_xpu_ckpt, dev, moe_backend="fused"))
+
+    captured = {}
+    pool = engine.ctx.kv_cache
+    orig_write_kv = pool.write_kv
+
+    def spy_write_kv(k, v, out_loc, layer_id=0):
+        if layer_id not in captured:
+            captured[layer_id] = out_loc.clone()
+        return orig_write_kv(k, v, out_loc, layer_id)
+
+    pool.write_kv = spy_write_kv
+    try:
+        _add_prompt(engine, output_len=1)
+        engine.generate()
+    finally:
+        pool.write_kv = orig_write_kv
+
+    full_layer_ids = [l.layer_id for l in engine.model.layers if getattr(l, "self_attn", None) is not None]
+    assert full_layer_ids, "the fabricated tower must have a full-attention layer"
+    lid = full_layer_ids[0]
+    assert lid in captured, "the full-attention layer's write_kv must have been called"
+
+    table_idx = 0
+    positions = torch.arange(5)  # len(input_ids) in _add_prompt: [1, 2, 3, 5, 8]
+    expected_slots = engine.ctx.page_table[table_idx, positions.long()]
+
+    # A real request's first token never lands on the reserved slot 0 --
+    # confirms the allocator genuinely isn't identity for this run.
+    assert 0 not in expected_slots.tolist()
+    # The actual out_loc write_kv received must be the PHYSICAL pool slots
+    # from the page table, not the raw logical positions [0, 1, 2, 3, 4].
+    assert captured[lid].equal(expected_slots)
+    assert not captured[lid].equal(positions)


### PR DESCRIPTION
## Why
Same bug class as #234 (`qwen3`/`qwen3_moe`, merged earlier this session): `write_kv`'s third argument is `out_loc` — PHYSICAL pool slots, not logical token positions. These only coincide under an identity page table. `MHAKVCache`'s real per-request free-list allocator (every live `Engine` uses this) reserves slot 0 as dummy/padding, so a real request's first token never lands on slot 0.

Both `qwen3_5_moe`'s full-attention layer and `deepseek_v4`'s MLA layer had the identical wrong pattern, both with a now-known-false "identity page table" comment justifying it — this session's #234 investigation flagged both as having the same real-hardware corruption risk, not fixed there (out of that issue's scope).

## Fix
Translate positions → physical slots via `ctx.page_table` before calling `write_kv`, exactly as `read_kv` already does internally and exactly as #234's fix did for `qwen3`/`qwen3_moe`.

## Real coverage gap closed
`qwen3_5_moe` was previously marked in `models-compat-matrix` as "✅ real checkpoint validated (`tiny-random/qwen3.5-moe`, GDN forward reference-matched)". That claim's supporting tests never actually exercised this bug: one uses the identity-mapped `BaseKVCachePool` directly (masks the bug by construction), the other (the one that actually used the real `tiny-random/qwen3.5-moe` checkpoint) never calls `Engine`/`write_kv` at all — it only tests weight-key-naming via `load_moe_expert_sources`. Re-ran the real checkpoint through an actual `Engine` + real `MHAKVCache` for the first time: confirmed the fix produces correctly translated physical slots (not raw positions) on the real checkpoint too.

## Test plan
- [x] Both new regression tests confirmed to FAIL without the fix (captured `out_loc` == raw positions) and PASS with it
- [x] `.venv` (torch-free): 208 passed
- [x] `.venv-xpu -m "not xpu"`: 591 passed, 1 pre-existing unrelated flake (`test_fetch_fraction_none_when_no_profile`), 1 skipped, 117 deselected
- [x] Real B70 hardware (`xpu:0`): both architectures verified with finite, in-range generation
- [x] Real `tiny-random/qwen3.5-moe` checkpoint re-verified through a real `Engine` + `MHAKVCache`, confirming the previously-unverified "real checkpoint validated" claim now actually holds

Parent: follow-up flagged in #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY