### PR TITLE
feat(models): port Mellum2-12B-A2.5B GQA/QK-norm attention + MoE router (issue #227)

### DIFF
--- a/python/freetoken/models/mellum/__init__.py
+++ b/python/freetoken/models/mellum/__init__.py
@@ -1,0 +1,246 @@
+"""Mellum2-12B-A2.5B (issue #227, `models-mellum-attn`) -- config parsing +
+GQA/QK-norm attention + the flat top-8/64 MoE router.
+
+Real checkpoint `JetBrains/Mellum2-12B-A2.5B-Base` (`model_type=mellum`,
+`transformers.MellumConfig`, v5.15.1): GQA (32 Q / 4 KV heads, head_dim=128,
+explicit -- hidden_size(2304)/num_heads(32)=72 != 128), per-head q_norm/k_norm,
+64 routed experts, flat top-8 (`norm_topk_prob=True`, no `n_group` -- ungrouped,
+matching this port's own `qwen3_moe` router), no shared expert.
+
+Two things confirmed from the REAL checkpoint's own config.json (not the HF
+class defaults, which differ): `layer_types` genuinely alternates 3
+sliding_attention + 1 full_attention every 4 layers (NOT the class default of
+all full_attention), and `mlp_layer_types` is genuinely all "sparse" (matches
+the class default -- every layer is MoE, no dense layers). Sliding-attention
+layers use plain RoPE; full-attention layers use YaRN-scaled RoPE with a
+DIFFERENT rope_theta config than the class default alone would suggest -- two
+independent per-layer-type RoPE tables, not one shared table.
+
+Attention and router math are adapted from this port's own `qwen3_moe`
+(`_Qwen3Attention`/`_Qwen3MoE`), which is the closest existing architecture
+(GQA + per-head QK-norm + flat-renormalized top-k, identical shape) --
+duplicated rather than imported (every model package in this port stands
+alone). Critically this reuse also carries forward PR #234's real KV-cache
+fix (`write_kv`'s `out_loc` must be the physical pool slot from
+`ctx.page_table`, not the logical token position -- the previous
+`qwen3`/`qwen3_moe` bug, invisible under a synthetic identity page table).
+
+Standalone primitives only (`MellumAttention`, `mellum_moe_router`) -- not
+yet wired into a decoder layer or the engine (that's #228's job).
+"""
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+if TYPE_CHECKING:
+    from freetoken.models.config import ModelConfig
+
+from freetoken.models.config import ModelConfig as _ModelConfig
+
+
+def _yarn_inv_freq_and_scaling(
+    head_dim: int, rope_theta: float, rope_params: dict, device
+) -> Tuple[torch.Tensor, float]:
+    """The real YaRN formula (HF ``modeling_rope_utils.py``'s
+    ``_compute_yarn_parameters``) -- identical to this port's own
+    ``gpt_oss._yarn_inv_freq_and_scaling``, duplicated per this port's
+    "every model package stands alone" convention. Mellum's real
+    checkpoint already provides ``attention_factor`` directly (no need to
+    infer it from ``mscale``/``mscale_all_dim``, which it doesn't set)."""
+    dim = head_dim
+    base = float(rope_theta)
+    factor = float(rope_params["factor"])
+    original_max = float(rope_params["original_max_position_embeddings"])
+    beta_fast = float(rope_params.get("beta_fast") or 32)
+    beta_slow = float(rope_params.get("beta_slow") or 1)
+    truncate = bool(rope_params.get("truncate", True))
+    attention_factor = rope_params.get("attention_factor")
+    mscale = rope_params.get("mscale")
+    mscale_all_dim = rope_params.get("mscale_all_dim")
+
+    def get_mscale(scale, m=1.0):
+        if scale <= 1:
+            return 1.0
+        return 0.1 * m * math.log(scale) + 1.0
+
+    if attention_factor is None:
+        if mscale and mscale_all_dim:
+            attention_factor = get_mscale(factor, mscale) / get_mscale(factor, mscale_all_dim)
+        else:
+            attention_factor = get_mscale(factor)
+
+    def find_correction_dim(num_rotations):
+        return (dim * math.log(original_max / (num_rotations * 2 * math.pi))) / (2 * math.log(base))
+
+    low = find_correction_dim(beta_fast)
+    high = find_correction_dim(beta_slow)
+    if truncate:
+        low, high = math.floor(low), math.ceil(high)
+    low, high = max(low, 0), min(high, dim - 1)
+
+    def linear_ramp_factor(lo, hi, n):
+        if lo == hi:
+            hi += 0.001
+        return torch.clamp((torch.arange(n, dtype=torch.float32) - lo) / (hi - lo), 0, 1)
+
+    pos_freqs = base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+    inv_freq_extrapolation = 1.0 / pos_freqs
+    inv_freq_interpolation = 1.0 / (factor * pos_freqs)
+    extrap_factor = 1 - linear_ramp_factor(low, high, dim // 2).to(device)
+    inv_freq = inv_freq_interpolation * (1 - extrap_factor) + inv_freq_extrapolation * extrap_factor
+    return inv_freq, float(attention_factor)
+
+
+def parse_config(hf_config, model_path: str | None = None, **_kwargs) -> "ModelConfig":
+    """Build a :class:`ModelConfig` from a real Mellum ``config.json``.
+
+    ``rope_parameters`` (per-attention-type: ``full_attention`` uses YaRN,
+    ``sliding_attention`` uses plain RoPE) and ``layer_types`` are stashed
+    verbatim on ``cfg.attrs`` -- read the REAL checkpoint's own values here,
+    never the HF class defaults (all-full-attention / all-plain-RoPE),
+    which do not match the real shipped checkpoint.
+    """
+    src = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(hf_config)
+    n = int(src.get("num_hidden_layers") or 0)
+    layer_types = src.get("layer_types") or (["full_attention"] * n)
+    mlp_layer_types = src.get("mlp_layer_types") or (["sparse"] * n)
+    rope_params = src.get("rope_parameters") or {}
+
+    cfg = _ModelConfig(
+        architectures=["MellumForCausalLM"],
+        hidden_size=src.get("hidden_size"),
+        vocab_size=src.get("vocab_size"),
+        num_layers=n,
+        num_experts=src.get("num_experts") or src.get("num_local_experts"),
+        num_attention_heads=src.get("num_attention_heads"),
+        num_key_value_heads=src.get("num_key_value_heads"),
+        head_dim=int(src["head_dim"]) if src.get("head_dim") else None,
+        intermediate_size=src.get("intermediate_size"),
+        moe_intermediate_size=src.get("moe_intermediate_size"),
+        num_experts_per_tok=src.get("num_experts_per_tok"),
+        max_position_embeddings=src.get("max_position_embeddings"),
+        tie_word_embeddings=src.get("tie_word_embeddings", False),
+        hidden_act=src.get("hidden_act", "silu"),
+        dtype=src.get("torch_dtype") or src.get("dtype"),
+    )
+    cfg.is_moe = True
+    cfg.attrs["layer_types"] = layer_types
+    cfg.attrs["mlp_layer_types"] = mlp_layer_types
+    cfg.attrs["rope_parameters"] = rope_params
+    cfg.attrs["sliding_window"] = int(src.get("sliding_window") or 0)
+    cfg.attrs["norm_topk_prob"] = bool(src.get("norm_topk_prob", True))
+    cfg.attrs["rms_norm_eps"] = float(src.get("rms_norm_eps", 1e-6))
+    return cfg
+
+
+class MellumAttention(nn.Module):
+    """GQA + per-head q/k RMSNorm attention for one Mellum layer.
+
+    ``layer_type`` ("full_attention" | "sliding_attention") picks this
+    layer's own RoPE table (YaRN for full, plain for sliding -- two
+    independent tables, per the real checkpoint's own per-type
+    ``rope_parameters``) and its sliding-window size (0 for full
+    attention). Adapted from ``qwen3_moe``'s own ``_Qwen3Attention``
+    (identical GQA/QK-norm math and KV-pool contract -- see that module's
+    own ``write_kv``/``out_loc`` comments, carried forward here verbatim:
+    ``out_loc`` must be the PHYSICAL pool slot from ``ctx.page_table``,
+    never the raw logical position, per PR #234's real fix).
+    """
+
+    def __init__(self, config: "ModelConfig", device, dtype, layer_id: int, layer_type: str) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        self.layer_type = layer_type
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads or config.num_attention_heads
+        self.head_dim = config.head_dim or (config.hidden_size // self.num_heads)
+        self.sliding_window = config.attrs.get("sliding_window", 0) if layer_type == "sliding_attention" else 0
+
+        from freetoken.layers import LinearOProj, LinearReplicated
+
+        self.q_proj = LinearReplicated(config.hidden_size, self.num_heads * self.head_dim, has_bias=False, dtype=dtype)
+        self.k_proj = LinearReplicated(config.hidden_size, self.num_kv_heads * self.head_dim, has_bias=False, dtype=dtype)
+        self.v_proj = LinearReplicated(config.hidden_size, self.num_kv_heads * self.head_dim, has_bias=False, dtype=dtype)
+        self.o_proj = LinearOProj(self.num_heads * self.head_dim, config.hidden_size, has_bias=False, dtype=dtype)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.attrs.get("rms_norm_eps", 1e-6), dtype=dtype)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.attrs.get("rms_norm_eps", 1e-6), dtype=dtype)
+
+        rope_params = (config.attrs.get("rope_parameters") or {}).get(layer_type, {})
+        theta = float(rope_params.get("rope_theta") or 10000.0)
+        rope_type = str(rope_params.get("rope_type") or "default").lower()
+        if rope_type == "yarn":
+            inv_freq, self.attention_scaling = _yarn_inv_freq_and_scaling(
+                self.head_dim, theta, rope_params, device
+            )
+        else:
+            inv_freq = 1.0 / (
+                theta ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32, device=device) / self.head_dim)
+            )
+            self.attention_scaling = 1.0
+        self.register_buffer("inv_freq", inv_freq)
+
+    def _rope(self, x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
+        # Half-split (rotate_half), matching the real HF convention (see
+        # qwen3/qwen3_moe's own docstrings on this exact bug class).
+        freqs = torch.outer(pos.to(torch.float32), self.inv_freq)  # [N, D/2]
+        emb = torch.cat((freqs, freqs), dim=-1)  # [N, D]
+        cos = (emb.cos() * self.attention_scaling)[None, :, :]
+        sin = (emb.sin() * self.attention_scaling)[None, :, :]
+        x_f = x.to(torch.float32)
+        half = x_f.shape[-1] // 2
+        x1, x2 = x_f[..., :half], x_f[..., half:]
+        rotated = torch.cat((-x2, x1), dim=-1)
+        return (x_f * cos + rotated * sin).to(x.dtype)
+
+    def forward(self, hidden_states, positions, table_idx, ctx, batch):
+        bsz, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).view(bsz, self.num_heads, self.head_dim).transpose(0, 1)
+        k = self.k_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        v = self.v_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        q = self._rope(self.q_norm(q), positions)
+        k = self._rope(self.k_norm(k), positions)
+        # write_kv's out_loc is the PHYSICAL pool slot (ctx.page_table),
+        # never the raw logical position -- PR #234's real fix, carried
+        # forward here from day one rather than reintroducing the bug.
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k, v, out_loc, self.layer_id)
+        from freetoken.attention.base import AttentionSpec
+
+        attn_spec = AttentionSpec(sliding_window=self.sliding_window or None)
+        out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, attn_spec=attn_spec, table_idx=table_idx)
+        return self.o_proj(out.transpose(0, 1).contiguous().reshape(bsz, -1))
+
+
+def mellum_moe_router(hidden_states: torch.Tensor, gate_weight: torch.Tensor, top_k: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Flat top-k router, no shared expert, always renormalized (matches
+    the real checkpoint's ``norm_topk_prob=True`` and this port's own
+    ``qwen3_moe`` router math exactly -- confirmed direct reuse).
+
+    ``hidden_states`` is ``[T, hidden]``, ``gate_weight`` is
+    ``[num_experts, hidden]`` (a plain linear, no bias). Returns
+    ``(top_w [T, top_k], top_idx [T, top_k])``.
+    """
+    routing = F.linear(hidden_states, gate_weight)  # [T, num_experts]
+    gate_log = F.softmax(routing, dim=-1)
+    top_w, top_idx = torch.topk(gate_log, top_k, dim=-1)
+    top_w = (top_w / top_w.sum(dim=-1, keepdim=True)).to(hidden_states.dtype)
+    return top_w, top_idx
+
+
+__all__ = ["MellumAttention", "mellum_moe_router", "parse_config"]
+
+
+# --------------------------------------------------------------------------- #
+# Not yet implemented: full model wiring (#228).
+# --------------------------------------------------------------------------- #
+
+from freetoken._stub import unimplemented
+
+
+def iter_weights(*args, **kwargs):
+    unimplemented("iter_weights", "models-mellum-e2e")

--- a/tests/test_models_mellum_attn.py
+++ b/tests/test_models_mellum_attn.py
@@ -1,0 +1,180 @@
+"""Unit tests for Mellum2-12B-A2.5B's attention + router primitives (issue
+`models-mellum-attn`, #227, first child of the Mellum epic #226).
+
+Standalone -- not yet wired into a decoder layer or the engine (that's
+#228's job). Pins: (1) the flat top-8/64 router's hand-computed math
+(direct reuse of `qwen3_moe`'s own router shape), (2) a real attention
+forward pass through both a `full_attention` (YaRN RoPE) and a
+`sliding_attention` (plain RoPE) layer, and (3) PR #234's KV-cache fix --
+`write_kv`'s `out_loc` must be the PHYSICAL page-table slot, never the
+raw logical position, using a deliberately NON-identity page table (slot
+0 reserved, matching the real `MHAKVCache` allocator's own convention)
+so an identity-table test could not silently hide the bug.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.attention.triton import TritonAttentionBackend
+from freetoken.core import Batch, Context, Req, SamplingParams, reset_global_ctx, set_global_ctx
+from freetoken.kvcache.base import BaseKVCachePool
+from freetoken.models.mellum import MellumAttention, mellum_moe_router, parse_config
+
+H, V, L = 32, 64, 4
+NH, KVH, HD = 4, 2, 16
+E, TOPK = 8, 2
+
+TINY_CONFIG = {
+    "architectures": ["MellumForCausalLM"],
+    "model_type": "mellum",
+    "hidden_size": H,
+    "vocab_size": V,
+    "num_hidden_layers": L,
+    "num_attention_heads": NH,
+    "num_key_value_heads": KVH,
+    "head_dim": HD,
+    "intermediate_size": 48,
+    "moe_intermediate_size": 24,
+    "num_experts": E,
+    "num_experts_per_tok": TOPK,
+    "norm_topk_prob": True,
+    "rms_norm_eps": 1e-6,
+    "sliding_window": 4,
+    "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"],
+    "mlp_layer_types": ["sparse"] * L,
+    "rope_parameters": {
+        "full_attention": {
+            "rope_type": "yarn",
+            "rope_theta": 500000.0,
+            "factor": 16.0,
+            "original_max_position_embeddings": 64,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "attention_factor": 1.2,
+        },
+        "sliding_attention": {"rope_type": "default", "rope_theta": 500000.0},
+    },
+    "max_position_embeddings": 4096,
+    "tie_word_embeddings": False,
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _config():
+    return parse_config(type("Hf", (), {"to_dict": lambda self: TINY_CONFIG})())
+
+
+def test_config_carries_real_per_layer_type_fields():
+    config = _config()
+    assert config.attrs["layer_types"] == TINY_CONFIG["layer_types"]
+    assert config.attrs["mlp_layer_types"] == ["sparse"] * L
+    assert config.attrs["sliding_window"] == 4
+    assert config.head_dim == HD  # explicit, not derived (H/NH != HD)
+
+
+def test_mellum_moe_router_matches_hand_computed_reference():
+    torch.manual_seed(0)
+    T = 5
+    hidden = torch.randn(T, H)
+    gate_weight = torch.randn(E, H) * 0.1
+
+    top_w, top_idx = mellum_moe_router(hidden, gate_weight, TOPK)
+    assert top_w.shape == (T, TOPK)
+    assert top_idx.shape == (T, TOPK)
+
+    # Independent hand-computed reference.
+    logits = hidden @ gate_weight.t()
+    probs = torch.softmax(logits, dim=-1)
+    exp_w, exp_idx = torch.topk(probs, TOPK, dim=-1)
+    exp_w = exp_w / exp_w.sum(dim=-1, keepdim=True)
+    torch.testing.assert_close(top_idx, exp_idx)
+    torch.testing.assert_close(top_w, exp_w, atol=1e-5, rtol=1e-5)
+    # norm_topk_prob=True: the selected weights always renormalize to 1.
+    torch.testing.assert_close(top_w.sum(dim=-1), torch.ones(T))
+
+
+def _run_attention_forward(layer_id: int, layer_type: str, num_pages: int = 32):
+    config = _config()
+    torch.manual_seed(1)
+    attn = MellumAttention(config, torch.device("cpu"), torch.float32, layer_id=layer_id, layer_type=layer_type)
+    # LinearReplicated/RMSNorm weights are `torch.empty` (loader-filled in
+    # production) -- a unit test must seed them itself or every forward is
+    # NaN from the first projection, before rope/KV-cache even run.
+    gen = torch.Generator().manual_seed(2024)
+    with torch.no_grad():
+        for p in attn.parameters():
+            p.copy_(torch.randn(p.shape, generator=gen) * 0.1)
+
+    T = 3
+    hidden_states = torch.randn(T, H)
+    positions = torch.arange(T)
+
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(config, page_size=1, num_pages=num_pages, device=torch.device("cpu"), dtype=torch.float32)
+    # Deliberately NON-identity page table (slot 0 reserved, matching the
+    # real MHAKVCache allocator's own convention) -- an identity table is
+    # exactly what let PR #234's bug hide in earlier tests.
+    pt = torch.zeros((1, num_pages), dtype=torch.int32)
+    pt[0, :T] = torch.arange(1, T + 1)
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    ctx.attn_backend = TritonAttentionBackend(config)
+    req = Req(
+        input_ids=list(range(T)), table_idx=0, cached_len=0, output_len=1, uid=0,
+        sampling_params=SamplingParams(), cache_handle=None,
+    )
+    req.device_len = T
+    batch = Batch(reqs=[req], phase="prefill", positions=positions.clone(), extend_lens=[T])
+    set_global_ctx(ctx)
+    ctx._batch = batch
+
+    captured = {}
+    orig_write_kv = ctx.kv_cache.write_kv
+
+    def spy_write_kv(k, v, out_loc, layer_id=0):
+        captured["out_loc"] = out_loc.clone()
+        return orig_write_kv(k, v, out_loc, layer_id)
+
+    ctx.kv_cache.write_kv = spy_write_kv
+    try:
+        out = attn.forward(hidden_states, positions, 0, ctx, batch)
+    finally:
+        ctx.kv_cache.write_kv = orig_write_kv
+    return out, captured, positions, pt
+
+
+def test_full_attention_layer_uses_yarn_rope_and_physical_slots():
+    out, captured, positions, pt = _run_attention_forward(3, "full_attention")
+    assert out.shape == (3, H)
+    assert torch.isfinite(out).all()
+    expected_slots = pt[0, positions.long()]
+    assert 0 not in expected_slots.tolist()
+    assert captured["out_loc"].equal(expected_slots)
+    assert not captured["out_loc"].equal(positions)
+
+
+def test_sliding_attention_layer_uses_plain_rope_and_physical_slots():
+    out, captured, positions, pt = _run_attention_forward(0, "sliding_attention")
+    assert out.shape == (3, H)
+    assert torch.isfinite(out).all()
+    expected_slots = pt[0, positions.long()]
+    assert captured["out_loc"].equal(expected_slots)
+    assert not captured["out_loc"].equal(positions)
+
+
+def test_full_and_sliding_layers_use_different_rope_tables():
+    config = _config()
+    full = MellumAttention(config, torch.device("cpu"), torch.float32, layer_id=3, layer_type="full_attention")
+    sliding = MellumAttention(config, torch.device("cpu"), torch.float32, layer_id=0, layer_type="sliding_attention")
+    assert not torch.allclose(full.inv_freq, sliding.inv_freq)
+    assert full.attention_scaling != 1.0  # YaRN's attention_factor
+    assert sliding.attention_scaling == 1.0  # plain RoPE, no scaling
+    assert full.sliding_window == 0
+    assert sliding.sliding_window == TINY_CONFIG["sliding_window"]


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 90** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 92e4bce](https://github.com/Performant-Labs/FreeToken-Intel/commit/92e4bce42e868c2931310e9c66e2d45e1ff0f3d1) · run [#33922183583](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33922183583) · 2026-09-04 15:51 MDT / 2026-09-04 21:51 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Summary
Implements `models-mellum-attn` (#227), the first child of the Mellum epic (#226).

Real checkpoint config (`JetBrains/Mellum2-12B-A2.5B-Base`) confirms genuine architectural complexity beyond the HF class defaults:
- `layer_types` genuinely alternates 3 `sliding_attention` + 1 `full_attention` every 4 layers (class default is all `full_attention`)
- `full_attention` layers use YaRN rope scaling; `sliding_attention` layers use plain rope -- **two independent per-layer-type rope tables**, not one shared table

Attention and router are adapted from this port's own `qwen3_moe` (closest existing match: GQA + per-head QK-norm + flat-renormalized top-k, identical shape), carrying forward PR #234's real KV-cache fix (`write_kv`'s `out_loc` must be the physical page-table slot, never the raw logical position) from day one rather than reintroducing that bug. YaRN math reuses `gpt_oss`'s own verbatim port of `transformers._compute_yarn_parameters`.

Standalone primitives only (`MellumAttention`, `mellum_moe_router`) -- not yet wired into a decoder layer or the engine (that's #228's job).

## Test plan
- [x] Small synthetic fixture, hand-computed router reference, real attention forward through both a `full_attention` (YaRN) and `sliding_attention` (plain rope) layer
- [x] Deliberately non-identity page table (slot 0 reserved) so the `write_kv` physical-slot regression check can't be silently hidden the way an identity table hid PR #234's bug in earlier tests
- [x] `.venv-xpu -m "not xpu"`: 626 passed, 1 pre-existing unrelated flake (`test_fetch_fraction_none_when_no_profile`), 1 skipped, 117 deselected
- [x] Real B70/XPU forward pass (`xpu:0`): finite output confirmed for both attention layer types and the router

Parent epic: #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `MellumAttention` with GQA, QK-norm, dual RoPE.

- Add YaRN port and per-layer-type config parsing.

- Add flat top-k renormalized MoE router primitive.

- Add tests for router math, KV-cache physical slots.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parse_config stores layer_types and rope_parameters"] -- "config" --> B["_yarn_inv_freq_and_scaling"]
  B -- "rope table" --> C["MellumAttention: GQA/QK-norm dual RoPE"]
  C -- "writes" --> D["KV-cache physical-slot write_kv"]
  E["mellum_moe_router: flat top-k"] --> F["Unit tests for router, attention, physical slots"]
  C --> F
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add Mellum attention, router, config parsing primitives</code>&nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/mellum/__init__.py

<ul><li>Add <code>_yarn_inv_freq_and_scaling</code> for YaRN RoPE parameters.<br> <li> Add <code>parse_config</code> storing <code>layer_types</code>, <code>rope_parameters</code>, <code>sliding_window</code>, <br>MoE flags.<br> <li> Add <code>MellumAttention</code> with GQA, QK-norm, per-layer-type RoPE and <br>physical-slot <code>write_kv</code>.<br> <li> Add <code>mellum_moe_router</code> flat top-k renormalized; stub <code>iter_weights</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/239/files#diff-9f7422d4fed6f5fdac4b4174bae08f7372f0ab6bf47511a47505e35540ae5017">+246/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_mellum_attn.py</strong><dd><code>Unit tests for Mellum attention and router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_mellum_attn.py

<ul><li>Test <code>parse_config</code> preserves real per-layer-type fields.<br> <li> Verify flat top-k router against hand-computed reference.<br> <li> Run attention forward for <code>full_attention</code> and <code>sliding_attention</code> layers.<br> <li> Use non-identity page table for physical-slot regression.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/239/files#diff-406d6a9095017f93864b6f4e6b0189616976d0c6587e51bca7b366d407c72d29">+180/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___