### PR TITLE
feat(models): port Qwen1.5-MoE-A2.7B bias-term attention + gated-shared-expert router (issue #221)

### DIFF
--- a/python/freetoken/models/qwen2_moe/__init__.py
+++ b/python/freetoken/models/qwen2_moe/__init__.py
@@ -1,0 +1,263 @@
+"""Qwen1.5-MoE-A2.7B model (issue `models-qwen2moe-attn`, #221).
+
+Upstream NVIDIA path: python/freetoken/models/qwen2_moe/
+
+Real, registered `transformers.Qwen2MoeConfig` (`model_type=qwen2_moe`,
+confirmed against the real downloaded `Qwen/Qwen1.5-MoE-A2.7B` checkpoint).
+Two real differences from this port's Qwen3-family models:
+
+* Attention is plain MHA with **bias terms** on q/k/v projections
+  (`qkv_bias=True` on the real checkpoint) -- no q/k RMS-norm at all,
+  unlike Qwen3's qk-norm attention. `o_proj` stays bias-free (confirmed
+  against `transformers.models.qwen2_moe.modeling_qwen2_moe.Qwen2MoeAttention`).
+* The MoE router is plain softmax top-k (`Qwen2MoeTopKRouter`: softmax over
+  all `num_experts` logits, top-`num_experts_per_tok`, optional renorm) with
+  an **always-on, gated** shared expert -- `sigmoid(shared_expert_gate(x)) *
+  shared_expert(x)`, added to the routed-expert output. This sigmoid gate is
+  a real, different mechanism from `deepseek_v4`/`glm_moe_dsa`'s
+  unconditional shared-expert add; confirmed against the real HF
+  `Qwen2MoeSparseMoeBlock.forward`.
+
+This issue (#221) covers config parsing, attention, and the router/shared-
+expert combination as standalone, independently-testable primitives (same
+shape as `qwen4_exp`'s own `#206`/`#208` primitives) -- NOT yet wired into a
+decoder layer, the engine's KV cache, or a `ForCausalLM` class; that is
+issue #222's job.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from safetensors import safe_open
+
+from freetoken.models.config import ModelConfig
+from freetoken.models.weight import iter_safetensors
+from freetoken.utils import cached_load_hf_config
+
+# --------------------------------------------------------------------------- #
+# Checkpoint side
+# --------------------------------------------------------------------------- #
+
+
+def _probe_head_dim(model_path: str, num_heads) -> int | None:
+    """Recover the per-head dim from the checkpoint's real ``o_proj`` shape.
+
+    Mirrors ``qwen3``/``qwen3_moe``'s own ``_probe_head_dim`` exactly.
+    """
+    if not num_heads or not isinstance(model_path, str) or not os.path.isdir(model_path):
+        return None
+    try:
+        folder = model_path
+        index = os.path.join(folder, "model.safetensors.index.json")
+        target = None
+        if os.path.isfile(index):
+            with open(index, encoding="utf-8") as f:
+                weight_map = json.load(f)["weight_map"]
+            for name in sorted(weight_map):
+                if name.endswith(".self_attn.o_proj.weight"):
+                    target = (name, weight_map[name]); break
+        if target is None:
+            for path in sorted(glob.glob(os.path.join(folder, "*.safetensors"))):
+                if path.endswith("consolidated.safetensors"):
+                    continue
+                with safe_open(path, framework="pt", device="cpu") as f:
+                    if "model.layers.0.self_attn.o_proj.weight" in f.keys():
+                        target = ("model.layers.0.self_attn.o_proj.weight", path); break
+        if target is None:
+            return None
+        name, path = target
+        with safe_open(path, framework="pt", device="cpu") as f:
+            heads_times_head_dim = f.get_slice(name).get_shape()[1]
+        if heads_times_head_dim % num_heads:
+            return None
+        return heads_times_head_dim // num_heads
+    except Exception:
+        return None
+
+
+def parse_config(hf_config, model_path: str | None = None, **_kwargs) -> ModelConfig:
+    """Build a :class:`ModelConfig` from a HF Qwen2-MoE (Qwen1.5-MoE) config.
+
+    ``mlp_only_layers``/``decoder_sparse_step`` control the real dense-vs-MoE
+    layer split (real checkpoint: ``decoder_sparse_step=1``, no
+    ``mlp_only_layers`` key -- the HF class default ``[]`` -- so every layer
+    is MoE; do not assume this for a different checkpoint, read it).
+    ``**_kwargs`` absorbs the MoE-backend kwargs ``load_model`` passes
+    uniformly across architectures.
+    """
+    src = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    cfg = ModelConfig(
+        architectures=["Qwen2MoeForCausalLM"],
+        hidden_size=src.get("hidden_size"),
+        vocab_size=src.get("vocab_size"),
+        num_layers=src.get("num_hidden_layers"),
+        num_experts=src.get("num_experts"),
+        num_attention_heads=src.get("num_attention_heads"),
+        num_key_value_heads=src.get("num_key_value_heads"),
+        head_dim=(
+            _probe_head_dim(model_path, src.get("num_attention_heads"))
+            or (int(src.get("head_dim")) if src.get("head_dim") else None)
+        ),
+        intermediate_size=src.get("intermediate_size"),
+        moe_intermediate_size=src.get("moe_intermediate_size"),
+        num_experts_per_tok=src.get("num_experts_per_tok"),
+        max_position_embeddings=src.get("max_position_embeddings"),
+        tie_word_embeddings=src.get("tie_word_embeddings", False),
+        rope_theta=src.get("rope_theta"),
+        rope_scaling=src.get("rope_scaling"),
+        hidden_act=src.get("hidden_act", "silu"),
+        dtype=src.get("torch_dtype"),
+    )
+    cfg.is_moe = True
+    cfg.attrs["qkv_bias"] = bool(src.get("qkv_bias", True))
+    cfg.attrs["norm_topk_prob"] = bool(src.get("norm_topk_prob", False))
+    cfg.attrs["shared_expert_intermediate_size"] = int(src.get("shared_expert_intermediate_size") or 0)
+    cfg.attrs["decoder_sparse_step"] = int(src.get("decoder_sparse_step") or 1)
+    cfg.attrs["mlp_only_layers"] = list(src.get("mlp_only_layers") or [])
+    return cfg
+
+
+def iter_weights(model_path: str, device: torch.device, **_kwargs) -> "iter[tuple[str, torch.Tensor]]":
+    """Yield the checkpoint's tensors, each placed on ``device``.
+
+    Synthesizes ``lm_head.weight`` from ``embed_tokens.weight`` for a
+    ``tie_word_embeddings: true`` checkpoint that ships no separate
+    ``lm_head.weight`` key (same real failure mode ``qwen3``/``qwen3_moe``
+    already guard against: an unfilled ``lm_head`` silently zeros every
+    logit). The real Qwen1.5-MoE-A2.7B checkpoint does NOT tie embeddings,
+    so this is a defensive no-op there, not exercised.
+    """
+    embed_tokens_weight = None
+    saw_lm_head = False
+    for name, tensor in iter_safetensors(model_path, device):
+        placed = tensor.to(device)
+        if name == "model.embed_tokens.weight":
+            embed_tokens_weight = placed
+        elif name == "lm_head.weight":
+            saw_lm_head = True
+        yield name, placed
+
+    if not saw_lm_head and embed_tokens_weight is not None:
+        hf_config = cached_load_hf_config(model_path)
+        if bool(getattr(hf_config, "tie_word_embeddings", False)):
+            yield "lm_head.weight", embed_tokens_weight
+
+
+# --------------------------------------------------------------------------- #
+# Forward side -- standalone primitives (#221); decoder-layer/engine wiring
+# and the causal-LM wrapper are #222's job.
+# --------------------------------------------------------------------------- #
+
+
+class Qwen2MoeAttention(nn.Module):
+    """Plain bias-term MHA (no q/k norm), RoPE, KV-pool driven.
+
+    Real difference from this port's Qwen3-family attention: q/k/v carry a
+    real bias term (``qkv_bias=True`` on the checkpoint) and there is no
+    per-head RMS-norm on q/k at all. ``o_proj`` stays bias-free. Confirmed
+    against ``transformers.models.qwen2_moe.modeling_qwen2_moe.Qwen2MoeAttention``.
+    """
+
+    def __init__(self, config, device, dtype, layer_id: int) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads or config.num_attention_heads
+        self.head_dim = getattr(config, "head_dim", None) or config.hidden_size // self.num_heads
+        qkv_bias = bool(config.attrs.get("qkv_bias", True))
+        from freetoken.layers import LinearOProj, LinearReplicated
+
+        self.q_proj = LinearReplicated(config.hidden_size, self.num_heads * self.head_dim, has_bias=qkv_bias, dtype=dtype)
+        self.k_proj = LinearReplicated(config.hidden_size, self.num_kv_heads * self.head_dim, has_bias=qkv_bias, dtype=dtype)
+        self.v_proj = LinearReplicated(config.hidden_size, self.num_kv_heads * self.head_dim, has_bias=qkv_bias, dtype=dtype)
+        self.o_proj = LinearOProj(self.num_heads * self.head_dim, config.hidden_size, has_bias=False, dtype=dtype)
+        theta = config.rope_theta or 10000.0
+        inv_freq = 1.0 / (
+            theta ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32, device=device) / self.head_dim)
+        )
+        self.register_buffer("inv_freq", inv_freq)
+
+    def _rope(self, x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
+        # Half-split (rotate_half) RoPE -- matches HF's real
+        # ``rotate_half``/``apply_rotary_pos_emb`` convention (confirmed
+        # directly against transformers' qwen2_moe modeling code; same
+        # convention this port's qwen3/qwen3_moe use after their own rope
+        # fix this session).
+        freqs = torch.outer(pos.to(torch.float32), self.inv_freq)  # [N, D/2]
+        emb = torch.cat((freqs, freqs), dim=-1)  # [N, D]
+        cos = emb.cos()[None, :, :]
+        sin = emb.sin()[None, :, :]
+        x_f = x.to(torch.float32)
+        half = x_f.shape[-1] // 2
+        x1, x2 = x_f[..., :half], x_f[..., half:]
+        rotated = torch.cat((-x2, x1), dim=-1)
+        return (x_f * cos + rotated * sin).to(x.dtype)
+
+    def forward(self, hidden_states, positions, table_idx, ctx, batch):
+        bsz, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).view(bsz, self.num_heads, self.head_dim).transpose(0, 1)
+        k = self.k_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        v = self.v_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        q = self._rope(q, positions)
+        k = self._rope(k, positions)
+        # write_kv's third argument is out_loc -- PHYSICAL pool slots, not
+        # logical token positions (see qwen3/__init__.py's own extensive
+        # comment on the real bug this fixed this session: MHAKVCache's
+        # real allocator reserves slot 0 as padding, so positions and slots
+        # are never the same number for a real request).
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k, v, out_loc, self.layer_id)
+        out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, table_idx=table_idx)
+        return self.o_proj(out.transpose(0, 1).contiguous().reshape(bsz, -1))
+
+
+def qwen2moe_router(
+    hidden_states: torch.Tensor, gate_weight: torch.Tensor, top_k: int, norm_topk_prob: bool
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """The real ``Qwen2MoeTopKRouter``: plain softmax over all experts, then
+    top-``top_k``, optional renormalization. ``hidden_states`` is ``[T, H]``,
+    ``gate_weight`` is ``[num_experts, H]``. Returns ``(routing_weights,
+    selected_experts)``, both ``[T, top_k]``."""
+    router_logits = F.linear(hidden_states, gate_weight)  # [T, num_experts]
+    router_probs = torch.softmax(router_logits.float(), dim=-1)
+    routing_weights, selected_experts = torch.topk(router_probs, top_k, dim=-1)
+    if norm_topk_prob:
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+    return routing_weights.to(hidden_states.dtype), selected_experts
+
+
+def qwen2moe_shared_expert_output(
+    hidden_states: torch.Tensor,
+    shared_gate_proj: torch.Tensor,
+    shared_up_proj: torch.Tensor,
+    shared_down_proj: torch.Tensor,
+    shared_expert_gate_weight: torch.Tensor,
+) -> torch.Tensor:
+    """The real, gated shared-expert combination: ``sigmoid(shared_expert_gate(x))
+    * shared_expert(x)`` -- a real, different mechanism from
+    ``deepseek_v4``/``glm_moe_dsa``'s unconditional shared-expert add.
+    Confirmed against the real HF ``Qwen2MoeSparseMoeBlock.forward``.
+    ``hidden_states`` is ``[T, H]``; the three shared-expert projections are
+    plain SwiGLU MLP weights ``[out, in]``; ``shared_expert_gate_weight`` is
+    ``[1, H]`` (bias-free)."""
+    shared = F.linear(
+        F.silu(F.linear(hidden_states, shared_gate_proj)) * F.linear(hidden_states, shared_up_proj),
+        shared_down_proj,
+    )
+    gate = torch.sigmoid(F.linear(hidden_states, shared_expert_gate_weight))
+    return gate * shared
+
+
+__all__ = [
+    "parse_config",
+    "iter_weights",
+    "Qwen2MoeAttention",
+    "qwen2moe_router",
+    "qwen2moe_shared_expert_output",
+]

--- a/tests/test_models_qwen2_moe_attn.py
+++ b/tests/test_models_qwen2_moe_attn.py
@@ -1,0 +1,159 @@
+"""Unit tests for Qwen1.5-MoE-A2.7B's bias-term attention + router/shared-
+expert primitives (issue `models-qwen2moe-attn`, #221). Standalone -- not
+yet wired into a decoder layer or the engine (that's #222's job); these pin
+the attention and router/shared-expert math against independently
+hand-computed references.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn.functional as F
+
+from freetoken.attention.triton import TritonAttentionBackend
+from freetoken.core import Batch, Context, Req, SamplingParams, reset_global_ctx, set_global_ctx
+from freetoken.kvcache.base import BaseKVCachePool
+from freetoken.models.config import ModelConfig
+from freetoken.models.qwen2_moe import Qwen2MoeAttention, qwen2moe_router, qwen2moe_shared_expert_output
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def test_qwen2moe_attention_forward_runs_and_bias_terms_are_real():
+    """Real forward pass through a Context/BaseKVCachePool (identity page
+    table -- the established pattern for a standalone-primitive test, per
+    #221's own scope; the real MHAKVCache validation is #222's e2e job).
+    Confirms finite output, and that the bias terms are actually wired
+    (zeroing them changes the output -- proves has_bias=True is load-bearing,
+    not a silently-ignored flag)."""
+    torch.manual_seed(0)
+    H, NH, NKV, D = 16, 4, 4, 8
+    config = ModelConfig(
+        hidden_size=H,
+        num_attention_heads=NH,
+        num_key_value_heads=NKV,
+        head_dim=D,
+        num_layers=1,
+        rope_theta=10000.0,
+        attrs={"qkv_bias": True},
+    )
+    dev = torch.device("cpu")
+    attn = Qwen2MoeAttention(config, dev, torch.float32, layer_id=0)
+    assert attn.q_proj.has_bias and attn.k_proj.has_bias and attn.v_proj.has_bias
+    assert not attn.o_proj.has_bias
+    with torch.no_grad():
+        for p in attn.parameters():
+            p.normal_(0, 0.02)
+
+    T = 5
+    hidden_states = torch.randn(T, H)
+    positions = torch.arange(T)
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(config, page_size=1, num_pages=32, device=dev, dtype=torch.float32)
+    pt = torch.zeros((2, 32), dtype=torch.int32)
+    pt[0, :T] = torch.arange(T)
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    ctx.attn_backend = TritonAttentionBackend(None)
+    req = Req(
+        input_ids=list(range(T)), table_idx=0, cached_len=0, output_len=1, uid=0,
+        sampling_params=SamplingParams(), cache_handle=None,
+    )
+    req.device_len = T
+    batch = Batch(reqs=[req], phase="prefill", positions=positions, extend_lens=[T])
+    set_global_ctx(ctx)
+    ctx._batch = batch
+
+    out = attn(hidden_states, positions, 0, ctx, batch)
+    assert out.shape == (T, H)
+    assert torch.isfinite(out).all()
+
+    # Zero every bias term and re-run: a real bias contribution must change
+    # the output (proves has_bias isn't silently ignored by the forward).
+    with torch.no_grad():
+        attn.q_proj.bias.zero_()
+        attn.k_proj.bias.zero_()
+        attn.v_proj.bias.zero_()
+    out_no_bias = attn(hidden_states, positions, 0, ctx, batch)
+    assert not torch.allclose(out, out_no_bias)
+
+
+def test_qwen2moe_router_matches_hand_computed_softmax_topk():
+    torch.manual_seed(0)
+    T, H, num_experts, top_k = 5, 8, 6, 2
+    x = torch.randn(T, H)
+    gate_weight = torch.randn(num_experts, H) * 0.1
+
+    weights, experts = qwen2moe_router(x, gate_weight, top_k, norm_topk_prob=False)
+    assert weights.shape == (T, top_k)
+    assert experts.shape == (T, top_k)
+
+    logits = F.linear(x, gate_weight)
+    probs = torch.softmax(logits.float(), dim=-1)
+    exp_weights, exp_experts = torch.topk(probs, top_k, dim=-1)
+    torch.testing.assert_close(weights.float(), exp_weights, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(experts, exp_experts)
+
+
+def test_qwen2moe_router_renormalizes_when_norm_topk_prob_true():
+    torch.manual_seed(1)
+    T, H, num_experts, top_k = 4, 6, 5, 2
+    x = torch.randn(T, H)
+    gate_weight = torch.randn(num_experts, H) * 0.1
+
+    weights, _ = qwen2moe_router(x, gate_weight, top_k, norm_topk_prob=True)
+    row_sums = weights.float().sum(dim=-1)
+    torch.testing.assert_close(row_sums, torch.ones(T), atol=1e-5, rtol=1e-5)
+
+
+def test_qwen2moe_router_no_renorm_rows_need_not_sum_to_one():
+    torch.manual_seed(2)
+    T, H, num_experts, top_k = 4, 6, 5, 2
+    x = torch.randn(T, H)
+    gate_weight = torch.randn(num_experts, H) * 0.1
+
+    weights, _ = qwen2moe_router(x, gate_weight, top_k, norm_topk_prob=False)
+    row_sums = weights.float().sum(dim=-1)
+    assert not torch.allclose(row_sums, torch.ones(T), atol=1e-3)
+
+
+def test_qwen2moe_shared_expert_output_matches_hand_computed_sigmoid_gate():
+    """Real, gated combination: sigmoid(shared_expert_gate(x)) * shared_expert(x)
+    -- a real, different mechanism from deepseek_v4/glm_moe_dsa's unconditional
+    add (confirmed against the real HF Qwen2MoeSparseMoeBlock.forward)."""
+    torch.manual_seed(3)
+    T, H, inter = 4, 8, 12
+    x = torch.randn(T, H)
+    gate_proj = torch.randn(inter, H) * 0.1
+    up_proj = torch.randn(inter, H) * 0.1
+    down_proj = torch.randn(H, inter) * 0.1
+    shared_gate_weight = torch.randn(1, H) * 0.1
+
+    got = qwen2moe_shared_expert_output(x, gate_proj, up_proj, down_proj, shared_gate_weight)
+    assert got.shape == (T, H)
+
+    shared_mlp = F.linear(F.silu(F.linear(x, gate_proj)) * F.linear(x, up_proj), down_proj)
+    gate = torch.sigmoid(F.linear(x, shared_gate_weight))
+    expected = gate * shared_mlp
+    torch.testing.assert_close(got, expected, atol=1e-6, rtol=1e-6)
+
+
+def test_qwen2moe_shared_expert_gate_actually_modulates_output():
+    """Proof the gate is active: an all-negative gate logit (sigmoid near 0)
+    must suppress the shared expert's output near zero."""
+    torch.manual_seed(4)
+    T, H, inter = 3, 6, 8
+    x = torch.rand(T, H) + 0.1  # strictly positive, so a negative-constant gate
+    # weight's dot product with x is guaranteed very negative regardless of seed.
+    gate_proj = torch.randn(inter, H) * 0.1
+    up_proj = torch.randn(inter, H) * 0.1
+    down_proj = torch.randn(H, inter) * 0.1
+    shared_gate_weight = -50.0 * torch.ones(1, H)
+
+    got = qwen2moe_shared_expert_output(x, gate_proj, up_proj, down_proj, shared_gate_weight)
+    assert got.abs().max() < 1e-3


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟠 **PR-Agent Score: 72** `score-70-79` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/238#issuecomment-5546569401) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit b883e83](https://github.com/Performant-Labs/FreeToken-Intel/commit/b883e83f248396573377eab86bd2a7865a8b6e9d) · run [#33920227904](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33920227904) · 2026-09-04 15:19 MDT / 2026-09-04 21:19 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Foundational first child of epic #220 (Qwen1.5-MoE-A2.7B). Real `parse_config`/`iter_weights` grounded against the real downloaded `Qwen/Qwen1.5-MoE-A2.7B` checkpoint, bias-term MHA attention (no q/k norm -- a real, different variant from this port's Qwen3-family attention), and the router + gated-shared-expert combination.

Two real things confirmed against the real HF reference (`transformers.models.qwen2_moe.modeling_qwen2_moe`), not assumed:
- `Qwen2MoeAttention`: q/k/v carry real bias terms (`qkv_bias=True`), `o_proj` stays bias-free.
- `Qwen2MoeSparseMoeBlock.forward`: the shared expert is **gated** -- `sigmoid(shared_expert_gate(x)) * shared_expert(x)` -- a different mechanism from `deepseek_v4`/`glm_moe_dsa`'s unconditional shared-expert add.

Standalone, independently-testable primitives (config + attention + router), same shape as `qwen4_exp`'s own `#206`/`#208` -- not yet wired into a decoder layer or the engine; that is issue #222's job.

Uses the correct KV-cache physical-slot addressing from the start (`out_loc = page_table[table_idx, positions]`) -- the pattern PR #234/#236 established this session after finding real corruption bugs in `qwen3`/`qwen3_moe`/`qwen3_5_moe`/`deepseek_v4`.

## Test plan
- [x] `.venv` (torch-free): 208 passed
- [x] `.venv-xpu -m "not xpu"`: 596 passed, 1 pre-existing unrelated flake (`test_fetch_fraction_none_when_no_profile`)
- [x] Real B70 forward pass (`xpu:0`): finite output, confirmed directly (not just via pytest's device-agnostic path)

Parent epic: #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Qwen2-MoE config parsing and weight loading

- Implement bias-term Qwen2MoeAttention with RoPE/KV-pool

- Add softmax top-k router and gated shared expert

- Add standalone unit tests for all new primitives


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New qwen2_moe primitives"] --> B["parse_config / iter_weights"]
  A --> C["Qwen2MoeAttention with bias q/k/v"]
  A --> D["qwen2moe_router softmax top-k"]
  A --> E["qwen2moe_shared_expert_output gated"]
  B --> F["Unit tests"]
  C --> F
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add Qwen2-MoE config, attention, and router primitives</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen2_moe/__init__.py

<ul><li>Add config parsing for HF Qwen2MoeConfig with qkv_bias and MoE <br>attributes<br> <li> Add weight iterator with lm_head synthesis for tied embeddings<br> <li> Implement Qwen2MoeAttention using bias q/k/v projections and RoPE<br> <li> Implement softmax top-k router and gated shared expert functions</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/238/files#diff-99e63ae2293988221e8df25e787743e70d974f3ccf9a6ac88f69617cf0da80be">+263/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_qwen2_moe_attn.py</strong><dd><code>Add unit tests for Qwen2-MoE primitives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_qwen2_moe_attn.py

<ul><li>Verify attention forward runs and bias terms affect output<br> <li> Test router softmax top-k matches hand-computed reference<br> <li> Test router renormalization behavior with norm_topk_prob<br> <li> Test gated shared expert output and gate modulation</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/238/files#diff-9e8fce1678803cf52d23977ad42a5f724166c17eae704f5a6c5a4d46d0c665a5">+159/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___