### PR TITLE
feat(models): port LFM2-MoE GQA attention + bias-corrected MoE router (issue #231)

### DIFF
--- a/python/freetoken/models/lfm2_moe/__init__.py
+++ b/python/freetoken/models/lfm2_moe/__init__.py
@@ -182,7 +182,192 @@ class ShortConv(nn.Module):
 
 
 # --------------------------------------------------------------------------- #
-# Not yet implemented: attention + MoE router (#231), full model wiring (#232).
+# GQA attention with per-head q/k RMSNorm (#231)
+#
+# Ground truth: ``Lfm2MoeAttention.forward`` in the real ``modeling_lfm2_moe.py``.
+# The issue that filed this work assumed "no QK-norm per the config class" --
+# that is WRONG: the config class has no boolean flag for it, but the real
+# modeling code unconditionally builds ``q_layernorm``/``k_layernorm``
+# (``Lfm2MoeRMSNorm(head_dim, eps=norm_eps)``) and applies them before RoPE,
+# every layer. Confirmed by reading the real forward, not assumed from the
+# issue text. Otherwise this is the same GQA + half-split (rotate_half) RoPE
+# shape as this port's own ``qwen3_moe`` attention -- adapted from it
+# (identical KV-pool contract, including the physical-slot ``write_kv`` fix),
+# not shared by reference (every model package in this port stands alone).
+# --------------------------------------------------------------------------- #
+
+
+class Lfm2MoeAttention(nn.Module):
+    """LFM2-MoE full-attention layer: GQA + per-head q/k RMSNorm + half-split RoPE."""
+
+    def __init__(self, config: ModelConfig, device, dtype, layer_id: int) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads or config.num_attention_heads
+        self.head_dim = getattr(config, "head_dim", None) or config.hidden_size // self.num_heads
+        norm_eps = config.attrs.get("norm_eps", 1e-5)
+
+        self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=False, dtype=dtype)
+        self.k_proj = nn.Linear(config.hidden_size, self.num_kv_heads * self.head_dim, bias=False, dtype=dtype)
+        self.v_proj = nn.Linear(config.hidden_size, self.num_kv_heads * self.head_dim, bias=False, dtype=dtype)
+        self.out_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=False, dtype=dtype)
+        self.q_layernorm = nn.RMSNorm(self.head_dim, eps=norm_eps, dtype=dtype)
+        self.k_layernorm = nn.RMSNorm(self.head_dim, eps=norm_eps, dtype=dtype)
+
+        theta = config.rope_theta or 10000.0
+        inv_freq = 1.0 / (
+            theta ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32, device=device) / self.head_dim)
+        )
+        self.register_buffer("inv_freq", inv_freq)
+
+    def _rope(self, x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
+        # Half-split (rotate_half), matching the real ``modeling_lfm2_moe.py``'s
+        # own ``rotate_half``/``apply_rotary_pos_emb`` -- byte-for-byte the same
+        # formula as HF Qwen3/Llama-family rope (this port's ``qwen3_moe`` had a
+        # real, confirmed bug here from an interleaved split mismatching this
+        # cos/sin layout; use the already-fixed half-split form from the start).
+        freqs = torch.outer(pos.to(torch.float32), self.inv_freq)  # [N, D/2]
+        emb = torch.cat((freqs, freqs), dim=-1)  # [N, D]
+        cos = emb.cos()[None, :, :]
+        sin = emb.sin()[None, :, :]
+        x_f = x.to(torch.float32)
+        half = x_f.shape[-1] // 2
+        x1, x2 = x_f[..., :half], x_f[..., half:]
+        rotated = torch.cat((-x2, x1), dim=-1)
+        return (x_f * cos + rotated * sin).to(x.dtype)
+
+    def forward(self, hidden_states, positions, table_idx, ctx, batch):
+        bsz, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).view(bsz, self.num_heads, self.head_dim).transpose(0, 1)
+        k = self.k_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        v = self.v_proj(hidden_states).view(bsz, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        q = self._rope(self.q_layernorm(q), positions)
+        k = self._rope(self.k_layernorm(k), positions)
+        # write_kv's out_loc is a PHYSICAL pool slot, not a logical token
+        # position -- MHAKVCache's real allocator reserves slot 0 as padding,
+        # so the two never coincide for a real request (see qwen3_moe's own
+        # extensive comment on this, PR #234/#236 -- the same fix applied here
+        # from the start rather than retrofit).
+        out_loc = ctx.page_table[table_idx, positions.long()]
+        ctx.kv_cache.write_kv(k, v, out_loc, self.layer_id)
+        out = ctx.attn_backend.forward(q, k, v, self.layer_id, batch, table_idx=table_idx)
+        return self.out_proj(out.transpose(0, 1).contiguous().reshape(bsz, -1))
+
+
+# --------------------------------------------------------------------------- #
+# Bias-corrected sigmoid top-k router + expert combination (#231)
+#
+# Ground truth: ``Lfm2MoeTopKRouter``/``Lfm2MoeExperts``/``Lfm2MoeSparseMoeBlock``
+# in the real ``modeling_lfm2_moe.py``. Confirmed against this port's own
+# ``deepseek_v4``/``glm_moe_dsa`` ``noaux_tc``-style routers: the SAME shape
+# (sigmoid scores; select top-k on scores+bias but gather WEIGHTS from the
+# raw, uncorrected sigmoid scores; optional renorm; scale by
+# ``routed_scaling_factor``) with two real differences confirmed from the
+# actual HF source, not assumed: (1) no grouped-expert pre-filtering at all
+# (LFM2's config has no ``n_group``/``topk_group`` -- flat top-k over every
+# expert, unlike DeepSeek-V3/V4's group-then-topk), and (2) no shared expert
+# (``Lfm2MoeSparseMoeBlock`` has none, unlike ``deepseek_v4``/``glm_moe_dsa``).
+# The bias itself is a plain zero-initialized buffer (``expert_bias``, only
+# present when ``use_expert_bias`` is set), not a checkpoint-trained weight --
+# same convention as DeepSeek's ``e_score_correction_bias``.
+# --------------------------------------------------------------------------- #
+
+
+class Lfm2MoeTopKRouter(nn.Module):
+    """Real HF ``Lfm2MoeTopKRouter`` math: sigmoid scores, optional additive
+    bias for SELECTION only (weights are gathered from the raw, uncorrected
+    scores), optional renorm, then ``routed_scaling_factor``."""
+
+    def __init__(self, config: ModelConfig, dtype) -> None:
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.attrs.get("norm_topk_prob", True)
+        self.routed_scaling_factor = config.attrs.get("routed_scaling_factor", 1.0)
+        self.use_expert_bias = config.attrs.get("use_expert_bias", False)
+        self.weight = nn.Parameter(torch.empty(self.num_experts, config.hidden_size, dtype=dtype))
+        if self.use_expert_bias:
+            self.register_buffer("expert_bias", torch.zeros(self.num_experts, dtype=torch.float32))
+        else:
+            self.expert_bias = None
+
+    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """``hidden_states [T, H]``. Returns ``(selected_experts [T, k],
+        topk_weights [T, k])``."""
+        router_logits = F.linear(hidden_states.float(), self.weight.float())  # [T, E]
+        routing_weights = router_logits.sigmoid()
+        if self.use_expert_bias:
+            scores_for_routing = routing_weights + self.expert_bias.unsqueeze(0)
+            _, selected_experts = torch.topk(scores_for_routing, k=self.top_k, dim=-1)
+            topk_weights = torch.gather(routing_weights, dim=1, index=selected_experts)
+        else:
+            topk_weights, selected_experts = torch.topk(routing_weights, k=self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-6)
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return selected_experts, topk_weights
+
+
+class Lfm2MoeExperts(nn.Module):
+    """Real HF ``Lfm2MoeExperts``: one fused 3D parameter per projection
+    (``gate_up_proj [E, 2*inter, H]``, ``down_proj [E, H, inter]``) -- matches
+    the real checkpoint's own weight layout (``base_model_ep_plan``:
+    ``feed_forward.experts.gate_up_proj``/``down_proj``), not per-expert
+    ``nn.Linear`` submodules. One-hot + ``index_add_`` dispatch, confirmed
+    byte-for-byte against the real forward (not a reference reimplementation
+    with different math -- this port's usual "pure-torch reference" cut is
+    the fused-kernel absence, not the dispatch algorithm itself here)."""
+
+    def __init__(self, config: ModelConfig, dtype) -> None:
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.hidden_dim = config.hidden_size
+        self.intermediate_dim = config.moe_intermediate_size
+        self.gate_up_proj = nn.Parameter(
+            torch.empty(self.num_experts, 2 * self.intermediate_dim, self.hidden_dim, dtype=dtype)
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty(self.num_experts, self.hidden_dim, self.intermediate_dim, dtype=dtype)
+        )
+
+    def forward(
+        self, hidden_states: torch.Tensor, selected_experts: torch.Tensor, topk_weights: torch.Tensor
+    ) -> torch.Tensor:
+        """``hidden_states [T, H]``, ``selected_experts``/``topk_weights [T, k]``."""
+        final_hidden_states = torch.zeros_like(hidden_states)
+        with torch.no_grad():
+            expert_mask = F.one_hot(selected_experts, num_classes=self.num_experts)
+            expert_mask = expert_mask.permute(2, 1, 0)
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+        for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            gate, up = F.linear(current_state, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
+            current_hidden_states = F.silu(gate) * up
+            current_hidden_states = F.linear(current_hidden_states, self.down_proj[expert_idx])
+            current_hidden_states = current_hidden_states * topk_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(0, token_idx, current_hidden_states.to(final_hidden_states.dtype))
+        return final_hidden_states
+
+
+class Lfm2MoeSparseMoeBlock(nn.Module):
+    """Router + experts, standalone (not yet wired into a decoder layer --
+    that is #232's job)."""
+
+    def __init__(self, config: ModelConfig, dtype) -> None:
+        super().__init__()
+        self.gate = Lfm2MoeTopKRouter(config, dtype)
+        self.experts = Lfm2MoeExperts(config, dtype)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        selected_experts, topk_weights = self.gate(hidden_states)
+        return self.experts(hidden_states, selected_experts, topk_weights)
+
+
+# --------------------------------------------------------------------------- #
+# Not yet implemented: full model wiring (#232).
 # --------------------------------------------------------------------------- #
 
 
@@ -198,6 +383,10 @@ __all__ = [
     "ShortConv",
     "causal_depthwise_conv1d",
     "iter_weights",
+    "Lfm2MoeAttention",
+    "Lfm2MoeExperts",
     "Lfm2MoeForCausalLM",
+    "Lfm2MoeSparseMoeBlock",
+    "Lfm2MoeTopKRouter",
     "parse_config",
 ]

--- a/tests/test_models_lfm2moe_attn_moe.py
+++ b/tests/test_models_lfm2moe_attn_moe.py
@@ -1,0 +1,223 @@
+"""Unit tests for LFM2-MoE's GQA attention + bias-corrected MoE router/experts
+(issue `models-lfm2moe-attn-moe`, #231). Standalone -- not yet wired into a
+decoder layer or the engine (that's #232's job); these pin the attention and
+router/expert math against independently hand-computed references.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn.functional as F
+
+from freetoken.attention.triton import TritonAttentionBackend
+from freetoken.core import Batch, Context, Req, SamplingParams, reset_global_ctx, set_global_ctx
+from freetoken.kvcache.base import BaseKVCachePool
+from freetoken.models.config import ModelConfig
+from freetoken.models.lfm2_moe import Lfm2MoeAttention, Lfm2MoeExperts, Lfm2MoeSparseMoeBlock, Lfm2MoeTopKRouter
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _rotate_half(x):
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def test_lfm2moe_attention_forward_runs_and_qk_norm_is_real():
+    """Real forward pass through a Context/BaseKVCachePool (identity page
+    table -- the established pattern for a standalone-primitive test, per
+    #231's own scope; the real MHAKVCache validation is #232's e2e job).
+    Confirms finite output, and that q/k RMSNorm is actually wired (the
+    issue text wrongly assumed no QK-norm exists -- the real modeling code
+    has it unconditionally; zeroing the norm weight must change output)."""
+    torch.manual_seed(0)
+    H, NH, NKV, D = 16, 4, 2, 8
+    config = ModelConfig(
+        hidden_size=H,
+        num_attention_heads=NH,
+        num_key_value_heads=NKV,
+        head_dim=D,
+        num_layers=1,
+        rope_theta=10000.0,
+        attrs={"norm_eps": 1e-5},
+    )
+    dev = torch.device("cpu")
+    attn = Lfm2MoeAttention(config, dev, torch.float32, layer_id=0)
+    with torch.no_grad():
+        for p in attn.parameters():
+            p.normal_(0, 0.02)
+        attn.q_layernorm.weight.fill_(1.0)
+        attn.k_layernorm.weight.fill_(1.0)
+
+    T = 5
+    hidden_states = torch.randn(T, H)
+    positions = torch.arange(T)
+    ctx = Context(page_size=1)
+    ctx.kv_cache = BaseKVCachePool(config, page_size=1, num_pages=32, device=dev, dtype=torch.float32)
+    pt = torch.zeros((2, 32), dtype=torch.int32)
+    pt[0, :T] = torch.arange(T)
+    ctx.page_table = pt
+    ctx.kv_cache.attach_page_table(pt)
+    ctx.attn_backend = TritonAttentionBackend(None)
+    req = Req(
+        input_ids=list(range(T)), table_idx=0, cached_len=0, output_len=1, uid=0,
+        sampling_params=SamplingParams(), cache_handle=None,
+    )
+    req.device_len = T
+    batch = Batch(reqs=[req], phase="prefill", positions=positions, extend_lens=[T])
+    set_global_ctx(ctx)
+    ctx._batch = batch
+
+    out = attn(hidden_states, positions, 0, ctx, batch)
+    assert out.shape == (T, H)
+    assert torch.isfinite(out).all()
+
+    # A real (non-identity) norm weight must change the output vs identity
+    # scale -- proves q_layernorm/k_layernorm are load-bearing, not a no-op.
+    with torch.no_grad():
+        attn.q_layernorm.weight.normal_(0, 1.0)
+        attn.k_layernorm.weight.normal_(0, 1.0)
+    out_diff_norm = attn(hidden_states, positions, 0, ctx, batch)
+    assert not torch.allclose(out, out_diff_norm)
+
+
+def test_lfm2moe_attention_rope_matches_hand_computed_rotate_half():
+    """Independent recomputation of the half-split RoPE applied to q, isolated
+    from attention/KV-cache plumbing -- pins the exact rotation formula."""
+    torch.manual_seed(1)
+    H, NH, NKV, D = 8, 2, 2, 4
+    config = ModelConfig(
+        hidden_size=H, num_attention_heads=NH, num_key_value_heads=NKV, head_dim=D,
+        num_layers=1, rope_theta=10000.0, attrs={"norm_eps": 1e-5},
+    )
+    attn = Lfm2MoeAttention(config, torch.device("cpu"), torch.float32, layer_id=0)
+
+    T = 6
+    x = torch.randn(NH, T, D)  # head-major, matching attn._rope's expected layout
+    positions = torch.arange(T)
+
+    got = attn._rope(x, positions)
+
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(0, D, 2, dtype=torch.float32) / D))
+    freqs = torch.outer(positions.float(), inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos, sin = emb.cos()[None, :, :], emb.sin()[None, :, :]
+    expected = x * cos + _rotate_half(x) * sin
+    torch.testing.assert_close(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_lfm2moe_router_matches_hand_computed_sigmoid_topk_no_bias():
+    """No expert bias: flat top-k directly on sigmoid scores (no grouping --
+    LFM2 has no n_group/topk_group at all, unlike DeepSeek-V3/V4)."""
+    torch.manual_seed(2)
+    T, H, E, K = 5, 8, 6, 2
+    config = ModelConfig(
+        hidden_size=H, num_experts=E, num_experts_per_tok=K,
+        attrs={"norm_topk_prob": False, "routed_scaling_factor": 1.0, "use_expert_bias": False},
+    )
+    router = Lfm2MoeTopKRouter(config, torch.float32)
+    with torch.no_grad():
+        router.weight.normal_(0, 0.1)
+    assert router.expert_bias is None
+
+    x = torch.randn(T, H)
+    selected, weights = router(x)
+    assert selected.shape == (T, K)
+    assert weights.shape == (T, K)
+
+    logits = F.linear(x, router.weight)
+    scores = logits.sigmoid()
+    exp_weights, exp_selected = torch.topk(scores, K, dim=-1)
+    torch.testing.assert_close(selected, exp_selected)
+    torch.testing.assert_close(weights, exp_weights, atol=1e-6, rtol=1e-6)
+
+
+def test_lfm2moe_router_bias_affects_selection_but_not_gathered_weight_value():
+    """With use_expert_bias=True: bias shifts WHICH experts get selected, but
+    the returned weight for a selected expert is its RAW (uncorrected)
+    sigmoid score -- confirmed against the real HF Lfm2MoeTopKRouter.forward,
+    same shape as DeepSeek-V3/V4's own e_score_correction_bias router."""
+    torch.manual_seed(3)
+    T, H, E, K = 1, 4, 4, 1
+    config = ModelConfig(
+        hidden_size=H, num_experts=E, num_experts_per_tok=K,
+        attrs={"norm_topk_prob": False, "routed_scaling_factor": 1.0, "use_expert_bias": True},
+    )
+    router = Lfm2MoeTopKRouter(config, torch.float32)
+    assert router.expert_bias is not None
+    with torch.no_grad():
+        router.weight.zero_()  # every expert's raw logit -> sigmoid(0) = 0.5
+        # Bias expert 2 heavily so it wins selection despite tied raw scores.
+        router.expert_bias.copy_(torch.tensor([0.0, 0.0, 10.0, 0.0]))
+
+    x = torch.randn(T, H)
+    selected, weights = router(x)
+    assert selected.item() == 2
+    # The gathered weight is the RAW sigmoid score (0.5), not score+bias.
+    torch.testing.assert_close(weights, torch.full((T, K), 0.5))
+
+
+def test_lfm2moe_router_renormalizes_when_norm_topk_prob_true():
+    torch.manual_seed(4)
+    T, H, E, K = 4, 6, 5, 2
+    config = ModelConfig(
+        hidden_size=H, num_experts=E, num_experts_per_tok=K,
+        attrs={"norm_topk_prob": True, "routed_scaling_factor": 1.0, "use_expert_bias": False},
+    )
+    router = Lfm2MoeTopKRouter(config, torch.float32)
+    with torch.no_grad():
+        router.weight.normal_(0, 0.1)
+    _, weights = router(torch.randn(T, H))
+    torch.testing.assert_close(weights.sum(dim=-1), torch.ones(T), atol=1e-5, rtol=1e-5)
+
+
+def test_lfm2moe_experts_matches_hand_computed_weighted_swiglu_sum():
+    """Independent per-token recomputation of the selected experts' SwiGLU
+    output, weighted and summed -- the one-hot/index_add dispatch inside
+    Lfm2MoeExperts must produce the same result as a naive per-token loop."""
+    torch.manual_seed(5)
+    T, H, E, K, inter = 6, 8, 5, 2, 12
+    config = ModelConfig(hidden_size=H, num_experts=E, moe_intermediate_size=inter)
+    experts = Lfm2MoeExperts(config, torch.float32)
+    with torch.no_grad():
+        experts.gate_up_proj.normal_(0, 0.1)
+        experts.down_proj.normal_(0, 0.1)
+
+    x = torch.randn(T, H)
+    selected = torch.randint(0, E, (T, K))
+    weights = torch.rand(T, K)
+
+    got = experts(x, selected, weights)
+    assert got.shape == (T, H)
+
+    expected = torch.zeros(T, H)
+    for t in range(T):
+        for k in range(K):
+            e = selected[t, k].item()
+            gate, up = F.linear(x[t], experts.gate_up_proj[e]).chunk(2, dim=-1)
+            h = F.silu(gate) * up
+            h = F.linear(h, experts.down_proj[e])
+            expected[t] += h * weights[t, k]
+    torch.testing.assert_close(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_lfm2moe_sparse_moe_block_end_to_end_finite():
+    torch.manual_seed(6)
+    T, H, E, K, inter = 4, 8, 6, 2, 16
+    config = ModelConfig(
+        hidden_size=H, num_experts=E, num_experts_per_tok=K, moe_intermediate_size=inter,
+        attrs={"norm_topk_prob": True, "routed_scaling_factor": 1.0, "use_expert_bias": True},
+    )
+    block = Lfm2MoeSparseMoeBlock(config, torch.float32)
+    with torch.no_grad():
+        for p in block.parameters():
+            p.normal_(0, 0.1)
+    out = block(torch.randn(T, H))
+    assert out.shape == (T, H)
+    assert torch.isfinite(out).all()


### PR DESCRIPTION
## Why
Second child of epic #229 (LFM2-MoE), depends on #230 (conv primitive, merged).

## What
- `Lfm2MoeAttention`: GQA (32 Q / 8 KV heads in the real checkpoint) with per-head q/k RMSNorm + half-split RoPE. **Correction to the issue's own scope text**: it assumed "no QK-norm per the config class" — that's wrong. The config class has no boolean flag for it, but the real `modeling_lfm2_moe.py` builds `q_layernorm`/`k_layernorm` unconditionally, every layer. Confirmed by reading the real forward, not assumed. Adapted from `qwen3_moe`'s own attention (same KV-pool contract, including the physical-slot `write_kv` fix from #234/#236 — applied from the start here, not retrofit).
- `Lfm2MoeTopKRouter` + `Lfm2MoeExperts` + `Lfm2MoeSparseMoeBlock`: sigmoid top-k router with an optional additive bias for *selection only* (weights gathered from the raw, uncorrected scores) — same shape as `deepseek_v4`/`glm_moe_dsa`'s `noaux_tc`-style routers, confirmed against the real HF source. Two real differences confirmed from that same source: no grouped-expert pre-filtering (LFM2 has no `n_group`/`topk_group` at all — flat top-k over every expert), and no shared expert. `Lfm2MoeExperts` uses the real fused 3D-parameter layout (`gate_up_proj`/`down_proj`) matching the checkpoint's actual weight shape, one-hot + `index_add_` dispatch confirmed byte-for-byte against the real forward.

## Test plan
- [x] 7 new hand-computed-reference unit tests (`tests/test_models_lfm2moe_attn_moe.py`)
- [x] `.venv-xpu -m "not xpu"`: 633 passed, only the known pre-existing `test_fetch_fraction_none_when_no_profile` flake
- [x] Real B70 forward pass (`xpu:0`): finite output confirmed for both the attention block and the MoE block, on a small synthetic fixture (real-checkpoint generation is #232's job, deliberately deferred — this box had a hard memory crash earlier this session, kept real-hardware use here small/synthetic)

Parent epic: #229
Depends on: #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY