### PR TITLE
feat(models): wire Mellum2-12B-A2.5B full model + register class (issue #228)

### DIFF
--- a/python/freetoken/models/mellum/__init__.py
+++ b/python/freetoken/models/mellum/__init__.py
@@ -232,15 +232,222 @@ def mellum_moe_router(hidden_states: torch.Tensor, gate_weight: torch.Tensor, to
     return top_w, top_idx
 
 
-__all__ = ["MellumAttention", "mellum_moe_router", "parse_config"]
+def _xpu_available() -> bool:
+    try:
+        return bool(torch.xpu.is_available())
+    except Exception:
+        return False
 
 
-# --------------------------------------------------------------------------- #
-# Not yet implemented: full model wiring (#228).
-# --------------------------------------------------------------------------- #
+def iter_weights(
+    model_path: str,
+    device: torch.device,
+    *,
+    include_moe_experts: bool = True,
+    include_non_moe: bool = True,
+) -> "iter[tuple[str, torch.Tensor]]":
+    """Yield the checkpoint's tensors, each on its destination device.
 
-from freetoken._stub import unimplemented
+    Fused (in-VRAM) experts only for now (issue #226's own scope note: no
+    offload/CPU/hybrid MoE backend for Mellum yet, mirroring how
+    ``glm4_moe``/``gpt_oss`` shipped fused-only first) -- every tensor,
+    including experts, is placed on ``device``. Real bug found wiring this:
+    ``include_moe_experts``/``include_non_moe`` are NOT no-ops even on the
+    fused path -- the loader's own ``load_moe_expert_sources`` streams this
+    generator with ``include_non_moe=False`` to gather ONLY expert tensors
+    into banks (fused and offload both build the banks first; fused then
+    copies them into resident expert modules), and ``_place_dense`` streams
+    it separately with ``include_moe_experts=False`` for the dense pass.
+    Ignoring these kwargs mixes dense tensors (e.g. ``lm_head.weight``) into
+    the expert-bank stream, which raises inside
+    ``weight.py:stream_moe_expert_sources`` ("Unexpected expert weight
+    key") -- confirmed by hitting exactly that error before this filter was
+    added. Mirrors ``qwen3_moe``'s own ``iter_weights`` filtering.
+
+    Synthesizes ``lm_head.weight`` from ``embed_tokens.weight`` for a
+    ``tie_word_embeddings: true`` checkpoint that ships no separate
+    ``lm_head.weight`` key -- same real failure mode ``qwen3``/``qwen3_moe``
+    already guard against (an unfilled ``lm_head`` silently zeros every
+    logit).
+    """
+    from freetoken.models.weight import iter_safetensors
+
+    embed_tokens_weight = None
+    saw_lm_head = False
+    for name, tensor in iter_safetensors(model_path, device):
+        is_expert = ".experts." in name
+        if is_expert and not include_moe_experts:
+            continue
+        if not is_expert and not include_non_moe:
+            continue
+        placed = tensor.to(device)
+        if name == "model.embed_tokens.weight":
+            embed_tokens_weight = placed
+        elif name == "lm_head.weight":
+            saw_lm_head = True
+        yield name, placed
+
+    if include_non_moe and not saw_lm_head and embed_tokens_weight is not None:
+        from freetoken.utils import cached_load_hf_config
+
+        hf_config = cached_load_hf_config(model_path)
+        if bool(getattr(hf_config, "tie_word_embeddings", False)):
+            yield "lm_head.weight", embed_tokens_weight
 
 
-def iter_weights(*args, **kwargs):
-    unimplemented("iter_weights", "models-mellum-e2e")
+class _MellumExpert(nn.Module):
+    """A single MoE expert: gate/up/down projections (SwiGLU), fused/in-VRAM only."""
+
+    def __init__(self, config, dtype) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(config.hidden_size, config.moe_intermediate_size, bias=False, dtype=dtype)
+        self.up_proj = nn.Linear(config.hidden_size, config.moe_intermediate_size, bias=False, dtype=dtype)
+        self.down_proj = nn.Linear(config.moe_intermediate_size, config.hidden_size, bias=False, dtype=dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _MellumMoE(nn.Module):
+    """Router + N fused (XPU-resident) experts, no shared expert.
+
+    Reuses ``mellum_moe_router`` (#227's own standalone primitive) for the
+    routing math, then a per-expert gather over the resident ``_MellumExpert``
+    modules -- the same "route on host, gather with index_select" pattern
+    ``qwen3_moe``'s fused path uses (XPU `nonzero()`/boolean-mask indexing on
+    this torch/XPU build silently returns empty for a bool tensor regardless
+    of content -- a real, confirmed bug this port routes around everywhere).
+    """
+
+    def __init__(self, config, device, dtype) -> None:
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        from freetoken.layers import LinearReplicated
+
+        self.gate = LinearReplicated(config.hidden_size, self.num_experts, has_bias=False, dtype=dtype)
+        self.experts = nn.ModuleList(_MellumExpert(config, dtype).to(device, dtype) for _ in range(self.num_experts))
+
+    def forward(self, hidden_states: torch.Tensor, model=None, batch=None) -> torch.Tensor:
+        in_shape = hidden_states.shape
+        flat = hidden_states.reshape(-1, in_shape[-1])  # [T, hidden]
+        top_w, top_idx = mellum_moe_router(flat, self.gate.weight, self.top_k)
+
+        out = torch.zeros_like(flat)
+        top_idx_host = top_idx.to("cpu")
+        for e in range(self.num_experts):
+            token_rows, k_slots = (top_idx_host == e).nonzero(as_tuple=True)
+            if token_rows.numel() == 0:
+                continue
+            token_rows = token_rows.to(flat.device)
+            k_slots = k_slots.to(flat.device)
+            sel = flat.index_select(0, token_rows)
+            expert_out = self.experts[e](sel)
+            w = top_w[token_rows, k_slots].unsqueeze(-1)
+            out.index_add_(0, token_rows, expert_out * w)
+        return out.view(in_shape)
+
+
+class _MellumDecoderLayer(nn.Module):
+    def __init__(self, config, device, dtype, layer_id: int) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        layer_types = config.attrs.get("layer_types") or []
+        layer_type = layer_types[layer_id] if layer_id < len(layer_types) else "full_attention"
+        eps = config.attrs.get("rms_norm_eps", 1e-6)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=eps, dtype=dtype)
+        self.self_attn = MellumAttention(config, device, dtype, layer_id, layer_type)
+        self.post_attention_layernorm = nn.RMSNorm(config.hidden_size, eps=eps, dtype=dtype)
+        self.mlp = _MellumMoE(config, device, dtype)
+        self.mlp.layer_id = layer_id
+
+    def forward(self, hidden_states, positions, table_idx, ctx, batch):
+        residual = hidden_states
+        hidden_states = self.self_attn(self.input_layernorm(hidden_states), positions, table_idx, ctx, batch)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = residual + self.mlp(
+            self.post_attention_layernorm(hidden_states), model=ctx.model, batch=batch
+        )
+        return hidden_states
+
+
+class MellumForCausalLM(nn.Module):
+    """The Mellum2 model: real forward pass for the Intel engine loop.
+
+    Subclasses ``nn.Module`` (not the torch-free ``BaseLLMModel`` stub) so its
+    parameters are real registered ``nn.Parameter``s -- the loader resolves
+    ``named_parameters()``/``named_buffers()`` to fill weights, which only
+    works for proper ``nn.Module`` children. Structurally identical to
+    ``qwen3_moe``'s own ``Qwen3MoeForCausalLM`` (same reuse this whole
+    package already leans on), fused-MoE-only (no offload path yet, see
+    ``iter_weights``'s own note).
+    """
+
+    def __init__(self, config, device=None) -> None:
+        super().__init__()
+        self.config = config
+        if device is None:
+            device = torch.device("xpu") if _xpu_available() else torch.device("cpu")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        self.device = device
+        dtype = getattr(config, "dtype", None) or torch.bfloat16
+        vocab_size = getattr(config, "vocab_size", 256)
+        hidden_size = getattr(config, "hidden_size", 256)
+        num_layers = getattr(config, "num_layers", 0)
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size, device=device, dtype=dtype)
+        self.layers = nn.ModuleList(
+            _MellumDecoderLayer(config, device, dtype, layer_id=i) for i in range(num_layers)
+        )
+        eps = config.attrs.get("rms_norm_eps", 1e-6) if getattr(config, "attrs", None) else 1e-6
+        self.norm = nn.RMSNorm(hidden_size, eps=eps, dtype=dtype)
+        from freetoken.layers import LinearReplicated
+
+        self.lm_head = LinearReplicated(hidden_size, vocab_size, has_bias=False, dtype=dtype)
+        # No offload/CPU/hybrid MoE backend yet (see iter_weights); always
+        # fused/in-VRAM, so the engine's offload plumbing must see this model
+        # as never eligible for it.
+        self.moe_offload = False
+        self.moe_cache = None
+        self.moe_layer_id = None
+        if self.device.type != "cpu":
+            self.to(self.device)
+
+    def forward(self, input_ids: torch.Tensor, positions: torch.Tensor, out_loc: torch.Tensor) -> torch.Tensor:
+        """Run one engine step; return the **last-position** logits ``[bs, V]``."""
+        from freetoken.core import get_global_ctx
+
+        ctx = get_global_ctx()
+        batch = ctx.batch
+        reqs = batch.reqs
+        num_tokens = input_ids.shape[0]
+
+        hidden = self.embed_tokens(input_ids)  # [num_tokens, hidden]
+        out = torch.empty((batch.size, self.config.hidden_size), device=hidden.device, dtype=hidden.dtype)
+
+        offset = 0
+        extend_lens = batch.extend_lens
+        if extend_lens is None:
+            prefill = batch.is_prefill or (num_tokens > batch.size)
+            extend_lens = [req.extend_len if prefill else 1 for req in reqs]
+        is_decode_batch = batch.phase == "decode"
+        for i, req in enumerate(reqs):
+            ext = 1 if is_decode_batch else int(extend_lens[i])
+            token_slice = slice(offset, offset + ext)
+            h = hidden[token_slice]
+            for layer in self.layers:
+                h = layer(h, positions[token_slice], req.table_idx, ctx, batch)
+            out[i] = self.norm(h)[-1]
+            offset += ext
+
+        return self.lm_head(out)
+
+
+__all__ = [
+    "MellumAttention",
+    "mellum_moe_router",
+    "parse_config",
+    "iter_weights",
+    "MellumForCausalLM",
+]

--- a/python/freetoken/models/register.py
+++ b/python/freetoken/models/register.py
@@ -35,6 +35,7 @@ _MODEL_REGISTRY: dict[str, ModelSpec] = {
     "OlmoeForCausalLM": ModelSpec("freetoken.models.olmoe", "OlmoeForCausalLM"),
     "Glm4MoeForCausalLM": ModelSpec("freetoken.models.glm4_moe", "Glm4MoeForCausalLM"),
     "GlmMoeDsaForCausalLM": ModelSpec("freetoken.models.glm_moe_dsa", "GlmMoeDsaForCausalLM"),
+    "MellumForCausalLM": ModelSpec("freetoken.models.mellum", "MellumForCausalLM"),
     # Qwen4ExpForCausalLM is the real registered class upstream builds
     # (model.py); ...ForConditionalGeneration is only config.py's own
     # fallback default string when a checkpoint's config.json lacks an

--- a/tests/test_models_mellum_e2e.py
+++ b/tests/test_models_mellum_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end: Mellum2-12B-A2.5B full model wiring (issue `models-mellum-e2e`,
+#228, final child of the Mellum epic #226).
+
+Small synthetic checkpoint only -- real-checkpoint validation against
+`JetBrains/Mellum2-12B-A2.5B-Base` is sequenced separately by the parent
+session (deliberately out of scope here, see the issue's own body). Mirrors
+the established per-model e2e pattern (`tests/test_models_glm_moe_dsa_e2e.py`,
+`tests/test_models_deepseek_v2_lite_mla_e2e.py`): seeded weights, no empty
+`model.safetensors.index.json`, a real `Engine` prefill+decode run.
+
+`layer_types` alternates 3 sliding_attention + 1 full_attention (matching the
+real checkpoint's own period-4 pattern, per `mellum/__init__.py`'s own
+docstring) -- 4 layers here exercises both attention variants and both
+per-type RoPE tables (plain for sliding, YaRN for full) in one small model.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.models.register import get_model_class
+
+DEVICE = "cpu"
+
+H, V, L = 32, 64, 4
+NH, KVH, HEAD_DIM = 4, 2, 8
+INTER, MOE_INTER = 48, 24
+E, TOPK = 4, 2
+LAYER_TYPES = ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"]
+
+TINY_CONFIG = {
+    "architectures": ["MellumForCausalLM"],
+    "model_type": "mellum",
+    "hidden_size": H,
+    "vocab_size": V,
+    "num_hidden_layers": L,
+    "num_attention_heads": NH,
+    "num_key_value_heads": KVH,
+    "head_dim": HEAD_DIM,
+    "intermediate_size": INTER,
+    "moe_intermediate_size": MOE_INTER,
+    "num_experts": E,
+    "num_experts_per_tok": TOPK,
+    "norm_topk_prob": True,
+    "max_position_embeddings": 128,
+    "sliding_window": 8,
+    "layer_types": LAYER_TYPES,
+    "mlp_layer_types": ["sparse"] * L,
+    "rope_parameters": {
+        "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+        "full_attention": {
+            "rope_type": "yarn",
+            "rope_theta": 500000.0,
+            "factor": 4.0,
+            "original_max_position_embeddings": 32,
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "attention_factor": 1.0,
+        },
+    },
+    "rms_norm_eps": 1e-5,
+    "tie_word_embeddings": False,
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _config():
+    from freetoken.models.mellum import parse_config
+
+    return parse_config(type("Hf", (), {"to_dict": lambda self: TINY_CONFIG})())
+
+
+def _write_tiny_checkpoint(tmp_path) -> str:
+    from safetensors.torch import save_file
+
+    model_path = tmp_path / "ckpt"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(json.dumps(TINY_CONFIG))
+
+    state = {}
+    gen = torch.Generator().manual_seed(0)
+
+    def add(name, shape):
+        state[name] = torch.randn(shape, generator=gen, dtype=torch.float32) * 0.02
+
+    add("model.embed_tokens.weight", (V, H))
+    for l in range(L):
+        p = f"model.layers.{l}"
+        add(f"{p}.input_layernorm.weight", (H,))
+        add(f"{p}.self_attn.q_proj.weight", (NH * HEAD_DIM, H))
+        add(f"{p}.self_attn.k_proj.weight", (KVH * HEAD_DIM, H))
+        add(f"{p}.self_attn.v_proj.weight", (KVH * HEAD_DIM, H))
+        add(f"{p}.self_attn.o_proj.weight", (H, NH * HEAD_DIM))
+        add(f"{p}.self_attn.q_norm.weight", (HEAD_DIM,))
+        add(f"{p}.self_attn.k_norm.weight", (HEAD_DIM,))
+        add(f"{p}.post_attention_layernorm.weight", (H,))
+        add(f"{p}.mlp.gate.weight", (E, H))
+        for e in range(E):
+            eb = f"{p}.mlp.experts.{e}"
+            add(f"{eb}.gate_proj.weight", (MOE_INTER, H))
+            add(f"{eb}.up_proj.weight", (MOE_INTER, H))
+            add(f"{eb}.down_proj.weight", (H, MOE_INTER))
+    add("model.norm.weight", (H,))
+    add("lm_head.weight", (V, H))
+
+    save_file(state, str(model_path / "model.safetensors"))
+    return str(model_path)
+
+
+def _engine_config(model_path: str, *, device: str | None = None) -> EngineConfig:
+    return EngineConfig(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=device,
+        attention_backend="auto",
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+    )
+
+
+def _add_prompt(engine: Engine, output_len: int) -> None:
+    engine.add_request(
+        Req(
+            input_ids=[1, 2, 3, 4, 5],
+            table_idx=0,
+            cached_len=0,
+            output_len=output_len,
+            uid=0,
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+            cache_handle=None,
+        )
+    )
+
+
+def test_model_class_builds_alternating_sliding_and_full_layers():
+    config = _config()
+    model = get_model_class("MellumForCausalLM", config, device=torch.device("cpu"))
+    for i, layer in enumerate(model.layers):
+        assert layer.self_attn.layer_type == LAYER_TYPES[i]
+        assert layer.self_attn.sliding_window == (8 if LAYER_TYPES[i] == "sliding_attention" else 0)
+
+
+def test_engine_generate_prefill_and_decode(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+    _add_prompt(engine, output_len=4)
+    generated = engine.generate()
+    vocab = engine.config.model_config.vocab_size
+    assert len(generated) == 1
+    assert len(generated[0]) == 4
+    assert all(0 <= t < vocab for t in generated[0])
+
+
+def test_engine_greedy_is_deterministic(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+
+    def build():
+        engine = Engine(_engine_config(model_path, device=DEVICE))
+        _add_prompt(engine, output_len=3)
+        return engine.generate()
+
+    a = build()
+    b = build()
+    assert a == b
+    assert len(a[0]) == 3


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 88** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/241#issuecomment-5547003378) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 85e0085](https://github.com/Performant-Labs/FreeToken-Intel/commit/85e008594a6f8297d16b8c4c2fb7ac01a929b197) · run [#33923996837](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33923996837) · 2026-09-04 16:09 MDT / 2026-09-04 22:09 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Why
Final child of the Mellum epic (#226), depends on #227 (attention+router, merged).

## What
Decoder layer combining #227's attention (alternating sliding/full RoPE tables per layer) and router primitives into a fused (in-VRAM) MoE block, plus the causal-LM wrapper, registered as `MellumForCausalLM` in `register.py`.

## Real bug found
`iter_weights` ignored the `include_moe_experts`/`include_non_moe` kwargs the loader relies on to separate the dense-weight pass from the expert-bank pass -- even on the fused path, `load_moe_expert_sources` streams expert tensors first (before `_place_expert_weights_any` copies them into resident modules). Mixing dense tensors (e.g. `lm_head.weight`) into that expert-only stream raised inside `stream_moe_expert_sources` ("Unexpected expert weight key"). Fixed to filter by `.experts.` in the tensor name, mirroring `qwen3_moe`'s own `iter_weights`.

## Scope note
Synthetic-checkpoint validation only per this task's directive (seeded weights, real `Engine` prefill+decode, real B70 forward pass confirmed). Real-checkpoint validation against the actual `JetBrains/Mellum2-12B-A2.5B-Base` download is sequenced separately by the parent session to avoid concurrent real-hardware memory pressure.

## Test plan
- [x] `.venv` (torch-free): skips as expected
- [x] `.venv-xpu -m "not xpu"`: 629 passed, 1 pre-existing unrelated flake (`test_fetch_fraction_none_when_no_profile`, present on `main`)
- [x] Real B70 forward pass (`xpu:0`) on the synthetic fixture: finite, in-range tokens confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add fused Mellum MoE, decoder, and causal-LM classes

- Fix iter_weights expert/dense filter handling

- Register MellumForCausalLM in model registry

- Add synthetic-checkpoint e2e generation tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add MellumForCausalLM wrapper"] --> B["Build fused _MellumMoE and decoder layers"]
  B --> C["Fix iter_weights dense/expert filtering"]
  C --> D["Register MellumForCausalLM in registry"]
  D --> E["Add synthetic-checkpoint e2e tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Implement fused Mellum model and weight iteration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/mellum/__init__.py

<ul><li>Add <code>iter_weights</code> with dense/expert filtering and <code>lm_head</code> synthesis<br> <li> Add fused <code>_MellumMoE</code> with CPU-routed expert gather<br> <li> Add <code>_MellumDecoderLayer</code> and <code>MellumForCausalLM</code> wrapper<br> <li> Update <code>__all__</code> exports</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/241/files#diff-9f7422d4fed6f5fdac4b4174bae08f7372f0ab6bf47511a47505e35540ae5017">+214/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register.py</strong><dd><code>Register MellumForCausalLM model class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/register.py

<ul><li>Add <code>MellumForCausalLM</code> architecture entry mapping to Mellum package</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/241/files#diff-e38ee7af842e0d485f9466cc2f82ee8a030eb7b9c2123709bb4d5ef745e4d65b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_mellum_e2e.py</strong><dd><code>Add Mellum e2e synthetic checkpoint tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_mellum_e2e.py

<ul><li>Add synthetic Mellum checkpoint fixture with alternating layer types<br> <li> Add model class layer-type assertion test<br> <li> Add engine prefill/decode generation and determinism tests</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/241/files#diff-4a69fc488e0fac35d122fa0df7ff07ab0e547a8aa6418cb710ba47627ab80c4f">+179/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___