### PR TITLE
feat(models): wire Qwen1.5-MoE-A2.7B decoder layer + full causal-LM (issue #222)

### DIFF
--- a/python/freetoken/models/qwen2_moe/__init__.py
+++ b/python/freetoken/models/qwen2_moe/__init__.py
@@ -18,11 +18,13 @@ Two real differences from this port's Qwen3-family models:
   unconditional shared-expert add; confirmed against the real HF
   `Qwen2MoeSparseMoeBlock.forward`.
 
-This issue (#221) covers config parsing, attention, and the router/shared-
-expert combination as standalone, independently-testable primitives (same
-shape as `qwen4_exp`'s own `#206`/`#208` primitives) -- NOT yet wired into a
-decoder layer, the engine's KV cache, or a `ForCausalLM` class; that is
-issue #222's job.
+Issue #221 built config parsing, attention, and the router/shared-expert
+combination as standalone primitives. Issue #222 (this file's decoder layer
+and `Qwen2MoeForCausalLM`) wires them into the real engine loop: dense vs.
+MoE layers split by `mlp_only_layers`/`decoder_sparse_step`, fused
+(in-VRAM) MoE only -- offload/cpu/hybrid raise loudly rather than silently
+leaving experts uninitialized (the real bug class `loader.py`'s
+`_CPU_MOE_CAPABLE_ARCHS` gate exists to prevent).
 """
 from __future__ import annotations
 
@@ -120,11 +122,27 @@ def parse_config(hf_config, model_path: str | None = None, **_kwargs) -> ModelCo
     cfg.attrs["shared_expert_intermediate_size"] = int(src.get("shared_expert_intermediate_size") or 0)
     cfg.attrs["decoder_sparse_step"] = int(src.get("decoder_sparse_step") or 1)
     cfg.attrs["mlp_only_layers"] = list(src.get("mlp_only_layers") or [])
+    cfg.attrs["rms_norm_eps"] = float(src.get("rms_norm_eps") or 1e-6)
     return cfg
 
 
-def iter_weights(model_path: str, device: torch.device, **_kwargs) -> "iter[tuple[str, torch.Tensor]]":
-    """Yield the checkpoint's tensors, each placed on ``device``.
+def iter_weights(
+    model_path: str,
+    device: torch.device,
+    *,
+    include_moe_experts: bool = True,
+    include_non_moe: bool = True,
+    **_kwargs,
+) -> "iter[tuple[str, torch.Tensor]]":
+    """Yield the checkpoint's tensors, each on its destination device.
+
+    MoE expert tensors (``...mlp.experts...``) stay on **host** memory (the
+    loader's fused-path expert placement reads them from there); every other
+    (dense) tensor is yielded on ``device``. ``include_moe_experts``/
+    ``include_non_moe`` let the loader stream just one half (mirrors
+    ``qwen3_moe``'s own ``iter_weights`` exactly -- same real failure mode:
+    without this split, ``load_moe_expert_sources`` chokes on dense tensors
+    like ``lm_head.weight`` mixed into the expert stream).
 
     Synthesizes ``lm_head.weight`` from ``embed_tokens.weight`` for a
     ``tie_word_embeddings: true`` checkpoint that ships no separate
@@ -136,14 +154,20 @@ def iter_weights(model_path: str, device: torch.device, **_kwargs) -> "iter[tupl
     embed_tokens_weight = None
     saw_lm_head = False
     for name, tensor in iter_safetensors(model_path, device):
-        placed = tensor.to(device)
+        is_expert = ".experts." in name
+        if is_expert and not include_moe_experts:
+            continue
+        if not is_expert and not include_non_moe:
+            continue
+        dest = torch.device("cpu") if is_expert else device
+        placed = tensor.to(dest)
         if name == "model.embed_tokens.weight":
             embed_tokens_weight = placed
         elif name == "lm_head.weight":
             saw_lm_head = True
         yield name, placed
 
-    if not saw_lm_head and embed_tokens_weight is not None:
+    if include_non_moe and not saw_lm_head and embed_tokens_weight is not None:
         hf_config = cached_load_hf_config(model_path)
         if bool(getattr(hf_config, "tie_word_embeddings", False)):
             yield "lm_head.weight", embed_tokens_weight
@@ -254,10 +278,190 @@ def qwen2moe_shared_expert_output(
     return gate * shared
 
 
+# --------------------------------------------------------------------------- #
+# Full model wiring (#222): decoder layer + causal-LM wrapper.
+# --------------------------------------------------------------------------- #
+
+
+def _xpu_available() -> bool:
+    try:
+        return bool(torch.xpu.is_available())
+    except Exception:
+        return False
+
+
+class _Qwen2MoeMLP(nn.Module):
+    """Plain dense SwiGLU MLP -- used for any layer ``mlp_only_layers``
+    marks dense (or every layer, if the checkpoint's ``decoder_sparse_step``
+    somehow yields none as MoE, though the real checkpoint has every layer
+    MoE)."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int, dtype) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False, dtype=dtype)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False, dtype=dtype)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False, dtype=dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _Qwen2MoeMoE(nn.Module):
+    """Router (flat softmax top-k) + per-expert dense loop + the real
+    sigmoid-gated shared expert. In-VRAM (fused) only -- offload/cpu/hybrid
+    are not wired for this architecture yet, same scope cut as
+    ``glm4_moe``/``deepseek_v4``/``glm_moe_dsa`` before their own follow-up
+    issues; guard loudly rather than silently leaving experts uninitialized
+    (the real bug class `loader.py`'s ``_CPU_MOE_CAPABLE_ARCHS`` gate exists
+    to prevent)."""
+
+    def __init__(self, config: ModelConfig, device, dtype, layer_id: int) -> None:
+        super().__init__()
+        if bool(getattr(config, "use_offload_moe", False)) or bool(getattr(config, "use_cpu_moe", False)) or bool(getattr(config, "use_hybrid", False)):
+            raise NotImplementedError(
+                "Qwen2MoeForCausalLM only supports the in-VRAM (fused) MoE backend "
+                "-- offload/cpu/hybrid are not wired yet. Pass moe_backend=\"fused\" "
+                "explicitly (EngineConfig's \"auto\" default does not know this "
+                "architecture can't offload)."
+            )
+        self.layer_id = layer_id
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = bool(config.attrs.get("norm_topk_prob", False))
+        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False, dtype=dtype)
+        self.experts = nn.ModuleList(
+            _Qwen2MoeMLP(config.hidden_size, config.moe_intermediate_size, dtype) for _ in range(config.num_experts)
+        )
+        shared_inter = int(config.attrs.get("shared_expert_intermediate_size", 0))
+        self.shared_expert = _Qwen2MoeMLP(config.hidden_size, shared_inter, dtype) if shared_inter > 0 else None
+        self.shared_expert_gate = (
+            nn.Linear(config.hidden_size, 1, bias=False, dtype=dtype) if shared_inter > 0 else None
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        in_shape = hidden_states.shape
+        flat = hidden_states.reshape(-1, in_shape[-1])
+        routing_weights, selected_experts = qwen2moe_router(
+            flat, self.gate.weight, self.top_k, self.norm_topk_prob
+        )
+
+        sel_cpu = selected_experts.to("cpu")
+        out = torch.zeros_like(flat)
+        for e in range(len(self.experts)):
+            for slot in range(selected_experts.shape[1]):
+                mask = sel_cpu[:, slot] == e
+                if not bool(mask.any()):
+                    continue
+                idx = mask.nonzero(as_tuple=True)[0].to(flat.device)
+                w = routing_weights.index_select(0, idx)[:, slot, None]
+                y = self.experts[e](flat.index_select(0, idx))
+                out.index_add_(0, idx, w * y)
+
+        if self.shared_expert is not None:
+            out = out + qwen2moe_shared_expert_output(
+                flat,
+                self.shared_expert.gate_proj.weight,
+                self.shared_expert.up_proj.weight,
+                self.shared_expert.down_proj.weight,
+                self.shared_expert_gate.weight,
+            )
+        return out.view(in_shape)
+
+
+class _Qwen2MoeDecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig, device, dtype, layer_id: int) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        eps = config.attrs.get("rms_norm_eps", 1e-6)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=eps, dtype=dtype)
+        self.self_attn = Qwen2MoeAttention(config, device, dtype, layer_id)
+        self.post_attention_layernorm = nn.RMSNorm(config.hidden_size, eps=eps, dtype=dtype)
+
+        mlp_only_layers = config.attrs.get("mlp_only_layers", [])
+        sparse_step = int(config.attrs.get("decoder_sparse_step", 1)) or 1
+        # Real checkpoint's own dense-vs-MoE rule (HF Qwen2MoeDecoderLayer):
+        # a layer is dense iff it's in mlp_only_layers OR sparse_step does
+        # not divide (layer_id + 1). Confirmed: real checkpoint has
+        # mlp_only_layers=[] and decoder_sparse_step=1, so every layer is
+        # MoE there -- but don't assume that for any other checkpoint.
+        is_dense = layer_id in mlp_only_layers or (layer_id + 1) % sparse_step != 0
+        self.mlp = (
+            _Qwen2MoeMLP(config.hidden_size, config.intermediate_size, dtype)
+            if is_dense
+            else _Qwen2MoeMoE(config, device, dtype, layer_id)
+        )
+
+    def forward(self, hidden_states, positions, table_idx, ctx, batch):
+        residual = hidden_states
+        hidden_states = self.self_attn(self.input_layernorm(hidden_states), positions, table_idx, ctx, batch)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = residual + self.mlp(self.post_attention_layernorm(hidden_states))
+        return hidden_states
+
+
+class Qwen2MoeForCausalLM(nn.Module):
+    """Qwen1.5-MoE-A2.7B: real forward pass for the Intel engine loop (``#14``)."""
+
+    def __init__(self, config, device=None) -> None:
+        super().__init__()
+        self.config = config
+        if device is None:
+            device = torch.device("xpu") if _xpu_available() else torch.device("cpu")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        self.device = device
+        dtype = getattr(config, "dtype", None) or torch.bfloat16
+        vocab_size = getattr(config, "vocab_size", 256)
+        hidden_size = getattr(config, "hidden_size", 256)
+        num_layers = getattr(config, "num_layers", 0)
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size, device=device, dtype=dtype)
+        self.layers = nn.ModuleList(
+            _Qwen2MoeDecoderLayer(config, device, dtype, layer_id=i) for i in range(num_layers)
+        )
+        eps = getattr(config, "attrs", {}).get("rms_norm_eps", 1e-6)
+        self.norm = nn.RMSNorm(hidden_size, eps=eps, dtype=dtype)
+        from freetoken.layers import LinearReplicated
+
+        self.lm_head = LinearReplicated(hidden_size, vocab_size, has_bias=False, dtype=dtype)
+        self.moe_offload = False
+        self.moe_cache = None
+        if self.device.type != "cpu":
+            self.to(self.device)
+
+    def forward(self, input_ids: torch.Tensor, positions: torch.Tensor, out_loc: torch.Tensor) -> torch.Tensor:
+        from freetoken.core import get_global_ctx
+
+        ctx = get_global_ctx()
+        batch = ctx.batch
+        reqs = batch.reqs
+        num_tokens = input_ids.shape[0]
+
+        hidden = self.embed_tokens(input_ids)
+        out = torch.empty((batch.size, self.config.hidden_size), device=hidden.device, dtype=hidden.dtype)
+
+        offset = 0
+        extend_lens = batch.extend_lens
+        if extend_lens is None:
+            prefill = batch.is_prefill or (num_tokens > batch.size)
+            extend_lens = [req.extend_len if prefill else 1 for req in reqs]
+        is_decode_batch = batch.phase == "decode"
+        for i, req in enumerate(reqs):
+            ext = 1 if is_decode_batch else int(extend_lens[i])
+            token_slice = slice(offset, offset + ext)
+            h = hidden[token_slice]
+            for layer in self.layers:
+                h = layer(h, positions[token_slice], req.table_idx, ctx, batch)
+            out[i] = self.norm(h)[-1]
+            offset += ext
+
+        return self.lm_head(out)
+
+
 __all__ = [
     "parse_config",
     "iter_weights",
     "Qwen2MoeAttention",
     "qwen2moe_router",
     "qwen2moe_shared_expert_output",
+    "Qwen2MoeForCausalLM",
 ]

--- a/python/freetoken/models/register.py
+++ b/python/freetoken/models/register.py
@@ -18,6 +18,7 @@ _MODEL_REGISTRY: dict[str, ModelSpec] = {
     "Qwen2ForCausalLM": ModelSpec("freetoken.models.qwen2", "Qwen2ForCausalLM"),
     "Qwen3ForCausalLM": ModelSpec("freetoken.models.qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": ModelSpec("freetoken.models.qwen3_moe", "Qwen3MoeForCausalLM"),
+    "Qwen2MoeForCausalLM": ModelSpec("freetoken.models.qwen2_moe", "Qwen2MoeForCausalLM"),  # gitleaks:allow -- architecture name, not a secret
     "Qwen3_5MoeForConditionalGeneration": ModelSpec(
         "freetoken.models.qwen3_5_moe", "Qwen3_5MoEForCausalLM"
     ),

--- a/tests/test_models_qwen2_moe_e2e.py
+++ b/tests/test_models_qwen2_moe_e2e.py
@@ -1,0 +1,216 @@
+"""End-to-end: Qwen1.5-MoE-A2.7B (qwen2_moe) -- bias-term MHA + the real
+gated-shared-expert MoE router, full model wiring (issue #222, final piece
+of epic #220). See qwen2_moe/__init__.py's own module docstring for the two
+real, confirmed differences from this port's Qwen3-family models: bias-term
+attention with no q/k norm, and the sigmoid-gated shared-expert combination.
+
+Small synthetic checkpoint only (2 layers: 1 dense via ``mlp_only_layers``,
+1 MoE) -- real-checkpoint validation against the actual downloaded
+Qwen/Qwen1.5-MoE-A2.7B is sequenced separately.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from freetoken.core import Req, SamplingParams, reset_global_ctx
+from freetoken.distributed import DistributedInfo
+from freetoken.engine.config import EngineConfig
+from freetoken.engine.engine import Engine
+from freetoken.models.qwen2_moe import Qwen2MoeForCausalLM, iter_weights, parse_config
+from freetoken.models.register import get_model_class
+
+DEVICE = "cpu"
+
+H, V, L = 32, 64, 2
+NH, NKV, HD = 4, 4, 8
+INTER = 48
+E, MOE_INTER, TOPK = 4, 24, 2
+SHARED_INTER = 24
+
+# The generic expert-source streamer (weight.py's stream_moe_expert_sources)
+# assumes dense layers are a leading PREFIX (first_k_dense_replace), not
+# qwen2_moe's real, arbitrary mlp_only_layers list. The real checkpoint's
+# own values are decoder_sparse_step=1, mlp_only_layers=[] -- every layer is
+# MoE -- so the full Engine e2e config below matches that (all-MoE) rather
+# than exercising a mismatch the real checkpoint doesn't have. The dense/MoE
+# *selection logic* itself (mlp_only_layers marking a layer dense) is
+# covered separately by test_model_class_builds_dense_layer_0_and_moe_layer_1
+# below, which builds the model directly without the checkpoint streamer.
+TINY_CONFIG = {
+    "architectures": ["Qwen2MoeForCausalLM"],
+    "model_type": "qwen2_moe",
+    "hidden_size": H,
+    "vocab_size": V,
+    "num_hidden_layers": L,
+    "num_attention_heads": NH,
+    "num_key_value_heads": NKV,
+    "head_dim": HD,
+    "qkv_bias": True,
+    "intermediate_size": INTER,
+    "num_experts": E,
+    "moe_intermediate_size": MOE_INTER,
+    "num_experts_per_tok": TOPK,
+    "norm_topk_prob": False,
+    "shared_expert_intermediate_size": SHARED_INTER,
+    "decoder_sparse_step": 1,
+    "mlp_only_layers": [],
+    "max_position_embeddings": 128,
+    "rope_theta": 10000.0,
+    "rms_norm_eps": 1e-6,
+    "tie_word_embeddings": False,
+}
+
+# Separate config for the dense/MoE selection-logic test: layer 0 dense.
+DENSE_SPLIT_CONFIG = dict(TINY_CONFIG, mlp_only_layers=[0])
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_ctx():
+    yield
+    reset_global_ctx()
+
+
+def _config():
+    return parse_config(type("Hf", (), {"to_dict": lambda self: TINY_CONFIG})())
+
+
+def test_config_derives_dense_vs_moe_layer_split():
+    config = parse_config(type("Hf", (), {"to_dict": lambda self: DENSE_SPLIT_CONFIG})())
+    assert config.attrs["mlp_only_layers"] == [0]
+    assert config.attrs["decoder_sparse_step"] == 1
+
+
+def test_model_class_builds_dense_layer_0_and_moe_layer_1():
+    config = parse_config(type("Hf", (), {"to_dict": lambda self: DENSE_SPLIT_CONFIG})())
+    model = get_model_class("Qwen2MoeForCausalLM", config, device=torch.device("cpu"))
+    from freetoken.models.qwen2_moe import _Qwen2MoeMLP, _Qwen2MoeMoE  # noqa: PLC0415
+
+    assert isinstance(model.layers[0].mlp, _Qwen2MoeMLP)
+    assert isinstance(model.layers[1].mlp, _Qwen2MoeMoE)
+    assert model.layers[1].mlp.shared_expert is not None
+
+
+def test_model_class_builds_every_layer_moe_matching_real_checkpoint():
+    config = _config()
+    model = get_model_class("Qwen2MoeForCausalLM", config, device=torch.device("cpu"))
+    from freetoken.models.qwen2_moe import _Qwen2MoeMoE  # noqa: PLC0415
+
+    assert all(isinstance(layer.mlp, _Qwen2MoeMoE) for layer in model.layers)
+
+
+def _write_tiny_checkpoint(tmp_path) -> str:
+    from safetensors.torch import save_file
+
+    model_path = tmp_path / "ckpt"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(json.dumps(TINY_CONFIG))
+
+    state = {}
+    gen = torch.Generator().manual_seed(0)
+
+    def add(name, shape):
+        state[name] = torch.randn(shape, generator=gen, dtype=torch.float32) * 0.02
+
+    add("model.embed_tokens.weight", (V, H))
+    for l in range(L):
+        p = f"model.layers.{l}"
+        add(f"{p}.input_layernorm.weight", (H,))
+        add(f"{p}.self_attn.q_proj.weight", (NH * HD, H))
+        add(f"{p}.self_attn.q_proj.bias", (NH * HD,))
+        add(f"{p}.self_attn.k_proj.weight", (NKV * HD, H))
+        add(f"{p}.self_attn.k_proj.bias", (NKV * HD,))
+        add(f"{p}.self_attn.v_proj.weight", (NKV * HD, H))
+        add(f"{p}.self_attn.v_proj.bias", (NKV * HD,))
+        add(f"{p}.self_attn.o_proj.weight", (H, NH * HD))
+        add(f"{p}.post_attention_layernorm.weight", (H,))
+        # Every layer MoE, matching TINY_CONFIG's mlp_only_layers=[] --
+        # the real checkpoint's own layer split (see the module note above).
+        add(f"{p}.mlp.gate.weight", (E, H))
+        for e in range(E):
+            eb = f"{p}.mlp.experts.{e}"
+            add(f"{eb}.gate_proj.weight", (MOE_INTER, H))
+            add(f"{eb}.up_proj.weight", (MOE_INTER, H))
+            add(f"{eb}.down_proj.weight", (H, MOE_INTER))
+        add(f"{p}.mlp.shared_expert.gate_proj.weight", (SHARED_INTER, H))
+        add(f"{p}.mlp.shared_expert.up_proj.weight", (SHARED_INTER, H))
+        add(f"{p}.mlp.shared_expert.down_proj.weight", (H, SHARED_INTER))
+        add(f"{p}.mlp.shared_expert_gate.weight", (1, H))
+    add("model.norm.weight", (H,))
+    add("lm_head.weight", (V, H))
+
+    save_file(state, str(model_path / "model.safetensors"))
+    return str(model_path)
+
+
+def _engine_config(model_path: str, *, device: str | None = None) -> EngineConfig:
+    return EngineConfig(
+        model_path=model_path,
+        tp_info=DistributedInfo(0, 1),
+        dtype=torch.float32,
+        device=device,
+        attention_backend="auto",
+        moe_backend="fused",
+        max_running_req=2,
+        page_size=1,
+        max_seq_len_override=32,
+    )
+
+
+def _add_prompt(engine: Engine, output_len: int) -> None:
+    engine.add_request(
+        Req(
+            input_ids=[1, 2, 3, 4, 5],
+            table_idx=0,
+            cached_len=0,
+            output_len=output_len,
+            uid=0,
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=output_len),
+            cache_handle=None,
+        )
+    )
+
+
+def test_iter_weights_covers_expert_and_shared_expert_tensors(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    names = {n for n, _ in iter_weights(model_path, torch.device("cpu"))}
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" in names
+    assert "model.layers.1.mlp.shared_expert_gate.weight" in names
+
+
+def test_iter_weights_include_moe_experts_flag_splits_dense_and_expert(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    dense_names = {n for n, _ in iter_weights(model_path, torch.device("cpu"), include_moe_experts=False)}
+    expert_names = {n for n, _ in iter_weights(model_path, torch.device("cpu"), include_non_moe=False)}
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" not in dense_names
+    assert "model.embed_tokens.weight" in dense_names
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" in expert_names
+    assert "model.embed_tokens.weight" not in expert_names
+
+
+def test_engine_generate_prefill_and_decode(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+    engine = Engine(_engine_config(model_path, device=DEVICE))
+    _add_prompt(engine, output_len=4)
+    generated = engine.generate()
+    vocab = engine.config.model_config.vocab_size
+    assert len(generated) == 1
+    assert len(generated[0]) == 4
+    assert all(0 <= t < vocab for t in generated[0])
+
+
+def test_engine_greedy_is_deterministic(tmp_path):
+    model_path = _write_tiny_checkpoint(tmp_path)
+
+    def build():
+        engine = Engine(_engine_config(model_path, device=DEVICE))
+        _add_prompt(engine, output_len=3)
+        return engine.generate()
+
+    a = build()
+    b = build()
+    assert a == b
+    assert len(a[0]) == 3


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟡 **PR-Agent Score: 86** `score-80-89` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** ⚠️ [yes](https://github.com/Performant-Labs/FreeToken-Intel/pull/243#issuecomment-5547050644) · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.synchronize` · [commit 611d9af](https://github.com/Performant-Labs/FreeToken-Intel/commit/611d9af0e0676e1d5826822fe7b269f5f0ea3cdf) · run [#33926106965](https://github.com/Performant-Labs/FreeToken-Intel/actions/runs/33926106965) · 2026-09-04 16:41 MDT / 2026-09-04 22:41 UTC
<!-- argos-status:end -->

<!-- pr-agent-generated -->
### **User description**
## Why
Final child of epic #220 (Qwen1.5-MoE-A2.7B). Wires #221's attention/router primitives into a real decoder layer and a full `Qwen2MoeForCausalLM`.

## What
- Dense-vs-MoE layer split per `mlp_only_layers`/`decoder_sparse_step` (real checkpoint: every layer is MoE).
- `_Qwen2MoeMoE`: router + per-expert loop + the real sigmoid-gated shared expert (#221's primitives).
- `Qwen2MoeForCausalLM` registered in `register.py`. In-VRAM (fused) MoE only -- offload/cpu/hybrid raise loudly (`NotImplementedError`) rather than silently leaving experts uninitialized, matching every other newly-ported architecture this session.
- `iter_weights` gained the `include_moe_experts`/`include_non_moe` split the generic expert-source streamer needs (mirrors `qwen3_moe`'s own `iter_weights` exactly).

## Test plan
- [x] Small synthetic checkpoint (seeded, all-MoE layers matching the real checkpoint's own split) through the real `Engine`: prefill+decode, deterministic greedy.
- [x] `.venv` (torch-free): 208 passed.
- [x] `.venv-xpu -m "not xpu"`: 633 passed, 1 pre-existing unrelated flake (`test_fetch_fraction_none_when_no_profile`), 1 skipped, 117 deselected.
- [x] Real B70 forward pass (`xpu:0`): finite, valid token ids.
- [ ] Real-checkpoint (`Qwen/Qwen1.5-MoE-A2.7B`) end-to-end validation -- deliberately out of scope here, sequenced separately to avoid concurrent real-hardware memory pressure across parallel work this session.

Parent epic: #220
Depends on: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJgbuhUHGu43RZAhTEgUY


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `Qwen2MoeForCausalLM` decoder-layer and causal-LM wiring
  - Dense-vs-MoE split via `mlp_only_layers` and `decoder_sparse_step`
  - Fused MoE only; offload/cpu/hybrid raise `NotImplementedError`

- Refactor `iter_weights` for expert/non-expert streaming

- Register `Qwen2MoeForCausalLM` in `register.py`

- Add synthetic checkpoint engine e2e tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parse_config adds rms_norm_eps"] --> B["_Qwen2MoeDecoderLayer"]
  B --> C["_Qwen2MoeMoE"]
  B --> D["_Qwen2MoeMLP"]
  E["iter_weights expert/non-expert split"] --> F["Fused checkpoint loading"]
  G["register.py"] --> H["Qwen2MoeForCausalLM"]
  I["tests/test_models_qwen2_moe_e2e.py"] --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Wire Qwen2 MoE decoder layer and causal LM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/qwen2_moe/__init__.py

<ul><li>Add <code>rms_norm_eps</code> to parsed config attrs<br> <li> Extend <code>iter_weights</code> with expert/non-expert stream flags, keep experts <br>on CPU<br> <li> Add <code>_Qwen2MoeMLP</code>, <code>_Qwen2MoeMoE</code>, <code>_Qwen2MoeDecoderLayer</code>, and <br><code>Qwen2MoeForCausalLM</code><br> <li> Implement fused MoE forward with router, per-expert loop, and gated <br>shared expert</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/243/files#diff-99e63ae2293988221e8df25e787743e70d974f3ccf9a6ac88f69617cf0da80be">+213/-9</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>register.py</strong><dd><code>Register Qwen2MoeForCausalLM model class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/freetoken/models/register.py

<ul><li>Register <code>Qwen2MoeForCausalLM</code> model spec for <code>freetoken.models.qwen2_moe</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/243/files#diff-e38ee7af842e0d485f9466cc2f82ee8a030eb7b9c2123709bb4d5ef745e4d65b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models_qwen2_moe_e2e.py</strong><dd><code>Add Qwen2MoE engine end-to-end tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models_qwen2_moe_e2e.py

<ul><li>Add synthetic checkpoint e2e tests for Qwen2MoE<br> <li> Verify dense-vs-MoE layer split and shared expert presence<br> <li> Test <code>iter_weights</code> expert/non-expert split flags<br> <li> Validate engine prefill/decode and deterministic greedy generation</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/FreeToken-Intel/pull/243/files#diff-449406c25a998f77939c04da1b858ab9426afa805e1c0a3146a1471c82b49eab">+216/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___